### PR TITLE
docs: add TUI rendering, state machines, and batch tool flow docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,8 @@
 # Architecture & Flow
 
-This document describes the overall architecture, core data flow, and terminal UI layout of `tact` using Mermaid diagrams.
+This document describes the overall architecture, core data flow, and terminal UI layout of `tact` using Mermaid diagrams. It reflects the current implementation rather than the original MVP design.
+
+For detailed state-machine diagrams (TUI status, input mode, task lifecycle, permissions, hooks, etc.), see [`docs/state_machines.md`](./docs/state_machines.md). For the TUI rendering architecture (layout, log panel, popups, Markdown rendering, etc.), see [`docs/tui_rendering.md`](./docs/tui_rendering.md). For the `batch_read`/`batch_edit` execution and TUI interaction flowcharts, see [`docs/batch_tools_flow.md`](./docs/batch_tools_flow.md).
 
 ---
 
@@ -8,13 +10,13 @@ This document describes the overall architecture, core data flow, and terminal U
 
 This project is a Cargo Workspace containing the following crates:
 
-| Directory | Package | Responsibility |
-|---|---|---|
-| `crates/core` | `tact_core` | Shared types: `AgentUpdate`, `UserCommand`, `PlanStep`, `StepResult`, `StepStatus` |
-| `crates/tools` | `tools` | `Sandbox`: secure wrappers for file I/O and command execution |
-| `crates/tui` | `tui` | Terminal UI built with `ratatui` |
-| `crates/tact` | `tact` | Agent runtime, main loop, tool router, CLI entry point |
-| `crates/tool_refactor_macros` | `tool_refactor_macros` | Proc macros for tool refactoring |
+| Directory | Package | Version | Responsibility |
+|---|---|---|---|
+| `crates/core` | `tact_core` | `0.1.0` (local) | Shared wire types: `AgentUpdate`, `UserCommand`, `PlanStep`, `StepResult`, `StepStatus`, `ModelCallParams`, `BalanceInfo`. Also contains a legacy `Agent` implementation that is no longer used by the runtime. |
+| `crates/tools` | `tools` | `0.1.0` (local) | `Sandbox`: secure wrappers for file I/O and command execution. |
+| `crates/tui` | `tui` | `0.1.0` (local) | Terminal UI built with `ratatui`. |
+| `crates/tact` | `tact` | `0.19.0` (workspace) | Agent runtime, tool router, MCP client, hooks, permissions, context compaction, and the two CLI binaries. |
+| `crates/tool_refactor_macros` | `tool_refactor_macros` | `0.19.0` (workspace) | Proc-macro `#[tool(name = "...", description = "...")]` that generates `Tool` trait implementations from async functions. |
 
 Dependency graph:
 
@@ -27,103 +29,320 @@ flowchart TB
     tact_core --> tools
 ```
 
+Binaries produced by `crates/tact`:
+
+| Binary | Source | Mode |
+|---|---|---|
+| `tact` | `crates/tact/src/main.rs` | Headless / CI / non-interactive |
+| `tact-tui` | `crates/tact/src/bin/tui.rs` | Interactive terminal UI |
+
 ---
 
 ## 1. Module Architecture
 
 ```mermaid
 flowchart TB
-    subgraph main["main.rs"]
-        M["main()<br/>Initialize runtime, channels, spawn tasks"]
+    subgraph bins["Binary entry points"]
+        B1["tact src/main.rs<br/>headless CLI"]
+        B2["tact-tui src/bin/tui.rs<br/>TUI entry"]
     end
 
-    subgraph agent_mod["tact/src/lib.rs — Agent Core"]
+    subgraph tact_lib["tact/src/lib.rs — Agent Runtime"]
         A["Agent struct"]
-        AG["generate_plan()<br/>Call LLM API"]
-        AE["execute_step()<br/>Call sandbox tools"]
-        A --> AG
-        A --> AE
+        AR["AgentRuntime"]
+        AL["agent_loop()<br/>streaming conversation loop"]
+        ETC["execute_tool_call()<br/>dispatch + permission + hooks"]
+        EX["execute()<br/>native tool or MCP tool"]
+        SP["build_system_prompt()<br/>Tera template + skills/memory"]
+        CH["compact_history()<br/>context compaction"]
+
+        A --> AR
+        A --> AL
+        AL --> ETC
+        ETC --> EX
+        A --> SP
+        A --> CH
     end
 
-    subgraph tools_mod["tools crate — Sandbox Tools"]
+    subgraph submods["tact/src/ — supporting modules"]
+        TOOL["tool/<br/>Tool trait, ToolRouter, 40+ tools"]
+        PERM["permission/<br/>CapabilityRisk, PermissionManager"]
+        HOOK["hook/<br/>Pre/Post/SessionStart hooks"]
+        MCP["mcp/<br/>PluginLoader, McpClient, MCPToolRouter"]
+        COMP["compact.rs<br/>micro_compact, transcript persistence"]
+        STORE["store/<br/>StoreRoot, Store, CollectionStore"]
+        LLM["llm/<br/>Anthropic / OpenAI adapters"]
+        TASK["task/<br/>persistent task manager"]
+        TEAM["team.rs<br/>teammate roster + inbox"]
+        BG["background.rs<br/>async shell tasks"]
+        CRON["cron/<br/>scheduled prompts"]
+        MEM["memory/<br/>persistent user/project memory"]
+        SKILL["skill/<br/>SKILL.md registry"]
+        WT["worktree/<br/>git worktree lanes"]
+        REC["recovery.rs<br/>transport/prompt-too-large recovery"]
+        STATS["stats.rs<br/>session statistics"]
+        CFG["config.rs<br/>CLI/env/TOML config"]
+        PROMPT["prompt/<br/>system prompt templates"]
+    end
+
+    subgraph core["tact_core — shared types"]
+        UPD["AgentUpdate enum"]
+        CMD["UserCommand enum"]
+        STEP["PlanStep / StepResult"]
+    end
+
+    subgraph tools_crate["tools crate — Sandbox"]
         S["Sandbox"]
         SR["read_file()"]
         SW["write_file()"]
         SC["run_command()"]
-        S --> SR
-        S --> SW
-        S --> SC
+        SSP["safe_path()<br/>workspace escape prevention"]
     end
 
-    subgraph tui_mod["tui/ — Terminal UI"]
-        T["mod.rs<br/>Event loop"]
-        TH["handlers.rs<br/>Key handling"]
-        TR["render.rs<br/>Panel rendering"]
-        TS["state.rs<br/>App state"]
-        TT["theme.rs<br/>Theme colors"]
-        T --> TH
-        T --> TR
-        T --> TS
-        TR --> TS
-        TH --> TS
-        TS --> TT
+    subgraph tui_crate["tui crate — Terminal UI"]
+        T["lib.rs<br/>event loop"]
+        TH["handlers/<br/>mode-specific key handling"]
+        TR["render/<br/>panel rendering"]
+        TS["state/<br/>App state"]
+        TT["theme.rs<br/>9 color themes"]
+        TI18N["i18n.rs<br/>EN / 中文"]
+        TW["widgets/<br/>history, select popups"]
     end
 
-    M -- "mpsc channel" --> A
-    M -- "mpsc channel" --> T
-    A -- "Arc<Sandbox>" --> S
-    AE -- "tool calls" --> S
-    T -- "UnboundedSender" --> A
-    A -- "AgentUpdate" --> T
+    B1 --> A
+    B2 --> T
+    T -- UnboundedSender<UserCommand> --> A
+    A -- UnboundedSender<AgentUpdate> --> T
+
+    A --> TOOL
+    A --> MCP
+    A --> HOOK
+    AR --> PERM
+    AR --> LLM
+    A --> COMP
+
+    TOOL --> TASK
+    TOOL --> TEAM
+    TOOL --> BG
+    TOOL --> CRON
+    TOOL --> MEM
+    TOOL --> SKILL
+    TOOL --> WT
+    TOOL --> STORE
+
+    S --> SR
+    S --> SW
+    S --> SC
+    S --> SSP
+    TOOL -. "file I/O fallback" .-> S
+
+    T --> TH
+    T --> TR
+    T --> TS
+    TR --> TS
+    TH --> TS
+    TS --> TT
+    TS --> TI18N
+    TS --> TW
 ```
 
 ---
 
 ## 2. Agent Task Execution Flow
 
+The runtime no longer pre-generates a fixed JSON plan. Instead it runs a streaming conversation loop that sends tool specifications to the LLM and executes `ToolUse` blocks as they arrive.
+
 ```mermaid
 sequenceDiagram
     actor U as User
     participant TUI as TUI Module
-    participant Agent as Agent Module
+    participant Main as tact-tui main()
+    participant Agent as Agent::agent_loop()
     participant LLM as LLM API
-    participant SB as Sandbox
+    participant Perm as PermissionManager
+    participant Hook as Hook Engine
+    participant TR as ToolRouter / MCP Router
+    participant SB as Sandbox / Tools
 
     U ->> TUI: Enter task and press Enter
-    TUI ->> Agent: UserCommand::SubmitTask
-    Agent ->> LLM: generate_plan(task)
-    LLM -->> Agent: JSON plan array
-    Agent ->> TUI: AgentUpdate::PlanGenerated
+    TUI ->> Main: UserCommand::SubmitTask
+    Main ->> Agent: push user message, call agent_loop()
+    Agent ->> Agent: build_system_prompt()<br/>skills + memory + dynamic context
 
-    loop Execute step by step
-        Agent ->> TUI: AgentUpdate::StepStarted(idx)
-        alt need_approval = true
-            Agent ->> TUI: AgentUpdate::NeedApproval
-            TUI ->> U: Show approval prompt (y/n)
-            U -->> TUI: y / n
-            TUI -->> Agent: oneshot::Sender<bool>
-            alt User rejects
-                Agent ->> TUI: AgentUpdate::StepFailed
-                Note over Agent,TUI: Terminate task
+    loop Streaming conversation
+        Agent ->> Agent: micro_compact() / compact_history()
+        Agent ->> LLM: stream_message(request + tool specs)
+        LLM -->> Agent: ContentBlock stream<br/>(Text, Thinking, ToolUse)
+        Agent ->> TUI: StreamChunk / ThinkingChunk
+
+        alt StopReason is ToolUse
+            Agent ->> Agent: execute_tool_call(content)
+            loop For each ToolUse block
+                Agent ->> TUI: StepAdded + StepStarted
+                Agent ->> Hook: PreToolUse hook
+                alt Hook blocks
+                    Agent ->> TUI: StepFailed
+                else Hook continues
+                    Agent ->> Perm: check(tool_name, input)
+                    alt PermissionBehavior::Deny
+                        Agent ->> TUI: StepFailed
+                    else PermissionBehavior::Ask
+                        Agent ->> TUI: RequestSelect / NeedApproval
+                        TUI -->> Agent: user choice
+                    end
+                    Agent ->> TR: call native or MCP tool
+                    TR ->> SB: execute
+                    SB -->> TR: output
+                    TR -->> Agent: output
+                    Agent ->> Hook: PostToolUse hook
+                    Agent ->> TUI: StepFinished
+                end
             end
-        end
-        Agent ->> SB: execute_step(step)
-        SB -->> Agent: Result / Error
-        alt Execution succeeded
-            Agent ->> TUI: AgentUpdate::StepFinished
-        else Execution failed
-            Agent ->> TUI: AgentUpdate::StepFailed
-            Note over Agent,TUI: Terminate task
+            Agent ->> Agent: push ToolResult messages
         end
     end
 
-    Agent ->> TUI: AgentUpdate::TaskComplete
-    TUI ->> U: Show completion message
+    Agent ->> TUI: TaskComplete(final text)
+    TUI ->> U: Show completion / statistics
 ```
+
+Key `AgentUpdate` variants used today:
+
+| Variant | Meaning |
+|---|---|
+| `PlanGenerated(Vec<PlanStep>)` | Initial placeholder plan displayed in the TUI. |
+| `StepAdded(PlanStep)` | A new tool-use step is appended to the plan panel. |
+| `StepStarted(usize)` | Step `idx` has begun. |
+| `StepFinished(usize, StepResult)` | Step `idx` succeeded with summary/detail/duration. |
+| `StepFailed(usize, String)` | Step `idx` failed. |
+| `RequestSelect { prompt, options, respond }` | Ask the user to pick an option. |
+| `StreamChunk(String)` | Streaming assistant text fragment. |
+| `ThinkingChunk(String)` | Streaming reasoning/thinking fragment. |
+| `ModelInfo(ModelCallParams)` | Model name, max tokens, thinking budget. |
+| `TokenUsage { ... }` | Prompt/completion/cache token counts. |
+| `Balance(BalanceInfo)` | DeepSeek account balance. |
+| `Info(String)` | Informational notice. |
+| `TaskComplete(String)` | The entire task finished. |
+| `Error(AgentErrorKind)` | Classified error. |
 
 ---
 
-## 3. TUI Render Layout
+## 3. Permission System
+
+Every tool call is classified by risk and checked against the active permission mode.
+
+```mermaid
+flowchart TD
+    ToolCall["ToolUse { name, input }"] --> Normalize["normalize_capability()"]
+    Normalize --> Risk["CapabilityRisk:<br/>Read / Write / High"]
+
+    Risk -- Read --> Allow["Allow immediately"]
+    Risk --> Mode{"PermissionMode?"}
+
+    Mode -- Plan --> Deny["Deny<br/>(write operations blocked)"]
+    Mode -- Auto --> AutoCheck{"High risk?"}
+    Mode -- Default --> DefaultCheck{"High risk?"}
+
+    AutoCheck -- Yes --> Ask["Ask user"]
+    AutoCheck -- No --> Allow
+
+    DefaultCheck -- Yes --> Ask
+    DefaultCheck -- No --> AlwaysAllowed{"always_allowed_tools?"}
+
+    AlwaysAllowed -- Yes --> Allow
+    AlwaysAllowed -- No --> Ask
+
+    Ask --> UserChoice["TUI RequestSelect<br/>or non-interactive deny"]
+    UserChoice -- Allow once --> Allow
+    UserChoice -- Always allow --> Update["add to allowlist"]
+    Update --> Allow
+    UserChoice -- Deny --> Deny
+```
+
+| Mode | Behavior |
+|---|---|
+| `default` | Read-only tools allowed; writes ask once; high-risk always asks. |
+| `plan` | Read-only only; all writes denied (useful for review-first workflows). |
+| `auto` | Read and non-high writes auto-approved; high-risk still asks. |
+
+Special cases:
+
+- `read_file` and tools whose names start with `read`, `list`, `get`, `show`, `search`, `query`, `inspect`, or `find` are classified as `Read`.
+- `task` is always `High` because it spawns a sub-agent with full filesystem/shell access.
+- `bash` commands containing `rm -rf`, `sudo`, `shutdown`, or `reboot` are always `High`.
+- Simple read-only bash commands (`ls`, `cat`, `git status`, etc.) are classified as `Read`.
+
+---
+
+## 4. Hook Engine
+
+Hooks are registered on the `Agent` and run at three points:
+
+| Hook type | When | Can mutate | Can veto |
+|---|---|---|---|
+| `SessionStart` | Before the first LLM call | `LoopState` | Yes |
+| `PreToolUse` | Before each tool execution | `ToolUse` input | Yes |
+| `PostToolUse` | After each tool execution | `ToolResult` content | Yes |
+
+A hook returns `HookControl::Continue` or `HookControl::Block(reason)`. The first `Block` short-circuits the chain.
+
+---
+
+## 5. MCP Integration
+
+`tact` is a native MCP client. External tools are exposed as namespaced tool names.
+
+```mermaid
+flowchart LR
+    Load["load_mcp_router()"] --> Scan["PluginLoader.scan()<br/>.claude-plugin/plugin.json"]
+    Scan --> Connect["McpClient.connect()<br/>stdio transport via rmcp"]
+    Connect --> Fetch["fetch_tools()"]
+    Fetch --> Register["MCPToolRouter.register_client()"]
+    Register --> Agent["Agent.all_tool_specs()"]
+
+    Call["Agent.execute()<br/>mcp__<server>__<tool>"] --> Parse["McpToolName::try_from"]
+    Parse --> Route["MCPToolRouter.call()"]
+    Route --> Client["McpClient.call_tool()"]
+```
+
+MCP tool naming convention: `mcp__<server_name>__<tool_name>`. Example: `mcp__filesystem__read_file`.
+
+---
+
+## 6. Context Compaction
+
+When the conversation approaches the context limit (`TACT_CONTEXT_LIMIT_CHARS`, default 500_000 characters), the agent compacts history:
+
+1. `micro_compact()` replaces old tool-result blocks longer than 120 chars with a stub, keeping the 12 most recent results intact.
+2. If still over the limit, `compact_history()` writes the full transcript to `<workdir>/.claude/transcripts/transcript_<ts>.jsonl`, asks the LLM to summarize recent messages, and replaces the context with a single summary message.
+3. Large `bash` outputs are persisted to `<workdir>/.claude/tool-results/<tool_use_id>.txt` instead of being kept verbatim in context.
+
+Recovery mechanisms inside `agent_loop()`:
+
+| Failure | Action |
+|---|---|
+| Prompt too long | Retry after `compact_history()` (up to `MAX_RECOVERY_ATTEMPTS`). |
+| Transient transport error | Exponential backoff retry. |
+| `max_tokens` truncation with pending tools | Execute pending tools, then continue with a continuation prompt. |
+
+---
+
+## 7. Sub-agents, Team, Tasks, Worktrees
+
+| Feature | Module | Description |
+|---|---|---|
+| `task` tool | `tool/subagent.rs` | Spawns an isolated sub-agent with a restricted toolset (`bash`, `read_file`, `write_file`, `edit_file`, `search_code`, `sleep`). |
+| Persistent tasks | `task/` | `TaskManager` stores task records with status and dependency tracking under `.claude/tasks/`. |
+| Teammates | `team.rs` | Named agents with roles and an inbox supporting point-to-point messages, broadcasts, `plan_approval`, and shutdown protocols. |
+| Worktrees | `worktree/` | Git worktree isolation: `create`, `list`, `status`, `run`, `events`. Metadata stored under `.claude/worktrees/`. |
+| Background tasks | `background.rs` | Async shell commands with polling via `background_run` / `check_background`. |
+| Cron | `cron/` | Recurring or one-shot scheduled prompts persisted under `.claude/cron/`. |
+| Memory | `memory/` | Markdown files with YAML frontmatter (`user`, `feedback`, `project`, `reference`) injected into the system prompt. |
+| Skills | `skill/` | `SKILL.md` files loaded into the system prompt wrapped in `<skill>` tags. |
+
+---
+
+## 8. TUI Render Layout
 
 ```mermaid
 block-beta
@@ -131,16 +350,20 @@ block-beta
     space
     block:status
         columns 1
-        status_bar["Status Bar (height 1)"]
+        status_bar["Status Bar (height 1)<br/>Status / model / token usage / balance"]
     end
     block:main
         columns 2
         plan["Plan Panel<br/>(40% width)<br/>Execution plan list<br/>▼ expanded / ▶ collapsed"]
-        log["Log Panel<br/>(60% width)<br/>Message scroll area<br/>Supports search highlight"]
+        log["Log Panel<br/>(60% width)<br/>Streaming message area<br/>Search highlight / diff cards / code blocks"]
     end
     block:input
         columns 1
-        input_box["Input Box (height 3)<br/>Insert mode: task input<br/>Command mode: :cmd<br/>Search mode: /term"]
+        input_box["Input Box (height 1–3 + border)<br/>Insert mode: task input<br/>Command mode: :cmd<br/>Search mode: /term"]
+    end
+    block:bottom
+        columns 1
+        bottom_bar["Bottom Bar (height 2–3)<br/>Mode hints / shortcuts / uptime"]
     end
     space
 
@@ -148,6 +371,7 @@ block-beta
     style plan fill:#2e3440,color:#eceff4
     style log fill:#2e3440,color:#eceff4
     style input_box fill:#2e3440,color:#eceff4
+    style bottom_bar fill:#2e3440,color:#eceff4
 ```
 
 ### Overlays (popup panels)
@@ -161,71 +385,115 @@ block-beta
         help["Help Panel<br/>Keyboard shortcuts reference"]
         history["History Panel<br/>Task history"]
         palette["Command Palette<br/>Filterable command list"]
+        select["Select Popup<br/>Permission / user choice"]
+        diff["Diff Popup<br/>File write preview"]
+        code["Code Block Popup"]
+        thinking["Thinking Popup"]
     end
     space
 
     style help fill:#1e1e28,color:#eceff4
     style history fill:#1e1e28,color:#eceff4
     style palette fill:#1e1e28,color:#eceff4
+    style select fill:#1e1e28,color:#eceff4
+    style diff fill:#1e1e28,color:#eceff4
+    style code fill:#1e1e28,color:#eceff4
+    style thinking fill:#1e1e28,color:#eceff4
 ```
 
 ---
 
-## 4. Event Loop Flow
+## 9. Event Loop Flow
 
 ```mermaid
 flowchart TD
-    Start([Start TUI]) --> Init["enable_raw_mode<br/>EnterAlternateScreen"]
+    Start([Start TUI]) --> Init["enable_raw_mode<br/>EnterAlternateScreen<br/>EnableMouseCapture"]
     Init --> InitApp["Initialize App state"]
     InitApp --> LoopStart{Main loop}
 
-    LoopStart --> Draw["terminal.draw()<br/>Render all panels"]
-    Draw --> PollAgent["try_recv()<br/>Consume Agent updates"]
-    PollAgent --> PollEvent["event::poll(50ms)<br/>Detect terminal events"]
+    LoopStart --> DrainAgent["try_recv()<br/>Consume Agent updates"]
+    DrainAgent --> DirtyCheck{dirty or Done?}
+    DirtyCheck -- No --> WaitEvent
+    DirtyCheck -- Yes --> Draw["terminal.draw()<br/>Render status / main / input / bottom bars<br/>Render palette / select popups if active"]
+    Draw --> ResetDirty["dirty = false"]
+    ResetDirty --> Timers["Handle Done→Idle timeout<br/>Handle flash_msg timeout"]
 
-    PollEvent -- "No event" --> CheckQuit{should_quit?}
-    PollEvent -- "Event received" --> HandleEvent["Handle Key / Mouse / Resize"]
+    Timers --> WaitEvent["tokio::select:<br/>recv event_rx / recv agent_rx / sleep idle_ms"]
+    WaitEvent -- Agent update --> DrainAgent
+    WaitEvent -- Terminal event --> HandleEvent["Handle Key / Mouse / Resize"]
 
     HandleEvent --> KeyCheck{Key type?}
     KeyCheck -- "Ctrl+C" --> SetQuit["should_quit = true"]
-    KeyCheck -- "Ctrl+H" --> ToggleHist["toggle show_history"]
+    KeyCheck -- "Ctrl+H" --> ToggleHist["show_history = !show_history"]
     KeyCheck -- "Ctrl+T" --> ToggleTheme["toggle_theme()"]
-    KeyCheck -- "Ctrl+?" --> ToggleHelp["toggle show_help"]
+    KeyCheck -- "Ctrl+L" --> ToggleLang["toggle_language()"]
+    KeyCheck -- "Ctrl+?" --> ToggleHelp["show_help = !show_help"]
     KeyCheck -- "Regular key" --> ModeDispatch["Dispatch by input_mode"]
 
     ModeDispatch --> Normal["handle_normal_mode()"]
     ModeDispatch --> Insert["handle_insert_mode()"]
-    ModeDispatch --> Command["handle_command_mode()"]
+    ModeDispatch --> Command["handle_palette_mode()"]
     ModeDispatch --> Search["handle_search_mode()"]
-    ModeDispatch --> Palette["handle_palette_mode()"]
+    ModeDispatch --> Select["handle_select_mode()"]
 
-    HandleEvent --> Mouse["Mouse event:<br/>scroll wheel / drag select"]
+    HandleEvent --> Mouse["Mouse event:<br/>scroll wheel / click / drag select"]
     HandleEvent --> Resize["Resize event:<br/>recalculate layout"]
 
-    SetQuit --> CheckQuit
-    ToggleHist --> CheckQuit
-    ToggleTheme --> CheckQuit
-    ToggleHelp --> CheckQuit
-    Normal --> CheckQuit
-    Insert --> CheckQuit
-    Command --> CheckQuit
-    Search --> CheckQuit
-    Palette --> CheckQuit
-    Mouse --> CheckQuit
-    Resize --> CheckQuit
+    SetQuit --> QuitCheck{should_quit?}
+    ToggleHist --> QuitCheck
+    ToggleTheme --> QuitCheck
+    ToggleLang --> QuitCheck
+    ToggleHelp --> QuitCheck
+    Normal --> QuitCheck
+    Insert --> QuitCheck
+    Command --> QuitCheck
+    Search --> QuitCheck
+    Select --> QuitCheck
+    Mouse --> QuitCheck
+    Resize --> QuitCheck
 
-    CheckQuit -- "No" --> LoopStart
-    CheckQuit -- "Yes" --> Cleanup["disable_raw_mode<br/>LeaveAlternateScreen"]
+    QuitCheck -- "No" --> LoopStart
+    QuitCheck -- "Yes" --> Cleanup["disable_raw_mode<br/>LeaveAlternateScreen"]
     Cleanup --> End([Exit])
 ```
 
+### Normal-mode shortcuts
+
+| Key | Action |
+|---|---|
+| `Tab` | Switch focus between Plan and Log panels. |
+| `e` | Toggle plan panel visibility. |
+| `j` / `k` | Scroll log or move plan selection. |
+| `g` / `G` | Jump to top / bottom of log. |
+| `i` / `Enter` | Enter insert mode. |
+| `:` | Open command palette. |
+| `/` | Enter search mode. |
+| `n` / `N` | Next / previous search match. |
+| `y` | Copy selection / last message / approve if waiting. |
+| `Y` | Copy last code block. |
+| `V` | Open closest code-block popup. |
+| `t` | Open closest thinking popup. |
+| `c` | Cancel current task. |
+| `q` | Quit. |
+| `Esc` | Reject approval / clear selection. |
+
+### Global shortcuts (any mode)
+
+| Key | Action |
+|---|---|
+| `Ctrl+C` | Quit. |
+| `Ctrl+H` | Toggle history overlay. |
+| `Ctrl+T` | Toggle theme. |
+| `Ctrl+L` | Toggle language (EN / 中文). |
+| `Ctrl+?` | Toggle help overlay. |
+
 ---
 
-## 5. Channel Communication Architecture
+## 10. Channel Communication Architecture
 
 ```mermaid
 flowchart LR
-    subgraph Channels["Tokio MPSC Channels"]
+    subgraph Channels["Tokio Unbounded MPSC Channels"]
         direction LR
         TX1["ui_tx<br/>(UnboundedSender&lt;AgentUpdate&gt;)"]
         RX1["agent_rx<br/>(UnboundedReceiver&lt;AgentUpdate&gt;)"]
@@ -237,8 +505,8 @@ flowchart LR
         A["Agent"]
     end
 
-    subgraph MainThread["Main thread"]
-        TUI["TUI event loop"]
+    subgraph MainThread["TUI task"]
+        TUI["App event loop"]
     end
 
     A -- "Send status updates" --> TX1
@@ -255,33 +523,97 @@ flowchart LR
     style RX2 fill:#a3be8c,color:#2e3440
 ```
 
+`UserCommand` variants:
+
+| Variant | Meaning |
+|---|---|
+| `SubmitTask(String)` | Submit a new natural-language task. |
+| `Cancel` | Cancel the current task. |
+| `QueryBalance` | Query DeepSeek account balance. |
+
 ---
 
-## 6. Sandbox Safe Path Resolution
+## 11. Sandbox Safe Path Resolution
+
+The runtime uses `resolve_safe_path(work_dir, path, allow_missing)` (`crates/tact/src/tool/mod.rs`). The legacy `tools` crate has a similar `safe_path()` implementation used by the old `tact_core::Agent`.
 
 ```mermaid
 flowchart TD
-    Input["safe_path(relative_path)"] --> Filter["Filter path components:<br/>- Keep Normal<br/>- Pop ParentDir(..)<br/>- Ignore RootDir / Prefix"]
-    Filter --> Join["Join with workspace_root"]
-    Join --> Exist{"File/directory<br/>exists?"}
+    Input["resolve_safe_path(work_dir, path, allow_missing)"] --> CanonWork["work_dir.canonicalize()"]
+    CanonWork --> Join["candidate = work_dir.join(path)"]
 
-    Exist -- "Yes" --> Canonical["canonicalize()<br/>Resolve symlinks"]
-    Exist -- "No" --> ParentExist{"Parent directory<br/>exists?"}
+    Join --> Exists{"candidate.exists() OR<br/>!allow_missing?"}
+    Exists -- Yes --> CanonCan["candidate.canonicalize()"]
+    Exists -- No --> Parent["parent = candidate.parent()"]
+    Parent --> CanonParent["parent.canonicalize()"]
+    CanonParent --> PrefixParent{"parent starts_with work_dir?"}
+    PrefixParent -- No --> Err1["Return error:<br/>Path escapes workspace"]
+    PrefixParent -- Yes --> JoinName["parent.join(file_name)"]
 
-    ParentExist -- "Yes" --> ParentCano["parent.canonicalize()<br/>+ file_name"]
-    ParentExist -- "No" --> PrefixCheck{"starts_with<br/>workspace_root?"}
+    CanonCan --> PrefixFull{"full starts_with work_dir?"}
+    JoinName --> PrefixFull
 
-    PrefixCheck -- "No" --> Err1["Return error:<br/>Path escapes workspace"]
-    PrefixCheck -- "Yes" --> Return1["Return full path"]
-
-    Canonical --> Check{"starts_with<br/>canonical_root?"}
-    ParentCano --> Check
-
-    Check -- "No" --> Err2["Return error:<br/>Path escapes workspace"]
-    Check -- "Yes" --> Return2["Return safe PathBuf"]
+    PrefixFull -- No --> Err2["Return error:<br/>Path escapes workspace"]
+    PrefixFull -- Yes --> Return["Return safe PathBuf"]
 
     Err1 --> End([End])
     Err2 --> End
-    Return1 --> End
-    Return2 --> End
+    Return --> End
 ```
+
+---
+
+## 12. Configuration Loading Order
+
+`tact::config::init()` merges configuration from (highest priority first):
+
+1. CLI arguments (`--model`, `--permission-mode`, positional prompt, etc.).
+2. Environment variables (`TACT_PROVIDER`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
+3. TOML config files: `<project>/.tact/config.toml`, `<project>/tact.toml`, `~/.tact/config.toml`.
+
+LLM provider selection:
+
+| `TACT_PROVIDER` | Required env vars |
+|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` |
+| `openai` | `OPENAI_API_KEY`; optional `OPENAI_BASE_URL` |
+
+If `TACT_PROVIDER` is unset but `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` is present, the provider is inferred from the key.
+
+---
+
+## 13. `#[tool]` Proc Macro
+
+The `tool_refactor_macros` crate provides the `#[tool(name = "...", description = "...")]` attribute macro. It is used by many built-in tools (e.g., `tool/bash.rs`, `tool/math.rs`) to auto-generate:
+
+- A JSON input schema via `schemars`.
+- A wrapper struct implementing the `Tool` trait.
+- Deserialization of the JSON input into the function's arguments.
+
+Handlers can be either:
+
+- **Pure functions**: arguments are plain types, wrapped into a generated input struct.
+- **Stateful handlers**: first argument is `ToolContext`, followed by a single deserializable input struct.
+
+---
+
+## 14. What Changed Since the Original Architecture
+
+If you are reading older branches or notes, the following major evolutions have happened:
+
+- The plan-then-execute model (`generate_plan()` → sequential `execute_step()`) was replaced by a streaming agent loop (`agent_loop()`).
+- Business tools moved from `crates/tools` into `crates/tact/src/tool/`; `crates/tools` now only provides the `Sandbox`.
+- The runtime gained native support for MCP, hooks, permissions, context compaction, recovery, sub-agents, teammates, worktrees, cron, memory, and skills.
+- `tact_core::Agent` is legacy code and is no longer used by the main binaries.
+- The TUI gained streaming output, diff/code/thinking popups, a command palette, mouse support, themes, and internationalization.
+
+---
+
+## 15. Related Documents
+
+| Document | Focus |
+|---|---|
+| [`docs/state_machines.md`](./docs/state_machines.md) | Detailed state-machine diagrams for the TUI, tasks, background jobs, permissions, hooks, and recovery. |
+| [`docs/tui_rendering.md`](./docs/tui_rendering.md) | TUI rendering architecture: layout, log panel, popups, Markdown, cells, performance optimization. |
+| [`docs/batch_tools_flow.md`](./docs/batch_tools_flow.md) | `batch_read`/`batch_edit` tool execution flow and interaction sequence diagrams with the TUI. |
+| [`docs/compaction.md`](./docs/compaction.md) | Context compaction behavior and tuning. |

--- a/docs/batch_tools_flow.md
+++ b/docs/batch_tools_flow.md
@@ -1,0 +1,282 @@
+# `batch_read` / `batch_edit` Tool Execution & TUI Interaction Flowcharts
+
+This Mermaid diagram document describes the complete data flow from the Agent main loop, through LLM streaming responses, to the actual execution of `batch_read` / `batch_edit`, and finally to the `AgentUpdate` messages sent to the TUI where they are consumed and rendered.
+
+> Files involved: `crates/tact/src/tool/batch_read.rs`, `crates/tact/src/tool/batch_edit.rs`, `crates/tact/src/lib.rs`, `crates/tact/src/llm/`, `crates/tui/src/lib.rs`, `crates/tui/src/state/app/agent.rs`
+
+---
+
+## 1. Overall Interaction Sequence
+
+```mermaid
+sequenceDiagram
+    participant TUI as TUI Main Thread
+    participant Agent as Agent Runtime<br/><Tact>
+    participant LLM as LLM Provider<br/>(Anthropic/OpenAI)
+    participant Toolset as ToolSet
+    participant BatchRead as batch_read impl
+    participant BatchEdit as batch_edit impl
+    participant FS as File System
+
+    TUI->>Agent: Create and start Agent (with_ui_channel)
+    TUI->>TUI: Hold agent_rx to receive AgentUpdate
+
+    Agent->>LLM: stream_message(request, ui_tx)
+
+    loop LLM streaming response
+        LLM->>Agent: StreamChunk / ThinkingChunk
+        Agent->>TUI: AgentUpdate::StreamChunk(text)
+        Agent->>TUI: AgentUpdate::ThinkingChunk(thinking)
+    end
+
+    LLM->>Agent: ToolUse {name: "batch_read", input}
+    Agent->>TUI: AgentUpdate::StepAdded(...)
+    Agent->>TUI: AgentUpdate::StepStarted(step_idx)
+
+    Agent->>Toolset: tools.call(ctx, "batch_read", input)
+    Toolset->>BatchRead: Match and execute batch_read
+
+    loop For each file entry
+        BatchRead->>FS: Read file content
+        alt success
+            BatchRead->>BatchRead: Record result
+        else failure
+            BatchRead->>BatchRead: Record error
+        end
+    end
+
+    BatchRead->>Toolset: Return JSON result
+    Toolset->>Agent: ToolResult {content}
+
+    Agent->>TUI: AgentUpdate::Info("Executing batch_read(...)")
+    Agent->>TUI: AgentUpdate::StepFinished(step_idx, StepResult)
+
+    Agent->>LLM: Append result to context, continue request
+
+    Note over TUI: TUI asynchronously receives all AgentUpdate
+    TUI->>TUI: handle_agent_update(msg) updates state
+    TUI->>TUI: terminal.draw(...) renders log/cards/popups
+
+    LLM->>Agent: ToolUse {name: "batch_edit", input}
+    Agent->>TUI: AgentUpdate::StepAdded / StepStarted
+    Agent->>Toolset: tools.call(ctx, "batch_edit", input)
+    Toolset->>BatchEdit: Match and execute batch_edit
+
+    BatchEdit->>BatchEdit: Atomically validate all edits
+
+    alt Any edit validation fails
+        BatchEdit->>Toolset: Return error, no files modified
+    else All pass
+        loop For each edit
+            BatchEdit->>FS: Read original file
+            BatchEdit->>BatchEdit: Replace old_string with new_string
+            BatchEdit->>FS: Write new content
+        end
+        BatchEdit->>Toolset: Return summary of all changes
+    end
+
+    Toolset->>Agent: ToolResult
+    Agent->>TUI: AgentUpdate::Info("Executing batch_edit(...)")
+    Agent->>TUI: AgentUpdate::StepFinished(step_idx, StepResult)
+
+    Agent->>LLM: Append edit result to context
+```
+
+---
+
+## 2. Agent Main Loop Internal Flow
+
+```mermaid
+flowchart TD
+    A[agent_loop start] --> B[Build system prompt]
+    B --> C[Assemble CreateMessageParams]
+    C --> D[emit_update AgentUpdate::ModelInfo]
+    D --> E[stream_message request]
+
+    E --> F{stop_reason?}
+    F -->|stop / max_tokens| G[Exit loop]
+    F -->|tool_use| H[execute_tool_call]
+
+    H --> I[Iterate ContentBlock]
+    I --> J{block type}
+    J -->|ToolUse| K[StepAdded + StepStarted]
+    J -->|Text/Thinking| L[Skip]
+
+    K --> M[Permission check]
+    M -->|Allow| N[execute tool]
+    M -->|Deny| O[StepFailed]
+    M -->|Ask| P[RequestSelect popup]
+    P -->|User approves| N
+    P -->|User denies| O
+
+    N --> Q{batch_edit?}
+    Q -->|Yes| R[tools.call batch_edit]
+    Q -->|No| S[tools.call other tool]
+
+    R --> T[Return ToolResult]
+    S --> T
+
+    T --> U[emit_update StepFinished]
+    U --> V[Generate ToolResult content block]
+    V --> W[Append to context]
+    W --> E
+```
+
+---
+
+## 3. `batch_edit` Atomic Execution Flow
+
+```mermaid
+flowchart TD
+    A[Input file list with old_string/new_string] --> B[Iterate validate each edit]
+    B --> C{Is old_string unique and present?}
+    C -->|Any failure| D[Return error: no files modified]
+    C -->|All pass| E[Execute all edits]
+
+    E --> F[Read original file]
+    F --> G[Exactly replace old_string with new_string]
+    G --> H[Write back to file system]
+    H --> I[Generate change summary]
+    I --> J[Return JSON result]
+```
+
+### Key Design
+
+- **Atomicity**: All `old_string` values are validated first; if any fails, no file is modified.
+- **Exact match**: Uses `str::replace_once` semantics, requiring `old_string` to appear exactly once in the file.
+- **TUI cards**: If the tool context contains `ui_tx`, `batch_edit` calls `emit_file_write_cards` to push `AgentUpdate::FileWrite` and `AgentUpdate::WriteFinalized` to the TUI, which renders the right-side diff cards.
+
+---
+
+## 4. `batch_read` Batch Read Flow
+
+```mermaid
+flowchart TD
+    A[Input file list with path/offset/limit] --> B[Iterate each file entry]
+    B --> C[Read file content]
+    C --> D{Success?}
+    D -->|Yes| E[Slice by offset/limit]
+    D -->|No| F[Record error]
+    E --> G[Aggregate result array]
+    F --> G
+    G --> H[Return JSON result]
+```
+
+### Key Design
+
+- Supports `offset`/`limit` parameters to avoid reading huge files at once.
+- Each file returns its own `content` or `error` independently.
+- A failed file does not affect the reading of other files.
+
+---
+
+## 5. TUI Consumption of AgentUpdate
+
+```mermaid
+flowchart TD
+    A[TUI main loop] --> B{agent_rx.try_recv}
+    B -->|No message| C[Continue waiting]
+    B -->|Has message| D[handle_agent_update]
+
+    D --> E{AgentUpdate type}
+
+    E -->|ModelInfo| F[Update app.model_call_params]
+    E -->|StreamChunk| G[Append text message or append to current reasoning/output]
+    E -->|ThinkingChunk| H[Append thinking block message]
+    E -->|StepAdded| I[Add to plan.steps]
+    E -->|StepStarted| J[Mark current executing step]
+    E -->|StepFinished| K[Update step result status]
+    E -->|StepFailed| L[Mark step failed]
+    E -->|FileWrite| M[Register diff preview card]
+    E -->|WriteFinalized| N[Convert diff card to code card]
+    E -->|RequestSelect| O[Open select popup wait for user]
+    E -->|TokenUsage| P[Update token statistics]
+
+    F --> Q[Set app.dirty = true]
+    G --> Q
+    H --> Q
+    I --> Q
+    J --> Q
+    K --> Q
+    L --> Q
+    M --> Q
+    N --> Q
+    O --> Q
+    P --> Q
+
+    Q --> R[terminal.draw render]
+```
+
+---
+
+## 6. TUI Rendering Layers
+
+```mermaid
+flowchart LR
+    A[terminal.draw] --> B[render_status_bar]
+    A --> C[render_main_area]
+    A --> D[render_input_box]
+    A --> E[render_bottom_bar]
+    A --> F[Popup layer]
+
+    C --> G{Plan visible?}
+    G -->|Yes| H[Left plan.rs<br/>Right log.rs]
+    G -->|No| I[Only log.rs]
+
+    I --> J[cells/text.rs text lines]
+    I --> K[cells/thinking.rs thinking cards]
+    I --> L[cells/diff.rs diff cards]
+    I --> M[cells/code.rs code cards]
+
+    F --> N[command_palette]
+    F --> O[select_popup]
+    F --> P[help / history]
+    F --> Q[thinking_popup]
+    F --> R[diff_popup]
+    F --> S[code_popup]
+```
+
+---
+
+## 7. Key Code Mapping
+
+| Flow Node | Code Location |
+|---|---|
+| Agent main loop | `crates/tact/src/lib.rs` `Tact::agent_loop()` |
+| Tool call dispatch | `crates/tact/src/lib.rs` `Tact::execute_tool_call()` |
+| Concrete tool execution | `crates/tact/src/lib.rs` `Tact::execute()` |
+| Tool registration & routing | `crates/tact/src/tool/mod.rs` `ToolSet::call()` |
+| `batch_read` implementation | `crates/tact/src/tool/batch_read.rs` `BatchRead::run()` |
+| `batch_edit` implementation | `crates/tact/src/tool/batch_edit.rs` `BatchEdit::run()` |
+| Streaming response Anthropic | `crates/tact/src/llm/anthropic.rs` `stream_message()` |
+| Streaming response OpenAI | `crates/tact/src/llm/openai.rs` `stream_message()` |
+| AgentUpdate definition | `crates/core/src/lib.rs` |
+| TUI main loop consumption | `crates/tui/src/lib.rs` `run_tui()` |
+| TUI handle AgentUpdate | `crates/tui/src/state/app/agent.rs` `handle_agent_update()` |
+| Log / card rendering | `crates/tui/src/render/log.rs`, `crates/tui/src/render/cells/` |
+
+---
+
+## 8. Performance & Concurrency Notes
+
+- `AgentUpdate` is sent via a **tokio unbounded channel**; `emit_update` uses `let _ = tx.send(...)`, so it never blocks even if the TUI is not connected.
+- `batch_edit` performs **atomic validation and writes** inside the tool; it does not concurrently modify the same file; all file writes happen sequentially.
+- `batch_read` reads each file independently in sequential order; it can be changed to concurrent `tokio::fs::read_to_string` if needed.
+- The TUI uses `app.dirty` for **dirty rendering**, so it only redraws when new messages or state changes arrive, avoiding idle spinning.
+
+---
+
+## 9. Extension Guide
+
+### Add a new batch tool
+
+1. Create a new module under `crates/tact/src/tool/` (refer to `batch_read.rs` / `batch_edit.rs`).
+2. Register it in `ToolSet::tool_specs()` and `ToolSet::call()`.
+3. If you need a special card, define a new `AgentUpdate` variant and handle it in `handle_agent_update`.
+4. Add the corresponding renderer in `crates/tui/src/render/cells/`.
+
+### Adjust TUI rendering
+
+- Modify `render/log.rs` `LogColumnRenderer` to change log layout.
+- Modify `cells/*.rs` to change thinking/diff/code card styles.
+- Modify `popups/*.rs` to change popup layout and interaction hints.

--- a/docs/state_machines.md
+++ b/docs/state_machines.md
@@ -1,0 +1,328 @@
+# State Machines
+
+This document describes the state machines used across the `tact` codebase. Most are plain Rust enums with explicit transitions driven by `AgentUpdate` messages, user input, or tool results.
+
+---
+
+## 1. TUI Execution Status
+
+File: `crates/tui/src/state/mod.rs`
+
+This is the highest-level UI state. It drives the status bar, the plan panel, and whether the user is being asked for approval.
+
+```rust
+pub(crate) enum Status {
+    Idle,
+    Planning,
+    Executing { current_step: usize, total: usize },
+    WaitingForUser { prompt: String, step_index: usize, approval_tx: oneshot::Sender<bool> },
+    Done,
+}
+```
+
+### State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: startup
+
+    Idle --> Planning: user submits task (Enter in Insert mode)
+    Planning --> Executing: AgentUpdate::PlanGenerated or StepAdded
+
+    Executing --> Executing: AgentUpdate::StepStarted (current_step updated)
+    Executing --> WaitingForUser: AgentUpdate::NeedApproval / RequestSelect
+    Executing --> Done: AgentUpdate::TaskComplete
+    Executing --> Idle: AgentUpdate::StepFailed / Error(Other)
+
+    WaitingForUser --> Executing: user approves (y / Enter)
+    WaitingForUser --> Idle: user denies (n / Esc)
+
+    Done --> Idle: after 2s timeout
+    Idle --> [*]: user quits
+```
+
+### Transition triggers
+
+| From | To | Trigger | Notes |
+|---|---|---|---|
+| `Idle` | `Planning` | User presses `Enter` in Insert mode with non-empty input. | Old approval (if any) is rejected; plan panel is cleared. |
+| `Planning` | `Executing` | `AgentUpdate::PlanGenerated` or `StepAdded`. | `total` is set to current plan length. |
+| `Executing` | `Executing` | `AgentUpdate::StepStarted(idx)`. | `current_step` is updated to `idx`. |
+| `Executing` | `WaitingForUser` | `AgentUpdate::NeedApproval` or `AgentUpdate::RequestSelect`. | `input_mode` is forced to `Normal` or `Select`. |
+| `Executing` | `Done` | `AgentUpdate::TaskComplete`. | `task_done_time` is recorded for the 2s highlight. |
+| `Executing` | `Idle` | `AgentUpdate::StepFailed` or fatal `AgentUpdate::Error(Other)`. | `task_start_time` is cleared. |
+| `WaitingForUser` | `Executing` | User presses `y` / `Enter` to approve. | `approval_tx.send(true)`. |
+| `WaitingForUser` | `Idle` | User presses `n` / `Esc` to deny. | `approval_tx.send(false)`. |
+| `Done` | `Idle` | 2-second auto-timeout elapses. | Implemented in the main TUI loop. |
+
+---
+
+## 2. TUI Input Mode
+
+File: `crates/tui/src/state/mod.rs`
+
+Determines how keyboard input is interpreted.
+
+```rust
+pub(crate) enum InputMode {
+    Normal,   // navigation, shortcuts
+    Insert,   // typing a task
+    Search,   // searching log messages
+    Palette,  // command palette
+    Select,   // option selection popup
+}
+```
+
+### State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Normal: startup
+
+    Normal --> Insert: i / Enter
+    Insert --> Normal: Esc
+    Insert --> Normal: Enter (submits task)
+
+    Normal --> Search: /
+    Search --> Normal: Enter / Esc
+
+    Normal --> Palette: :
+    Palette --> Normal: Enter / Esc
+
+    Normal --> Select: AgentUpdate::RequestSelect
+    Select --> Normal: Enter / Esc
+```
+
+### Mode-specific behavior
+
+| Mode | Purpose | Confirm key | Cancel key |
+|---|---|---|---|
+| `Normal` | Navigate panels, run shortcuts, approve/deny. | — | — |
+| `Insert` | Type a natural-language task. | `Enter` | `Esc` |
+| `Search` | Filter log messages with `/term`. | `Enter` | `Esc` |
+| `Palette` | Run commands (`theme`, `quit`, `balance`, …). | `Enter` | `Esc` |
+| `Select` | Pick one option from a popup. | `Enter` | `Esc` |
+
+---
+
+## 3. Persistent Task Lifecycle
+
+File: `crates/tact/src/task/mod.rs`
+
+Tasks are durable work items with dependency tracking.
+
+```rust
+pub enum TaskStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Deleted,
+}
+```
+
+### State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: task_create
+    Pending --> InProgress: task_update(status = "in_progress")
+    InProgress --> Completed: task_update(status = "completed")
+    Pending --> Completed: task_update(status = "completed")
+    InProgress --> Deleted: task_update(status = "deleted")
+    Pending --> Deleted: task_update(status = "deleted")
+    Completed --> [*]
+    Deleted --> [*]
+```
+
+### Dependency rules
+
+- `blocked_by`: list of task IDs that must be completed before this task is unblocked.
+- `blocks`: list of task IDs that this task blocks.
+- When a task is marked `Completed`, its ID is removed from all other tasks' `blocked_by` lists (`clear_dependency`).
+- Rendering markers: `[ ]` Pending, `[>]` InProgress, `[x]` Completed, `[-]` Deleted.
+
+---
+
+## 4. Background Task Lifecycle
+
+File: `crates/tact/src/background.rs`
+
+Background tasks are asynchronous shell commands spawned via `tokio::spawn`.
+
+```rust
+pub enum BackgroundTaskStatus {
+    Running,
+    Completed,
+    Error,
+}
+```
+
+### State transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running: background_run(command)
+    Running --> Completed: command exits with success
+    Running --> Error: command exits with failure or spawn fails
+    Completed --> [*]
+    Error --> [*]
+```
+
+Each transition is persisted to disk under `.claude/background/tasks/<id>.json` so the task can be polled later with `check_background` even if the agent restarts.
+
+---
+
+## 5. Permission Decision
+
+File: `crates/tact/src/permission/mod.rs`
+
+Every tool call is classified and checked against the active permission mode.
+
+```rust
+pub enum PermissionBehavior {
+    Allow,
+    Deny,
+    Ask,
+}
+```
+
+### Decision flow
+
+See [`ARCHITECTURE.md`](../ARCHITECTURE.md#3-permission-system) for the full diagram. In short:
+
+1. `normalize_capability(tool, input)` computes `CapabilityRisk` (`Read`, `Write`, `High`).
+2. `PermissionManager::check(mode, risk, allowlist)` returns `PermissionBehavior`.
+3. If `Ask`, the TUI shows a `RequestSelect` popup or the headless runtime denies.
+4. User choice transitions the allowlist (`always_allowed_tools`) and returns to `Allow` or `Deny`.
+
+### Mode-specific state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> ClassifyRisk: tool call
+    ClassifyRisk --> Allow: Read (all modes)
+    ClassifyRisk --> Deny: Plan mode + Write
+    ClassifyRisk --> Ask: High risk
+    ClassifyRisk --> Allow: Auto mode + non-high Write
+    ClassifyRisk --> Ask: Default mode + Write
+    ClassifyRisk --> Allow: tool in always_allowed_tools
+
+    Ask --> Allow: user chooses allow once / always allow
+    Ask --> Deny: user chooses deny
+```
+
+---
+
+## 6. Hook Control
+
+File: `crates/tact/src/hook/mod.rs`
+
+Hooks can permit or veto operations at three lifecycle points.
+
+```rust
+pub enum HookControl {
+    Continue,
+    Block(String),
+}
+```
+
+### Behavior
+
+- `Continue`: proceed to the next hook or to the next operation.
+- `Block(reason)`: stop the chain and treat the tool call as failed with `reason`.
+
+Hooks are invoked in this order during a tool call:
+
+1. `PreToolUse` hooks — can mutate `ToolUse` input.
+2. If all return `Continue`, permission check and tool execution run.
+3. `PostToolUse` hooks — can mutate `ToolResult` content.
+
+---
+
+## 7. Step Execution Status
+
+File: `crates/core/src/lib.rs`
+
+A small enum attached to `StepResult` for TUI display.
+
+```rust
+pub enum StepStatus {
+    Success,
+    Failed,
+}
+```
+
+This is not a lifecycle state machine by itself; it is the outcome of a single tool execution recorded in `StepResult`.
+
+---
+
+## 8. Select Popup State
+
+File: `crates/tui/src/state/select_popup.rs`
+
+The select popup has its own implicit state machine managed through the `respond` oneshot channel.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Inactive: new()
+    Inactive --> Active: set(prompt, options, respond)
+    Active --> Confirmed: confirm() sends Some(idx)
+    Active --> Cancelled: cancel() sends None
+    Confirmed --> Inactive: respond channel consumed
+    Cancelled --> Inactive: respond channel consumed
+```
+
+`RequestSelect` from the agent activates the popup; `Enter` confirms and `Esc` cancels, both returning the UI to `InputMode::Normal`.
+
+---
+
+## 9. Streaming / Parsing State
+
+File: `crates/tui/src/state/stream_state.rs` and `crates/tui/src/state/thinking_state.rs`
+
+The TUI maintains mutable streaming parsers for assistant output:
+
+- `StreamState` tracks whether the stream is inside a code block, a table, or a plain paragraph.
+- `ThinkingState` buffers thinking content until a complete line or the end of the thinking block is detected.
+
+These are not formal enums but are stateful machines with guarded transitions (e.g., ` ``` ` toggles code-block mode, blank lines flush paragraph mode).
+
+Key transitions:
+
+| Event | StreamState change |
+|---|---|
+| `AgentUpdate::ThinkingChunk` | Buffer thinking text; flush on newline; close on first non-thinking update. |
+| `AgentUpdate::StreamChunk` with ` ```lang ` | Enter code-block mode, remember start index. |
+| `AgentUpdate::StreamChunk` with ` ``` ` | Close code block, replace placeholders with a `CodeBlock` overlay. |
+| `AgentUpdate::StreamChunk` blank line | Flush paragraph and table buffers. |
+
+---
+
+## 10. Agent Runtime Recovery State
+
+File: `crates/tact/src/lib.rs` (via `AgentRuntime.recovery_state`)
+
+The agent loop keeps counters for automatic recovery:
+
+- `transport_attempts`: transient network errors → exponential backoff retry.
+- `compact_attempts`: prompt-too-large errors → retry after `compact_history()`.
+- `continuation_attempts`: `max_tokens` truncation → continue with a continuation prompt.
+
+All three are reset to zero when the corresponding recovery path succeeds or when the loop moves on to a fresh LLM call.
+
+---
+
+## Summary Table
+
+| State machine | File | Driven by | Purpose |
+|---|---|---|---|
+| `Status` | `crates/tui/src/state/mod.rs` | `AgentUpdate` + user input | Top-level TUI execution state. |
+| `InputMode` | `crates/tui/src/state/mod.rs` | Keyboard events | Keyboard input interpretation. |
+| `TaskStatus` | `crates/tact/src/task/mod.rs` | `task_*` tools | Persistent task lifecycle. |
+| `BackgroundTaskStatus` | `crates/tact/src/background.rs` | `background_run` / completion | Async shell task lifecycle. |
+| `PermissionBehavior` | `crates/tact/src/permission/mod.rs` | Risk classification + mode | Approve/deny/ask for each tool call. |
+| `HookControl` | `crates/tact/src/hook/mod.rs` | Hook return value | Permit or veto agent operations. |
+| `StepStatus` | `crates/core/src/lib.rs` | Tool execution result | Per-step success/failure display. |
+| `SelectPopup` | `crates/tui/src/state/select_popup.rs` | `RequestSelect` + keys | User option selection popup. |
+| `StreamState` / `ThinkingState` | `crates/tui/src/state/stream_state.rs` / `thinking_state.rs` | Stream chunks | Parse Markdown/code/thinking output. |
+| `RecoveryState` | `crates/tact/src/recovery.rs` | LLM errors | Auto-recovery from transport/context errors. |

--- a/docs/tui_rendering.md
+++ b/docs/tui_rendering.md
@@ -1,0 +1,326 @@
+# TUI 渲染文档
+
+本文档描述 `crates/tui/src/render` 模块的渲染架构、模块划分、渲染流程及性能优化策略。
+
+---
+
+## 1. 架构总览
+
+TUI 基于 [ratatui](https://docs.rs/ratatui) 绘制，采用**分层渲染**设计：
+
+- `lib.rs` 中的主循环负责初始化终端、处理事件、调度渲染。
+- `render/` 目录包含所有绘制逻辑，按功能拆分为多个子模块。
+- 渲染以 `Frame` 为单位，每一帧将 `App` 状态转换为终端画面。
+
+```
+crates/tui/src/render/
+├── mod.rs              # 模块导出
+├── layout.rs           # 主区域布局
+├── bar.rs              # 顶部/底部状态栏
+├── input.rs            # 输入框与命令行
+├── log.rs              # 日志面板
+├── log_column.rs       # 日志列渲染器
+├── plan.rs             # 执行计划面板
+├── render_md.rs        # Markdown 渲染
+├── renderable.rs       # Renderable trait
+├── util.rs             # 文本换行工具
+├── welcome.rs          # 启动 Logo 组件
+├── cells/              # 卡片渲染单元
+│   ├── text.rs
+│   ├── thinking.rs
+│   ├── diff.rs
+│   └── code.rs
+└── popups/             # 弹窗
+    ├── command_palette.rs
+    ├── select.rs
+    ├── help.rs
+    ├── history.rs
+    ├── thinking_popup.rs
+    ├── diff_popup.rs
+    └── code_popup.rs
+```
+
+---
+
+## 2. 主循环与渲染入口
+
+主循环位于 `crates/tui/src/lib.rs` 的 `run_tui()` 中：
+
+1. **处理 Agent 更新**：在渲染前先消费 `agent_rx` 中的消息，保证状态一致性。
+2. **脏检查**：仅当 `app.dirty` 为 `true` 或状态为 `Status::Done` 时才重绘。
+3. **计算布局**：根据终端大小、输入框行数、余额信息行数切分区域。
+4. **按层次渲染**：状态栏 → 主区域 → 输入框 → 底部栏 → 弹窗。
+5. **清理状态**：如 `Done` 高亮 2 秒后恢复 `Idle`，`flash_msg` 3 秒后清除。
+
+```rust
+terminal.draw(|f| {
+    let size = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),          // 顶部状态栏
+            Constraint::Min(3),              // 主区域
+            Constraint::Length(input_height),// 输入框
+            Constraint::Length(bottom_height),// 底部栏
+        ])
+        .split(size);
+
+    render_status_bar(f, chunks[0], &app);
+    render_main_area(f, chunks[1], &mut app);
+    render_input_box(f, chunks[2], &mut app);
+    render_bottom_bar(f, chunks[3], &app);
+
+    if app.input_mode == InputMode::Palette { render_command_palette(f, size, &app); }
+    if app.input_mode == InputMode::Select  { render_select_popup(f, size, &app); }
+})?;
+```
+
+---
+
+## 3. 布局模块 (`layout.rs`)
+
+`render_main_area()` 负责主内容区：
+
+| 显示状态 | 布局行为 |
+|---|---|
+| `show_history == true` | 全屏显示历史任务面板 |
+| `show_help == true` | 全屏显示帮助面板 |
+| `plan.visible == true` | 左侧 20% 计划面板，右侧 80% 日志面板 |
+| 默认 | 100% 日志面板 |
+
+同时根据布局结果更新 `app.mouse.plan_area` 和 `app.mouse.log_area`，用于后续鼠标命中测试。
+
+---
+
+## 4. 状态栏 (`bar.rs`)
+
+### 顶部状态栏 (`render_status_bar`)
+
+- 显示当前输入模式（`Normal` / `Insert` / `Search` / `Palette` / `Select`）
+- 显示当前焦点面板（`[Log]` / `[Plan]`）
+- 根据 `Status` 显示任务状态：
+  - `Idle`：主题、语言、快捷键提示
+  - `Planning`：正在规划中
+  - `Executing`：执行到第 N / 总 M 步
+  - `WaitingForUser`：等待用户审批
+  - `Done`：任务完成（绿色高亮 2 秒）
+- 特殊状态覆盖：
+  - `party_mode`：派对模式全彩横幅
+  - `flash_msg`：临时通知（3 秒）
+
+### 底部栏 (`render_bottom_bar`)
+
+- 焦点面板提示
+- 工作目录、Git 分支
+- 当前模型、最大 token、thinking budget
+- Token 统计（prompt / completion / cache hit）
+- 任务耗时与 TUI 运行时间
+- DeepSeek 账户余额（可选第三行）
+
+---
+
+## 5. 输入区域 (`input.rs`)
+
+### 命令行 (`render_command_line`)
+
+用于 `Search`（前缀 `/`）和 `Palette`（无前缀）模式：
+
+- 显示 `cmd_line` 内容
+- 光标定位在文本末尾
+
+### 主输入框 (`render_input_box`)
+
+- 支持最多 3 行的多行输入
+- 在 `Insert` 模式下渲染带圆角边框的输入框
+- 在 `WaitingForUser` 状态下渲染审批横幅
+- 光标按字符宽度计算（支持中文等宽字符）
+
+---
+
+## 6. 日志面板 (`log.rs`)
+
+日志面板是最复杂的渲染组件，核心流程如下：
+
+### 6.1 可见性索引 (`visible_indices`)
+
+- 某些物理消息行可能被隐藏（如思考块的详细内容、代码块占位符）
+- 维护 `visible_indices`：逻辑行 → 物理行
+- 维护 `phys_to_logical_cache`：物理行 → 逻辑行
+
+### 6.2 视觉缓存 (`visual_cache`)
+
+- 每行按面板宽度自动换行
+- 缓存 `visual_cache` 和 `visual_start_cache`
+- 当 `messages.len()` 或宽度变化时重建缓存
+
+### 6.3 视口裁剪
+
+- 根据 `log_scroll.offset` 计算可见的逻辑行范围
+- 只渲染落在当前视口内的 `TextCell`
+
+### 6.4 卡片覆盖层
+
+在日志面板之上叠加三种卡片：
+
+| 卡片类型 | 文件 | 说明 |
+|---|---|---|
+| Thinking 卡片 | `cells/thinking.rs` | 折叠显示思考块，最多 3 行预览 |
+| Diff 卡片 | `cells/diff.rs` | 文件写入预览，显示行号与 `+` 前缀 |
+| Code 卡片 | `cells/code.rs` | 已完成代码块卡片，支持语法高亮 |
+
+### 6.5 滚动条
+
+- 基于**视觉行总数**计算滚动条位置
+- 使用自定义符号：`▲` / `▼` / `│` / `█`
+
+---
+
+## 7. 渲染单元 (`cells/`)
+
+### `Renderable` trait (`renderable.rs`)
+
+所有可渲染单元实现该 trait：
+
+```rust
+pub(crate) trait Renderable {
+    fn render(&self, area: Rect, buf: &mut Buffer);
+    fn render_partial(&self, area: Rect, buf: &mut Buffer, skip_lines: usize);
+    fn height(&self, width: u16) -> u16;
+}
+```
+
+### `TextCell` (`cells/text.rs`)
+
+日志基本渲染单元，支持：
+
+- 预换行缓存
+- 搜索高亮（黄色背景）
+- 鼠标选中（反色）
+- 词级双击选择
+- 思考块折叠指示前缀
+
+### 卡片单元
+
+- `thinking.rs`：紫色调边框，显示最近最多 3 行思考内容
+- `diff.rs`：绿色 `+` 前缀，显示文件路径与行号
+- `code.rs`：深蓝灰背景，显示语言标签与代码预览
+
+---
+
+## 8. Markdown 渲染 (`render_md.rs`)
+
+使用 `tui-markdown` 将 Markdown 转换为 `Line` 列表：
+
+- 自定义 `TuiStyleSheet`：标题、代码、链接、引用样式
+- 代码块后处理：统一深蓝灰背景
+- 表格格式化：对齐列、加粗表头
+- 水平线检测
+
+> 注意：不处理超链接 OSC 8 序列，因为 ratatui 会剥离转义序列。
+
+---
+
+## 9. 弹窗 (`popups/`)
+
+| 弹窗 | 文件 | 说明 |
+|---|---|---|
+| 命令面板 | `command_palette.rs` | `:` 触发，模糊过滤命令 |
+| 选择弹窗 | `select.rs` | 代理请求用户选择 |
+| 帮助面板 | `help.rs` | `Ctrl+?` 触发，快捷键说明 |
+| 历史面板 | `history.rs` | `Ctrl+H` 触发，可重试历史任务 |
+| 思考详情 | `thinking_popup.rs` | 查看完整思考内容 |
+| 文件详情 | `diff_popup.rs` | 查看写入文件的完整内容 |
+| 代码详情 | `code_popup.rs` | 查看完整代码块 |
+
+弹窗通常：
+
+- 占据屏幕 80% × 80%
+- 先渲染 `Clear` 清除背景
+- 显示 `[y] Copy`、`[Esc] Close`、`[j/k] Scroll` 提示
+- 记录区域到 `app.mouse.*_popup_area` 用于点击外部关闭
+
+---
+
+## 10. 性能优化
+
+### 10.1 脏渲染 (Dirty Rendering)
+
+- 仅在 `app.dirty == true` 或 `Status::Done` 时调用 `terminal.draw()`
+- 空闲时以 1 秒间隔 poll，降低 CPU 占用
+
+### 10.2 缓存策略
+
+| 缓存 | 位置 | 失效条件 |
+|---|---|---|
+| `visible_indices` | `log_scroll` | `messages.len()` 变化 |
+| `visual_cache` | `log_scroll` | `messages.len()` 或宽度变化 |
+| `phys_to_logical_cache` | `log_scroll` | `messages.len()` 变化 |
+| 代码块 `styled` | `CodeBlock` | 块创建时 |
+| Diff 预览行 | `DiffBlock` | 块创建时 |
+
+### 10.3 视口裁剪
+
+- `LogColumnRenderer` 只渲染落在当前视口内的单元
+- 每个 `TextCell` 支持 `render_partial` 跳过不可见行
+
+### 10.4 自适应事件轮询
+
+| 状态 | 轮询间隔 | 原因 |
+|---|---|---|
+| `Done` 或 `flash_msg` | 200ms | 及时清理超时状态 |
+| `dirty == true` | 10ms | 快速触发重绘 |
+| 空闲 | 1000ms | 降低 CPU 占用 |
+
+---
+
+## 11. 主题与国际化
+
+### 主题 (`theme.rs`)
+
+- 内置 9 套主题：`Dark`、`Light`、`SolarizedDark`、`SolarizedLight`、`GruvboxDark`、`Nord`、`Retro`、`Kawaii`、`Japanese`
+- 每个主题定义背景、前景、强调色、警告色、边框等
+- 通过 `Ctrl+T` 循环切换
+
+### 国际化 (`i18n.rs`)
+
+- 支持 `English` 和 `Chinese`
+- 所有 UI 字符串集中定义在 `Messages` 结构体
+- 命名约定：
+  - `_tmpl`：含 `{}` 占位符的模板
+  - `_pl`：复数形式
+- 通过 `Ctrl+L` 循环切换
+
+---
+
+## 12. 相关状态机
+
+渲染状态受以下状态机驱动，详见 `docs/state_machines.md`：
+
+- `Status`：Idle / Planning / Executing / WaitingForUser / Done
+- `InputMode`：Normal / Insert / Search / Palette / Select
+- `SelectPopup`：Inactive / Active / Confirmed / Cancelled
+- `StreamState` / `ThinkingState`：流式输出解析
+
+---
+
+## 13. 调试与扩展
+
+### 添加新面板
+
+1. 在 `render/` 下新建渲染模块
+2. 在 `layout.rs` 中根据状态分配区域
+3. 在 `state/mod.rs` 的 `App` 中添加所需状态
+4. 如有需要，在 `mouse_state.rs` 中记录区域用于鼠标命中
+
+### 添加新弹窗
+
+1. 在 `render/popups/` 下新建模块
+2. 在 `popups/mod.rs` 中导出
+3. 在 `layout.rs` 或主循环中调用
+4. 在 `App` 中添加弹窗状态与打开/关闭/滚动方法
+
+### 性能分析
+
+- 关注 `log.rs` 中缓存命中率
+- 使用 `app.dirty` 控制重绘频率
+- 避免在 `render()` 中执行文件 I/O（如 `diff_popup.rs` 已使用 `cached_content` 懒加载）


### PR DESCRIPTION
- Add docs/tui_rendering.md covering rendering architecture, layout, log panel, cells, popups, Markdown rendering, performance optimization, and extension guide.
- Add docs/state_machines.md for TUI/agent state-machine diagrams.
- Add docs/batch_tools_flow.md with sequence/flow diagrams for batch_read, batch_edit execution and TUI interaction.
- Update ARCHITECTURE.md to reference the new docs.