### PR TITLE
feat: Mermaid main-area rendering + complete OpenAI Responses support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,7 +4767,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "anyhow",
  "async-openai 0.20.0",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "tact-ui"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "anyhow",
  "base64",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "tact_llm"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "anyhow",
  "async-openai 0.20.0",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "tool_refactor_macros"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.13"
+version = "1.1.14"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/book/05_chapter_compact.md
+++ b/book/05_chapter_compact.md
@@ -328,9 +328,9 @@ protocol baseline through the Responses API instead of running a local
 summarizer. The local pipeline above (steps 1–4, `compact_history_local`)
 remains the path for **non-Responses** providers (Anthropic, DeepSeek, Kimi,
 Chat Completions); it is **never** used as a fallback for OpenAI Responses.
-The one exception is DeepSeek + Responses (see "DeepSeek exception" below).
+DeepSeek and Kimi Responses configurations are currently rejected during config resolution until their endpoints pass the same native-compaction and state-continuation verification.
 
-The native path has six properties:
+The native path has seven properties:
 
 1. **Ordinary request + `context_management`** — every `/responses` request
    built by `create_response` carries
@@ -367,14 +367,14 @@ The native path has six properties:
    unsupported (a hard protocol error, never a silent local summary). Tact
    resets `last_token_total` to 0 after native compaction because the next
    request's input is the compacted baseline, not the pre-compact prompt.
+7. **Raw item preservation** — the adapter parses the response envelope before
+   typed normalization. Known items feed Tact content/state logic; unknown
+   input/output items remain raw JSON in the protocol baseline and are replayed
+   on the next request. Unknown harmless stream events are ignored, while an
+   incomplete protocol-state item still fails the response.
 
-**DeepSeek exception** — DeepSeek + `protocol = "responses"` accepts
-`context_management` on ordinary requests (automatic endpoint-side compaction
-works), but its `/responses/compact` is **not** implemented (live-verified
-2026-08-02: it returns an empty body). `compact_history` therefore routes
-DeepSeek + Responses to the local summary pipeline (`compact_history_local`),
-clears the old `provider_state` baseline, and persists messages + `None` state
-atomically. OpenAI Responses keeps the strict no-fallback contract above.
+**Provider availability note** — The generic adapter can still be constructed by lower-level tests for endpoint experiments, but normal configuration keeps DeepSeek and Kimi Responses disabled until their endpoint capabilities are verified.
+
 
 **Protocol contract and verification status** — the automatic-compaction
 replacement baseline (the single `compaction` item first, followed by the
@@ -383,8 +383,9 @@ captured from the target endpoint during design
 (`crates/tact_llm/src/openai/responses/fixtures/automatic_compact.json`); it
 has **not** been verified against a live endpoint. Hard validation remains in
 force: zero or multiple `compaction` items and empty `encrypted_content` are
-protocol errors, and a truly unknown output item type is rejected by the typed
-SDK boundary (no silent drop, no fallback — see [Ch 22 §6.2.2](./22_chapter_llm.md#the-compaction-item-round-trip)).
+protocol errors, and a malformed known output item is rejected by the typed
+normalizer. A truly unknown output item is retained by the raw wire boundary
+and replayed on the next request (see [Ch 22 §6.2.2](./22_chapter_llm.md#the-compaction-item-round-trip)).
 An endpoint whose compaction contract differs from the fixture fails loudly
 with a protocol error rather than being papered over.
 

--- a/book/05_chapter_compact_zh.md
+++ b/book/05_chapter_compact_zh.md
@@ -327,10 +327,10 @@ flowchart LR
 管理协议基线（baseline），而不是运行本地摘要器。上文步骤 1–4（
 `compact_history_local`）的本地流水线仍然是**非 Responses** provider
 （Anthropic、DeepSeek、Kimi、Chat Completions）的路径；它**永远不会**作为
-OpenAI Responses 的回退方案。唯一例外是 DeepSeek + Responses（见下文
-"DeepSeek 例外"）。
+OpenAI Responses 的回退方案。DeepSeek 与 Kimi 的 Responses 配置目前会在配置解析阶段拒绝，
+直到对应端点通过同样的原生压缩与状态续传验证。
 
-原生路径有六个性质：
+原生路径有七个性质：
 
 1. **普通请求 + `context_management`** — `create_response` 构建的每个
    `/responses` 请求在解析出阈值后都会携带
@@ -361,21 +361,21 @@ OpenAI Responses 的回退方案。唯一例外是 DeepSeek + Responses（见下
 6. **不回退** — 不支持原生压缩的 Responses 端点是硬性协议错误，绝不静默走
    本地摘要。原生压缩后 Tact 会把 `last_token_total` 重置为 0，因为下一次
    请求的输入是压缩后的基线，而不是压缩前的大 prompt。
+7. **原始 item 保留** — adapter 会先解析 response envelope，再进行 typed
+   normalization。已知 item 用于构造 Tact 内容和状态；未知 input/output item
+   以 raw JSON 保留在协议基线中，并在下一次请求中回放。无害的未知流事件会被
+   忽略，但未完成的协议状态 item 仍会使响应失败。
 
-**DeepSeek 例外** — DeepSeek + `protocol = "responses"` 在普通请求上接受
-`context_management`（端点侧自动压缩可用），但其 `/responses/compact` **没有**
-实现（2026-08-02 实测：返回空响应体）。因此 `compact_history` 会把 DeepSeek +
-Responses 路由到本地摘要流水线（`compact_history_local`），清掉旧的
-`provider_state` 基线，并以原子方式持久化消息 + `None` 状态。OpenAI Responses
-仍保持上述严格"不回退"契约。
+**Provider 可用性说明** — 底层测试仍可以构造通用 adapter 做端点实验，但正常配置会在能力验证完成前保持 DeepSeek 与 Kimi Responses 禁用。
+
 
 **协议契约与验证状态** — 自动压缩的替换基线（单个 `compaction` item 置前，
 后跟本次 response 的非 compaction 输出 items）来源于设计阶段从目标端点捕获
 的脱敏 fixture
 （`crates/tact_llm/src/openai/responses/fixtures/automatic_compact.json`），
 **尚未**经过真实端点验证。硬性校验仍然生效：零个或多个 `compaction` item、
-空的 `encrypted_content` 都是协议错误；真正未知的输出 item 类型会被 typed
-SDK 边界拒绝（不静默丢弃、不回退，见
+空的 `encrypted_content` 都是协议错误；格式错误的已知输出 item 会被 typed
+normalizer 拒绝，真正未知的输出 item 会由 raw wire 边界保留并在下一轮请求中回放（见
 [Ch 22 §6.2.2](./22_chapter_llm.md#the-compaction-item-round-trip)）。
 与 fixture 契约不同的端点会以协议错误的方式响亮失败，而不会被掩盖。
 

--- a/book/06_chapter_recovery.md
+++ b/book/06_chapter_recovery.md
@@ -122,9 +122,11 @@ Each recovery emits an `AgentUpdate::Info` line visible in the TUI, e.g.:
 
 ```text
 [Recovery] compact (1/3): context too large
-[Recovery] backoff (2/3): retrying in 4.3s
+[Recovery] backoff (2/3): retrying in 4.3s — http request failed: error sending request for url
 [Recovery] continue (1/3): output truncated
 ```
+
+The `backoff` and `compact retry` lines append the underlying error (collapsed to one line, truncated at 200 chars via `error_summary`), so a retry says *why* it is retrying, not just when.
 
 For output-limit recovery, attempt 1 uses the direct-resume prompt. If the model is truncated again, attempts 2 and 3 switch to a convergence prompt that stops expansion and requests only a concise structured result containing the conclusion, verified issues, and minimal fixes. The attempt counter and three-attempt cap are unchanged.
 

--- a/book/06_chapter_recovery_zh.md
+++ b/book/06_chapter_recovery_zh.md
@@ -123,9 +123,11 @@ flowchart TB
 
 ```text
 [Recovery] compact (1/3): context too large
-[Recovery] backoff (2/3): retrying in 4.3s
+[Recovery] backoff (2/3): retrying in 4.3s — http request failed: error sending request for url
 [Recovery] continue (1/3): output truncated
 ```
+
+`backoff` 与 `compact retry` 行会追加底层错误（通过 `error_summary` 折叠为单行、超过 200 字符截断），因此重试不仅说明何时，还会说明*为什么*重试。
 
 对于输出上限恢复，第 1 次续写使用直接接续提示。如果模型再次被截断，第 2、3 次续写切换到收敛提示：停止扩展分析，不再重复场景，只返回包含结论、已确认问题和最小修复建议的简洁结构化结果。尝试计数和最多 3 次的上限保持不变。
 

--- a/book/21_chapter_config.md
+++ b/book/21_chapter_config.md
@@ -95,11 +95,27 @@ explicit path is an error (never auto-created).
 | `base_url` | CLI → entry → `ProviderKind::default_base_url()` |
 | `max_tokens` / `thinking_budget` | CLI → entry → `[llm]` global → code defaults |
 | `protocol` | entry → `chat_completions` default |
-| `reasoning_effort` | entry (openai / deepseek / kimi) → provider default (model-dependent) |
+| `reasoning_effort` | entry (openai / deepseek / kimi / custom) → provider default (model-dependent) |
 
 Required: **`llm.provider`**, plus **`api_key`** and **`model`** on the active
 entry. `anthropic` has no default `base_url` and must set one explicitly.
-Unknown map keys or missing active entries error at resolve time.
+Missing active entries error at resolve time.
+
+Any provider name not in the built-in list (`anthropic | openai | deepseek |
+kimi`) is accepted as a **custom OpenAI-compatible provider**: it reuses the
+OpenAI protocol (`chat_completions` by default, `responses` opt-in), has no
+default `base_url` (must be set explicitly on its entry), and supports
+`reasoning_effort`. Example:
+
+```toml
+[llm]
+provider = "moonshot"   # any name works
+
+[llm.providers.moonshot]
+api_key = "sk-..."
+base_url = "https://api.moonshot.cn/v1"   # required for custom providers
+model = "kimi-k2.5"
+```
 
 ---
 
@@ -109,7 +125,7 @@ Top-level sections in `TactTomlConfig`:
 
 ```toml
 [llm]
-provider = "kimi"          # active ProviderKind: anthropic | openai | deepseek | kimi
+provider = "kimi"          # active ProviderKind: anthropic | openai | deepseek | kimi | any custom name
 max_tokens = 32000         # optional global default
 thinking_budget = 32000
 

--- a/book/21_chapter_config_zh.md
+++ b/book/21_chapter_config_zh.md
@@ -93,9 +93,21 @@ pub fn init_config() -> anyhow::Result<CliArgs> {
 | `base_url` | CLI → 条目 → `ProviderKind::default_base_url()` |
 | `max_tokens` / `thinking_budget` | CLI → 条目 → `[llm]` 全局 → 代码默认值 |
 | `protocol` | 条目 → 默认 `chat_completions` |
-| `reasoning_effort` | entry（openai / deepseek / kimi）→ provider 默认（模型相关） |
+| `reasoning_effort` | entry（openai / deepseek / kimi / 自定义）→ provider 默认（模型相关） |
 
-必填：**`llm.provider`**，以及活跃条目上的 **`api_key`** 和 **`model`**。`anthropic` 没有默认 `base_url`，必须显式设置。未知 map 键或缺失活跃条目会在 resolve 时报错。
+必填：**`llm.provider`**，以及活跃条目上的 **`api_key`** 和 **`model`**。`anthropic` 没有默认 `base_url`，必须显式设置。缺失活跃条目会在 resolve 时报错。
+
+不在内建列表（`anthropic | openai | deepseek | kimi`）中的任意 provider 名称会被接受为**自定义 OpenAI 兼容 provider**：复用 OpenAI 协议（默认 `chat_completions`，可选 `responses`），没有默认 `base_url`（必须在其条目上显式设置），并支持 `reasoning_effort`。示例：
+
+```toml
+[llm]
+provider = "moonshot"   # 任意名称均可
+
+[llm.providers.moonshot]
+api_key = "sk-..."
+base_url = "https://api.moonshot.cn/v1"   # 自定义 provider 必填
+model = "kimi-k2.5"
+```
 
 ---
 
@@ -105,7 +117,7 @@ pub fn init_config() -> anyhow::Result<CliArgs> {
 
 ```toml
 [llm]
-provider = "kimi"          # 活跃 ProviderKind：anthropic | openai | deepseek | kimi
+provider = "kimi"          # 活跃 ProviderKind：anthropic | openai | deepseek | kimi | 任意自定义名称
 max_tokens = 32000         # 可选全局默认
 thinking_budget = 32000
 

--- a/book/22_chapter_llm.md
+++ b/book/22_chapter_llm.md
@@ -138,11 +138,16 @@ Heuristic helpers on `ProviderInfo` (also exported at crate root):
 | `is_kimi_k2x()` | K2.x family — drives the **32k max_tokens** default and Kimi thinking wire shape |
 | `is_kimi_k27()` | K2.7-code / `kimi-for-coding` / `api.kimi.com/coding` |
 | `is_deepseek()` | `provider == DeepSeek`, **or** URL/model contains deepseek |
+| `is_deepseek_balance_supported()` | official HTTPS `api.deepseek.com` only (no proxy fallback) |
+| `is_kimi_balance_supported()` | official HTTPS `api.moonshot.cn` / `api.moonshot.ai` only |
+| `is_kimi_usage_supported()` | official HTTPS `api.kimi.com/coding` only (no proxy fallback) |
 
 So `provider = openai` + a Moonshot-compatible `base_url` still behaves as Kimi
 for thinking injection. Balance polling is enabled only for the official HTTPS
-`api.moonshot.cn` / `api.moonshot.ai` hosts; custom proxies never forward their
-credentials to Moonshot. Prefer a dedicated `[llm.providers.kimi]` entry.
+`api.moonshot.cn` / `api.moonshot.ai` hosts (Kimi) and `api.deepseek.com`
+(DeepSeek); Kimi Code usage quota only on `api.kimi.com/coding`. Custom proxies
+never forward their credentials to an official balance / usage endpoint. Prefer
+a dedicated `[llm.providers.kimi]` entry.
 
 ---
 
@@ -611,22 +616,34 @@ Intent: per-session KV cache isolation on DeepSeek (and compatible proxies), red
 
 | Function | Endpoint | When used |
 |----------|----------|-----------|
-| `query_deepseek_balance()` | `GET .../user/balance` | TUI startup + periodic timer + `/balance` command |
+| `query_deepseek_balance()` | `GET https://api.deepseek.com/user/balance` | TUI startup + periodic timer + `/balance` command |
 | `query_kimi_balance()` | `GET .../v1/users/me/balance` on `api.moonshot.cn` or `api.moonshot.ai` | Same |
-| `query_kimi_code_usage()` | `GET .../v1/usages` on `api.kimi.com/coding` | Kimi Code subscription quota |
+| `query_kimi_code_usage()` | `GET https://api.kimi.com/coding/v1/usages` | Kimi Code subscription quota |
 
 `query_*_balance()` returns `tact_protocol::BalanceInfo`, routed on the separate account channel as `AccountUpdate::Balance`. Kimi Code usage returns `UsageQuotaInfo` as `AccountUpdate::UsageQuota`.
 
-**Kimi Code endpoint:** `api.kimi.com/coding` has no balance REST API. Use `query_kimi_code_usage()` instead; surfaced as `AccountUpdate::UsageQuota` on the bottom bar (`week` + `5h` windows).
+**Kimi Code endpoint:** `api.kimi.com/coding` has no balance REST API. Use `query_kimi_code_usage()` instead; surfaced as `AccountUpdate::UsageQuota` on the bottom bar (`week` + `5h` windows). The usage API is official-endpoint only (HTTPS, exact host `api.kimi.com`, `/coding` path): custom proxies serving `kimi-for-coding` are treated as unsupported and their API keys are never sent to `api.kimi.com`.
+
+**DeepSeek endpoint:** the balance API exists only on the official host.
+`query_deepseek_balance()` is enabled exclusively when `base_url` uses HTTPS
+with the exact host `api.deepseek.com` (a `/v1` suffix is fine; an empty base
+URL resolves to the official default). Custom OpenAI-compatible proxies
+targeting DeepSeek models are treated as unsupported and their API keys are
+never sent to `api.deepseek.com`.
 
 **Credential boundary:** Kimi balance polling is enabled only when `base_url`
 uses HTTPS with the exact host `api.moonshot.cn` or `api.moonshot.ai`. Custom
 OpenAI-compatible proxies are treated as unsupported and their API keys are
-never sent to an official Moonshot balance endpoint.
+never sent to an official Moonshot balance endpoint. The same boundary applies
+to DeepSeek (`api.deepseek.com`) and Kimi Code usage (`api.kimi.com/coding`).
 
 **Polling:** `interactive.rs` performs one startup query and starts
 `account::spawn_poller` only when `account::is_supported()` is true. The
 `/balance` command uses the same `query_once` path through the command driver.
+On failure the poller backs off (10 s → 20 s → … → 5 min) and forwards only the
+**first** `AccountUpdate::Error` of a consecutive outage; later retries stay
+silent until a query succeeds again, so a single outage shows one flash message
+instead of one per backoff tick.
 
 ```mermaid
 sequenceDiagram

--- a/book/22_chapter_llm_zh.md
+++ b/book/22_chapter_llm_zh.md
@@ -123,8 +123,11 @@ Provider 初始化从 Ch 21 的 resolved 配置流入 `tact_llm`。活跃 `Provi
 | `is_kimi_k2x()` | K2.x 家族 — 驱动 **32k max_tokens** 默认值与 Kimi thinking wire shape |
 | `is_kimi_k27()` | K2.7-code / `kimi-for-coding` / `api.kimi.com/coding` |
 | `is_deepseek()` | `provider == DeepSeek`，**或** URL/model 含 deepseek |
+| `is_deepseek_balance_supported()` | 仅官方 HTTPS `api.deepseek.com`（无代理回退） |
+| `is_kimi_balance_supported()` | 仅官方 HTTPS `api.moonshot.cn` / `api.moonshot.ai` |
+| `is_kimi_usage_supported()` | 仅官方 HTTPS `api.kimi.com/coding`（无代理回退） |
 
-因此 `provider = openai` + Moonshot 兼容 `base_url` 在 thinking 注入上仍按 Kimi 行为。余额轮询仅对官方 HTTPS `api.moonshot.cn` / `api.moonshot.ai` 主机启用；自定义代理绝不会把凭据转发给 Moonshot。更推荐专用 `[llm.providers.kimi]` 条目。
+因此 `provider = openai` + Moonshot 兼容 `base_url` 在 thinking 注入上仍按 Kimi 行为。余额轮询仅对官方 HTTPS `api.moonshot.cn` / `api.moonshot.ai`（Kimi）与 `api.deepseek.com`（DeepSeek）主机启用；Kimi Code 用量配额仅限 `api.kimi.com/coding`。自定义代理绝不会把凭据转发给官方余额 / 用量端点。更推荐专用 `[llm.providers.kimi]` 条目。
 
 ---
 
@@ -522,17 +525,19 @@ self.runtime.client.set_user_id(&session_id);
 
 | 函数 | 端点 | 使用时机 |
 |------|------|----------|
-| `query_deepseek_balance()` | `GET .../user/balance` | TUI 启动 + 周期 timer + `/balance` 命令 |
+| `query_deepseek_balance()` | `GET https://api.deepseek.com/user/balance` | TUI 启动 + 周期 timer + `/balance` 命令 |
 | `query_kimi_balance()` | `GET .../v1/users/me/balance` on `api.moonshot.cn` 或 `api.moonshot.ai` | 同上 |
-| `query_kimi_code_usage()` | `GET .../v1/usages` on `api.kimi.com/coding` | Kimi Code 订阅配额 |
+| `query_kimi_code_usage()` | `GET https://api.kimi.com/coding/v1/usages` | Kimi Code 订阅配额 |
 
 `query_*_balance()` 返回 `tact_protocol::BalanceInfo`，并通过独立 account channel 路由为 `AccountUpdate::Balance`。Kimi Code 用量返回 `UsageQuotaInfo` 为 `AccountUpdate::UsageQuota`。
 
-**Kimi Code 端点：** `api.kimi.com/coding` 无余额 REST API。改用 `query_kimi_code_usage()`；在底栏显示为 `AccountUpdate::UsageQuota`（`week` + `5h` 窗口）。
+**Kimi Code 端点：** `api.kimi.com/coding` 无余额 REST API。改用 `query_kimi_code_usage()`；在底栏显示为 `AccountUpdate::UsageQuota`（`week` + `5h` 窗口）。用量 API 仅限官方端点（HTTPS、主机精确为 `api.kimi.com`、含 `/coding` 路径）：提供 `kimi-for-coding` 的自定义代理视为不支持，其 API key 绝不会发送到 `api.kimi.com`。
 
-**凭据边界：** Kimi 余额轮询仅在 `base_url` 使用 HTTPS 且主机精确为 `api.moonshot.cn` 或 `api.moonshot.ai` 时启用。自定义 OpenAI 兼容代理视为不支持，代理 API key 绝不会发送到官方 Moonshot 余额端点。
+**DeepSeek 端点：** 余额 API 仅存在于官方主机。`query_deepseek_balance()` 仅在 `base_url` 使用 HTTPS 且主机精确为 `api.deepseek.com` 时启用（`/v1` 后缀可以；空 base URL 解析为官方默认）。面向 DeepSeek 模型的自定义 OpenAI 兼容代理视为不支持，其 API key 绝不会发送到 `api.deepseek.com`。
 
-**轮询：** `interactive.rs` 仅在 `account::is_supported()` 为 true 时执行一次启动查询并启动 `account::spawn_poller`。`/balance` 命令通过 command driver 复用同一 `query_once` 路径。
+**凭据边界：** Kimi 余额轮询仅在 `base_url` 使用 HTTPS 且主机精确为 `api.moonshot.cn` 或 `api.moonshot.ai` 时启用。自定义 OpenAI 兼容代理视为不支持，代理 API key 绝不会发送到官方 Moonshot 余额端点。同样的边界也适用于 DeepSeek（`api.deepseek.com`）与 Kimi Code 用量（`api.kimi.com/coding`）。
+
+**轮询：** `interactive.rs` 仅在 `account::is_supported()` 为 true 时执行一次启动查询并启动 `account::spawn_poller`。`/balance` 命令通过 command driver 复用同一 `query_once` 路径。失败时 poller 指数退避（10 s → 20 s → … → 5 min），且连续故障期间只转发**第一条** `AccountUpdate::Error`；后续重试保持静默，直到查询再次成功才复位——因此一次故障只弹一条提示，而不是每个退避周期都弹。
 
 ```mermaid
 sequenceDiagram

--- a/book/23_chapter_tui.md
+++ b/book/23_chapter_tui.md
@@ -329,7 +329,7 @@ pub(crate) trait Renderable {
 
 **Bottom bar** (`render_bottom_bar`, always 2 rows):
 - Row 1: cwd, uptime (`⊙ Up` / `运行`), git branch (`⎇`), optional account (`¤ …` for DeepSeek / Kimi). Segments joined with ` │ `. Prompt elapsed lives on the **task-end separator** (not the bottom bar).
-- Row 2: model name, `out`/`输出`, `think high(32K)`/`思考 …`, `ctx` meter with `■`/`·` fill, `∑ₜₒₖ` last-call total, `▣ cache%`/`缓存%`. Segments joined with two spaces. Narrow terminals drop cache → uptime → path → ∑ → ctx first.
+- Row 2: model name, `out`/`输出`, `think high`/`思考 high` (effort) or `think 32K`/`思考 32K` (budget; the two are mutually exclusive — a stale budget is never shown next to an effort), `ctx` meter with `■`/`·` fill, `∑ₜₒₖ` last-call total, `▣ cache%`/`缓存%`. Segments joined with two spaces. Narrow terminals drop cache → uptime → path → ∑ → ctx first.
 
 **Input** (`render_input_box`): rounded border in `Insert` mode; up to 3 content lines; CJK-aware cursor width; approval banner when `WaitingForUser`. Palette mode uses `render_command_line`. When `[voice].enabled = true`, a **centered** title-bar button (separate `Block` title from the left input label, so the top border stays visible between them) records microphone audio (macOS permission required), sends WAV to the configured transcription service, and inserts the returned text at the cursor (`Esc` cancels). Optional `[voice].voice_keybind` toggles the same control from the keyboard; only an exact match is consumed. See [Ch 21](./21_chapter_config.md) and `crates/tact/src/voice/`.
 

--- a/book/23_chapter_tui.md
+++ b/book/23_chapter_tui.md
@@ -337,7 +337,16 @@ pub(crate) trait Renderable {
 
 `render_md.rs` converts assistant markdown via `tui-markdown` with a custom `TuiStyleSheet` (headings, code, links, blockquotes). Code blocks get a unified dark background; tables are column-aligned. Hyperlink OSC-8 sequences are not preserved — ratatui strips escape sequences.
 
-**Streaming fence boundary rule:** the TUI has two different code paths for fenced content. Normal markdown rendering (`render_markdown_tui`) can display fenced text inline, while the streaming log pipeline may **promote** a completed fenced block into a dedicated code card overlay. After the 2026-08-01 bugfix, an **empty-language** fence (plain ```) that appears immediately after an in-progress markdown paragraph or list is kept in normal markdown flow instead of being promoted into a code card. This prevents a trailing list line or explanatory tail text from being hijacked into a `Click for full code` card. Real streamed code blocks with an explicit language tag (for example ```rust) still use the code-card path.
+**Streaming fence boundary rule:** the TUI has two different code paths for fenced content. Normal markdown rendering (`render_markdown_tui`) can display fenced text inline, while the streaming log pipeline may **promote** a completed fenced block into a dedicated code card overlay. After the 2026-08-01 bugfix, an **empty-language** fence (plain ```) that appears immediately after an in-progress markdown paragraph or list is kept in normal markdown flow instead of being promoted into a code card. This prevents a trailing list line or explanatory tail text from being hijacked into a `Click for full code` card. Streamed code blocks with an explicit language tag still use the code-card path, with one exception since 2026-08-08: a complete `mermaid` fence is rendered as a terminal diagram instead (see below).
+
+**Mermaid fenced blocks** (since 2026-08-08):
+
+- A complete ```mermaid fenced block is rendered as a **terminal diagram** in the main log instead of a code card.
+- Supported diagram types follow the pinned `ratatui-markdown` Mermaid renderer (flowchart/graph, sequenceDiagram, pie, gantt, stateDiagram, classDiagram, quadrantChart, block); unsupported diagram types fall back to code.
+- Streaming buffers the whole block until its closing fence; when rendering succeeds, the diagram lines are spliced into the log directly and **no code card** is created.
+- Invalid or unsupported Mermaid falls back to the normal code block/card, so the original source stays readable.
+- Ordinary explicit-language fences (```rust and similar) keep their existing code-card behavior.
+- Width changes and viewport scrolling use the existing log layout/cache behavior — once spliced in, diagram lines are ordinary log lines.
 
 ### 6.8 Popups
 

--- a/book/23_chapter_tui.md
+++ b/book/23_chapter_tui.md
@@ -342,8 +342,9 @@ pub(crate) trait Renderable {
 **Mermaid fenced blocks** (since 2026-08-08):
 
 - A complete ```mermaid fenced block is rendered as a **terminal diagram** in the main log instead of a code card.
-- Supported diagram types follow the pinned `ratatui-markdown` Mermaid renderer (flowchart/graph, sequenceDiagram, pie, gantt, stateDiagram, classDiagram, quadrantChart, block); unsupported diagram types fall back to code.
-- Streaming buffers the whole block until its closing fence; when rendering succeeds, the diagram lines are spliced into the log directly and **no code card** is created.
+- Supported diagram types follow the pinned `ratatui-markdown` Mermaid renderer (flowchart/graph, pie, gantt, stateDiagram, classDiagram, quadrantChart, block). `sequenceDiagram` uses Tact's own renderer (`mermaid_sequence.rs`) so aliases, `+/-` activation shorthand, and CJK/wide labels stay aligned; unsupported diagram types fall back to code.
+- Streaming buffers the whole block until its closing fence; when rendering succeeds, the diagram lines are spliced into the log directly and **no code card** is created. The fence body is retained in a `MermaidBlock` so double-click can open a source popup.
+- **Double-click** any diagram row → Mermaid popup; popup **`y`** copies the Mermaid source. Log selection / Normal **`y`** still copies the visible ASCII diagram.
 - Invalid or unsupported Mermaid falls back to the normal code block/card, so the original source stays readable.
 - Ordinary explicit-language fences (```rust and similar) keep their existing code-card behavior.
 - Width changes and viewport scrolling use the existing log layout/cache behavior — once spliced in, diagram lines are ordinary log lines.
@@ -361,6 +362,7 @@ pub(crate) trait Renderable {
 | Thinking detail | double-click thinking card; adjacent ordered-list items have blank-row separation | `popups/thinking_popup.rs` |
 | Tool/file detail | double-click tool card | `popups/diff_popup.rs` |
 | Code detail | double-click code card | `popups/code_popup.rs` |
+| Mermaid source | double-click rendered Mermaid diagram | `popups/mermaid_popup.rs` |
 
 Popups typically occupy ~80%×80% of the terminal, record `app.mouse.*_popup_area` for click-outside-to-close, and show `[y] Copy` / `[Esc] Close` / `[j/k] Scroll` hints. `diff_popup` lazy-loads full content via `cached_content` — no file I/O inside hot `render()` paths.
 

--- a/book/23_chapter_tui_zh.md
+++ b/book/23_chapter_tui_zh.md
@@ -339,8 +339,9 @@ scroll 后 cell 仅部分可见时 `LogColumnRenderer` 调用 `render_partial` �
 **Mermaid fenced block**（自 2026-08-08 起）：
 
 - 完整的 ```mermaid fenced block 在主日志区渲染为**终端图**，不再生成 code card。
-- 支持的图类型跟随固定的 `ratatui-markdown` Mermaid 渲染器（flowchart/graph、sequenceDiagram、pie、gantt、stateDiagram、classDiagram、quadrantChart、block）；不支持的图类型回退为代码。
-- 流式渲染会缓冲整个 block 直到闭合 fence；渲染成功时 diagram 行直接拼接进日志，**不创建 code card**。
+- 支持的图类型跟随固定的 `ratatui-markdown` Mermaid 渲染器（flowchart/graph、pie、gantt、stateDiagram、classDiagram、quadrantChart、block）。`sequenceDiagram` 使用 Tact 自有渲染器（`mermaid_sequence.rs`），以正确处理别名、`+/-` 激活简写以及 CJK/宽字符标签对齐；不支持的图类型回退为代码。
+- 流式渲染会缓冲整个 block 直到闭合 fence；渲染成功时 diagram 行直接拼接进日志，**不创建 code card**。fence 正文保留在 `MermaidBlock` 中，供双击打开源码弹窗。
+- **双击**任意 diagram 行 → Mermaid 弹窗；弹窗内 **`y`** 复制 Mermaid 源码。主区选区 / Normal **`y`** 仍复制可见 ASCII 图。
 - 无效或不支持的 Mermaid 回退到普通 code block/card，原始源码仍可读。
 - 普通显式语言 fence（```rust 等）保留原有 code-card 行为。
 - 宽度变化与视口滚动沿用现有 log 布局/缓存行为——diagram 行一旦拼接即为普通日志行。
@@ -358,6 +359,7 @@ scroll 后 cell 仅部分可见时 `LogColumnRenderer` 调用 `render_partial` �
 | Thinking detail | 双击 thinking card；相邻有序列表项以空行分隔 | `popups/thinking_popup.rs` |
 | Tool/file detail | 双击 tool card | `popups/diff_popup.rs` |
 | Code detail | 双击 code card | `popups/code_popup.rs` |
+| Mermaid source | 双击已渲染的 Mermaid 图 | `popups/mermaid_popup.rs` |
 
 Popups 通常占终端约 80%×80%，记录 `app.mouse.*_popup_area` 供点击外部关闭，显示 `[y] Copy` / `[Esc] Close` / `[j/k] Scroll` 提示。`diff_popup` 经 `cached_content` 懒加载全文 — 热路径 `render()` 内无文件 I/O。
 

--- a/book/23_chapter_tui_zh.md
+++ b/book/23_chapter_tui_zh.md
@@ -326,7 +326,7 @@ scroll 后 cell 仅部分可见时 `LogColumnRenderer` 调用 `render_partial` �
 
 **底栏**（`render_bottom_bar`，始终 2 行）：
 - 第 1 行：cwd、运行（`⊙ 运行` / `Up`）、git 分支（`⎇`）、可选账户（`¤ …`，DeepSeek / Kimi）。段落用 ` │ ` 连接。任务耗时在 **task-end 分隔线**上（不在底栏）。
-- 第 2 行：模型名、`输出`/`out`、`思考 high(32K)`/`think …`、带 `■`/`·` 填充的 `ctx` 进度、`∑ₜₒₖ` 上次调用合计、`▣ 缓存%`/`cache%`。段落用两个空格连接。窄终端优先丢弃：缓存 → 运行 → 路径 → ∑ → ctx。
+- 第 2 行：模型名、`输出`/`out`、`思考 high`/`think high`（effort）或 `思考 32K`/`think 32K`（预算；两者互斥——effort 存在时绝不显示残留的旧预算）、带 `■`/`·` 填充的 `ctx` 进度、`∑ₜₒₖ` 上次调用合计、`▣ 缓存%`/`cache%`。段落用两个空格连接。窄终端优先丢弃：缓存 → 运行 → 路径 → ∑ → ctx。
 
 **输入**（`render_input_box`）：`Insert` 模式圆角 border；最多 3 行内容；CJK 感知光标宽度；`WaitingForUser` 时批准横幅。Palette 模式用 `render_command_line`。当 `[voice].enabled = true` 时，标题栏**居中**按钮（与左侧 Input 标题拆成两个 `Block` title，中间顶边保持可见）可录制麦克风（macOS 需授权），将 WAV 发往配置的转写服务，并把文本插入光标处（`Esc` 可取消）。可选 `[voice].voice_keybind` 用键盘切换同一控件；仅精确匹配时消费按键。见 [第 21 章](./21_chapter_config_zh.md) 与 `crates/tact/src/voice/`。
 

--- a/book/23_chapter_tui_zh.md
+++ b/book/23_chapter_tui_zh.md
@@ -334,7 +334,16 @@ scroll 后 cell 仅部分可见时 `LogColumnRenderer` 调用 `render_partial` �
 
 `render_md.rs` 经 `tui-markdown` 与自定义 `TuiStyleSheet`（标题、代码、链接、引用）转换 assistant markdown。Code block 统一深色背景；表格列对齐。不保留 Hyperlink OSC-8 序列 — ratatui 剥离转义序列。
 
-**流式 fence 边界规则：** TUI 对 fenced 内容有两条不同路径。普通 markdown 渲染（`render_markdown_tui`）可以直接内联显示 fenced 文本；而流式日志管线则可能在 fenced block 完整闭合后，**提升**为专门的 code card overlay。2026-08-01 的 bugfix 之后，如果一个**空语言** fence（普通 ```）紧跟在进行中的 markdown 段落或列表后面，它会继续留在普通 markdown 流程里，而不会被提升成 code card。这样可避免列表尾行或说明性尾文本被错误劫持进 `Click for full code` 卡片。真正带显式语言标签的流式代码块（例如 ```rust）仍走 code-card 路径。
+**流式 fence 边界规则：** TUI 对 fenced 内容有两条不同路径。普通 markdown 渲染（`render_markdown_tui`）可以直接内联显示 fenced 文本；而流式日志管线则可能在 fenced block 完整闭合后，**提升**为专门的 code card overlay。2026-08-01 的 bugfix 之后，如果一个**空语言** fence（普通 ```）紧跟在进行中的 markdown 段落或列表后面，它会继续留在普通 markdown 流程里，而不会被提升成 code card。这样可避免列表尾行或说明性尾文本被错误劫持进 `Click for full code` 卡片。带显式语言标签的流式代码块仍走 code-card 路径，唯一的例外自 2026-08-08 起：完整的 `mermaid` fence 会渲染为终端图（见下）。
+
+**Mermaid fenced block**（自 2026-08-08 起）：
+
+- 完整的 ```mermaid fenced block 在主日志区渲染为**终端图**，不再生成 code card。
+- 支持的图类型跟随固定的 `ratatui-markdown` Mermaid 渲染器（flowchart/graph、sequenceDiagram、pie、gantt、stateDiagram、classDiagram、quadrantChart、block）；不支持的图类型回退为代码。
+- 流式渲染会缓冲整个 block 直到闭合 fence；渲染成功时 diagram 行直接拼接进日志，**不创建 code card**。
+- 无效或不支持的 Mermaid 回退到普通 code block/card，原始源码仍可读。
+- 普通显式语言 fence（```rust 等）保留原有 code-card 行为。
+- 宽度变化与视口滚动沿用现有 log 布局/缓存行为——diagram 行一旦拼接即为普通日志行。
 
 ### 6.8 Popups
 

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,19 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-08 — Main-area Markdown renders complete Mermaid fences as terminal diagrams
+
+| Field | Value |
+|-------|-------|
+| Type  | `optimization` |
+| Related | `crates/tui/src/render/render_md.rs`, `crates/tui/src/widgets/state/app/agent.rs`, `crates/tui/src/widgets/state/app/visibility.rs`, `crates/tui/src/widgets/state/stream_state.rs`, Ch 23 §6.7 |
+| Symptom / motivation | Every explicit-language streamed fence — including ```mermaid — was promoted to a `CodeBlock` card overlay when it closed, so Mermaid source appeared as syntax-tinted code instead of a diagram. |
+| Decision | Route complete, top-level `mermaid` fences through a shared `render_mermaid_block` helper (`ratatui-markdown::mermaid::render_mermaid` with the app-theme adapter) in `render_md.rs`; mark the buffered streamed fence as Mermaid in `stream_state.rs`; on a valid closed fence, `agent.rs` / `visibility.rs` splice the diagram lines into the log instead of pushing a `CodeBlock`. The code-card fallback is kept for invalid, unsupported, or unclosed Mermaid so no source is ever dropped. |
+| Behavior after | A complete ```mermaid fence renders as a themed terminal diagram at the log width (nominal 80 columns in fixed-width Markdown paths); a valid streamed Mermaid block closes without creating a code card; invalid/unsupported/unclosed Mermaid and ordinary explicit-language fences keep the existing code-card path; width re-layout and viewport scrolling use the existing log layout/cache behavior. |
+| Pointers | `render_md.rs` (`render_mermaid_block`, `route_mermaid_fences`) and tests `render_mermaid_sequence_returns_terminal_lines`, `render_markdown_mermaid_flowchart_uses_box_art`, `render_markdown_invalid_mermaid_falls_back_to_code`, `render_markdown_unclosed_mermaid_fence_keeps_source`; `stream_state.rs` (`code_block_is_mermaid`); `agent.rs` (`finish_stream_code_block`), `visibility.rs` (`flush_stream_pending`); regressions in `render_gap_tests.rs` (`log_renders_streamed_mermaid_without_code_card`, `log_falls_back_to_code_card_for_invalid_streamed_mermaid`, `flush_renders_streamed_mermaid_without_trailing_newline`, `flush_falls_back_to_code_card_for_unclosed_streamed_mermaid`), `cells/markdown.rs` (`markdown_cell_renders_mermaid_at_the_requested_width`); spec `docs/superpowers/specs/2026-08-08-mermaid-main-rendering-design.md`; plan `docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md`; docs `book/23_chapter_tui*.md` §6.7 |
+
+---
+
 ## 1. 2026-08-06 — OpenAI Responses exposes detailed reasoning summaries
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,19 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-06 — Thinking effort and budget are mutually exclusive in status bar / config
+
+| Field | Value |
+|-------|-------|
+| Type  | `bugfix` |
+| Related | `crates/tact/src/agent/mod.rs` (`set_thinking_budget` / `set_reasoning_effort`), `crates/tact/src/config/mod.rs` (`update_llm_model_and_*`, `update_subagent_*`), `crates/tact/src/config/persist.rs` (TOML removals), `crates/tui/src/render/bar.rs` (`format_think_segment`), Ch 23 §6.6 |
+| Symptom / motivation | On OpenAI Chat Completions (effort semantics), the bottom bar showed `think high(32K)`: `high` was the real `reasoning_effort`, but the `32K` was a stale `thinking_budget` left over from a previous budget-semantic model (claude / kimi-for-coding). The budget is meaningless for effort models and is never sent on the wire, yet it rendered next to the effort because neither the runtime setters, the in-memory config updaters, nor the TOML persist path cleared the other field. |
+| Decision | Make effort and budget **mutually exclusive** end to end: `set_thinking_budget` clears `reasoning_effort` and `set_reasoning_effort` zeroes `thinking_budget`; the config update fns (`update_llm_model_and_thinking_budget` / `update_llm_model_and_reasoning_effort` and their subagent twins) do the same; the TOML persist fns remove the opposite key from the provider/subagent entry. In the status bar, `format_think_segment` now gives effort precedence (effort present → `think high`, stale budget ignored; budget only → `think 32K`), and an effort without any budget still renders instead of disappearing. |
+| Behavior after | Effort-semantic models show `think high` (never `think high(32K)`); budget-semantic models show `think 32K`. Picking an effort removes the stored `thinking_budget` from config.toml; picking a budget removes `reasoning_effort`. Legacy configs that still contain both fields render effort-only and self-heal on the next `/model` persist. |
+| Pointers | `format_think_segment` + tests in `crates/tui/src/render/bar.rs`; setters in `crates/tact/src/agent/mod.rs`; config updaters in `crates/tact/src/config/mod.rs`; TOML removals + tests in `crates/tact/src/config/persist.rs`; driver test `set_reasoning_effort_clears_stale_thinking_budget`; TUI test `applying_effort_pick_clears_stale_thinking_budget`; docs `book/23_chapter_tui*.md` §6.6 |
+
+---
+
 ## 1. 2026-08-06 — Recovery retry messages include the underlying error
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,19 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-06 — Unknown provider names allowed as custom OpenAI-compatible providers
+
+| Field | Value |
+|-------|-------|
+| Type  | `optimization` |
+| Related | `crates/tact_llm/src/types.rs` (`ProviderKind::Custom`, `FromStr`), `crates/tact_llm/src/provider.rs` (`build_client`, `model_uses_effort`), `crates/tact_llm/src/hook_select.rs` (`body_hook_for`), `crates/tact_llm/src/models.rs` (`is_models_query_supported`), `crates/tact/src/config/resolve.rs` (`resolve_provider_kind`, `resolve_llm`, `resolve_subagent`), Ch 21 §3–§4 |
+| Symptom / motivation | `ProviderKind::from_str` rejected any name outside `anthropic | openai | deepseek | kimi`, so `llm.provider = "moonshot"` (or any self-hosted / gateway provider) failed with "unknown provider" even though the entry carried a working OpenAI-compatible `base_url`. The config layer could not express third-party OpenAI-compatible endpoints. |
+| Decision | Add `ProviderKind::Custom(String)` for every non-built-in name. Custom providers reuse the OpenAI protocol end to end: `build_client` dispatches to the OpenAI-compatible adapter (`chat_completions` default, `responses` opt-in), `body_hook_for` follows the same endpoint heuristics as `openai`, `/v1/models` supplementation is supported, and `reasoning_effort` is accepted. They have **no default `base_url`** — resolve fails with "base_url not configured" unless the entry sets one. Built-in gates are unchanged: `responses` protocol stays limited to `openai | deepseek | custom`, `reasoning_effort` to OpenAI-compatible providers (all but anthropic); the map-key validation loop in `resolve_llm` was removed (custom keys are no longer an error). `ProviderKind` lost `Copy` (it now owns a `String`); method receivers changed to `&self`. |
+| Behavior after | `llm.provider` / `--provider` accepts any name. Non-built-in names behave as custom OpenAI-compatible providers and require an explicit `base_url` in `[llm.providers.<name>]`. Missing active entries still error at resolve time. |
+| Pointers | `ProviderKind` in `crates/tact_llm/src/types.rs`; tests `provider_kind_from_str_accepts_unknown_as_custom` (tact_llm), `custom_provider_resolves_with_openai_protocol` / `custom_provider_without_base_url_errors` / `custom_provider_in_map_resolves` (tact config resolve); docs `book/21_chapter_config*.md` §3–§4, `config.example.toml` |
+
+---
+
 ## 1. 2026-08-06 — Account poller reports each outage once instead of every backoff tick
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,30 @@ Newest entries first. Each entry should include:
 
 ---
 
+
+
+## 1. 2026-08-08 — DeepSeek and Kimi Responses remain configuration-gated
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | The generic Responses adapter can be constructed for OpenAI-compatible endpoints, but DeepSeek/Kimi native compaction and state-continuation behavior are not verified to the production contract. Allowing them through normal config would make unsupported fallback behavior look supported. |
+| Decision | Keep DeepSeek and Kimi `protocol = "responses"` rejected at config resolution. Lower-level adapter construction remains available for isolated endpoint tests; production configuration uses Chat Completions until native Responses capabilities are verified. |
+| Behavior after | DeepSeek/Kimi users receive a clear configuration error instead of entering an unverified Responses path. OpenAI and explicitly configured custom OpenAI-compatible providers retain their existing Responses routes. |
+| Pointers | `crates/tact/src/config/resolve.rs`; provider construction: `crates/tact_llm/src/provider.rs`; related design: `docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`; compaction behavior: Ch 5. |
+
+
+## 1. 2026-08-08 — OpenAI Responses preserves unknown wire items
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | The typed `async-openai` Responses enum rejects a newly introduced output item before Tact can preserve it, making forward-compatible provider state impossible. Tact also had no explicit request extension for Responses-only fields outside the shared Chat/Anthropic request model. |
+| Decision | Parse the raw Responses envelope before typed normalization; normalize known items while retaining unknown input/output items as raw JSON. Add a `ResponsesRequestOptions` boundary consumed only by the Responses adapter, and expose conservative provider capability metadata without forking `async-openai` until a reproducible SDK blocker exists. |
+| Behavior after | Unknown harmless stream events no longer abort a response. Unknown output items survive ordinary and streamed turns, session state serialization, and the next Responses request. Responses-only request options do not appear in Chat Completions or Anthropic payloads. |
+| Pointers | `crates/tact_llm/src/openai/responses/wire.rs`, `request_options.rs`, `stream.rs`, `provider.rs`; design: `docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`; plan: `docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md`; compaction: Ch 5 and `docs/compaction.md`. |
+
+
 ## 1. 2026-08-06 — OpenAI Responses exposes detailed reasoning summaries
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,7 +29,27 @@ Newest entries first. Each entry should include:
 
 ---
 
-## 1. 2026-08-06 — Thinking effort and budget are mutually exclusive in status bar / config
+## 1. 2026-08-06 — OpenAI Responses exposes detailed reasoning summaries
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Related | `crates/tact_llm/src/openai/responses/convert.rs`, Responses reasoning request construction |
+| Symptom / motivation | Ordinary OpenAI Responses requests asked for `reasoning.summary = auto`, so the streamed thinking block could contain only a short provider-selected summary even when reasoning was enabled. |
+| Decision | Keep the Responses API `summary` field, but request `ReasoningSummary::Detailed` (`"detailed"`) whenever Tact enables reasoning. No changes are needed to stream parsing, which already consumes reasoning summary deltas. |
+| Behavior after | OpenAI Responses thinking blocks request and display the detailed reasoning summary rather than the automatic summary level. |
+| Pointers | Request conversion and regression assertion: `crates/tact_llm/src/openai/responses/convert.rs`; related Responses adapter: `crates/tact_llm/src/openai/responses/`. |
+
+
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Related | `crates/tui/src/render/log.rs`, `crates/tui/src/render/cells/text.rs`, `crates/tui/src/render/log_render_tests.rs` |
+| Symptom / motivation | The main log area wrapped lines to the full panel content width, then added a left indent while drawing ordinary messages. Full-width messages were consequently clipped by several columns at the right edge; selection redraws also used the wrong wrap width. |
+| Decision | Subtract each message's actual indent before caching wrapped lines; use the same reply indent for the streaming row. Make `TextCell` selection wrapping use the already-available width after indentation. |
+| Behavior after | Full-width ordinary, nested, and streaming text wraps within its actual drawable width, so right-edge characters are preserved. |
+| Pointers | Layout and wrap cache: `render/log.rs`; text drawing: `render/cells/text.rs`; regression test: `log_full_width_nested_line_wraps_before_indentation_clip`. |
 
 | Field | Value |
 |-------|-------|

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -32,6 +32,56 @@ Newest entries first. Each entry should include:
 
 
 
+## 1. 2026-08-09 — Task-stats `[copy]` copies the last turn
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | After a turn finished, users had no one-click way to copy that turn's conversation from the task-stats row. |
+| Decision | Append a `[copy]` button on each `📊 任务统计：` row; click copies log text from after the previous stats row (or session start) up to but not including the current stats row, skipping blanks and task-end separators. |
+| Behavior after | Click `[copy]` on a stats line → clipboard gets that turn's user/assistant content; earlier turns are excluded. |
+| Pointers | `add_task_stats_block` / `copy_turn_ending_at_stats` in `messages.rs`; mouse hit in `handlers/mouse.rs`; regression `copy_turn_ending_at_stats_copies_last_turn_only`. |
+
+## 1. 2026-08-09 — Mermaid diagram copy popup (double-click → source)
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | Successfully rendered Mermaid diagrams discarded their fence body when splicing ASCII art into the log, so users could not recover the source for re-editing. |
+| Decision | Keep a `MermaidBlock { start_idx, end_idx, source }` per successful render; double-click opens a Mermaid popup; popup `y` copies the source. Log selection yank stays ASCII. |
+| Behavior after | Double-click any diagram row → source popup (`y` / `j/k` / `Esc`); failed Mermaid still uses the code-card path. |
+| Pointers | Spec `docs/superpowers/specs/2026-08-09-mermaid-diagram-copy-popup-design.md`; `finish_stream_code_block`; `popups/mermaid_popup.rs`; regressions `log_renders_streamed_mermaid_without_code_card`, `mermaid_popup_copy_uses_source_not_ascii`. |
+
+## 1. 2026-08-09 — Mermaid sequence self-messages draw a U-shaped loop
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | Self-messages (`A->>A`) rendered as a one-cell stub `<│◀`, which looked like broken chevrons rather than a return-to-self arrow. |
+| Decision | Render self-messages as a two-row box-drawing loop (`│──┐` / `│◀─┘`, or left-side `┌──│` / `└─▶│` on the last participant) with the label beside the loop. |
+| Behavior after | Self calls read as a clear U-turn on the lifeline; last-column self-messages loop left so the shape stays inside the diagram. |
+| Pointers | `crates/tui/src/render/mermaid_sequence.rs` (`self_loop_rows`); regressions `self_message_draws_u_shaped_loop`, `self_message_on_last_participant_loops_left`. |
+
+## 1. 2026-08-09 — Mermaid sequence labels no longer drop characters or shift columns
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | The custom `sequenceDiagram` renderer dropped any label glyph whose display cells overlapped a lifeline (e.g. `submitTask` → `ubmitTask` / `submi│Task`), and left a ghost space after each width-2 CJK glyph so label rows were wider than lifeline/arrow rows — lifelines looked jagged and arrows appeared broken on multi-participant diagrams. |
+| Decision | In `label_row`, clear continuation cells of wide glyphs to empty spans, and reflow label characters past occupied lifeline cells instead of skipping them. |
+| Behavior after | Long ASCII and CJK arrow labels keep every character (split around `│` when needed) and every diagram row shares the same display width, so lifelines stay vertically aligned. |
+| Pointers | `crates/tui/src/render/mermaid_sequence.rs` (`label_row`); regressions `cjk_label_keeps_same_display_width_as_lifeline_row`, `long_ascii_label_is_not_eaten_by_lifelines`, `self_message_keeps_lifeline_intact`. |
+
+## 1. 2026-08-08 — TUI renders Mermaid sequence diagrams with its own renderer
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | The upstream `ratatui-markdown` sequence renderer mishandled three common inputs: `participant A as 用户` aliases were shown verbatim, the `+`/`-` activation shorthand (`A->>+B`) created phantom participant columns (`+B`, `-B`, …), and 2-column CJK arrow labels could overwrite a lifeline (or be dropped), so labelled arrows looked misaligned. |
+| Decision | Route `sequenceDiagram` fences in the TUI through Tact's own renderer (`crates/tui/src/render/mermaid_sequence.rs`); all other Mermaid diagram types keep using `ratatui-markdown`. The new renderer parses `as` aliases, strips `+`/`-` activation prefixes before participant lookup, and places label glyphs by display column only when every cell of the glyph's width is free. |
+| Behavior after | Only declared participants render as columns; `A->>+B` targets participant `B`; CJK labels stay centered between lifelines and never overwrite a `│`. Unparseable sources still fall back to ordinary code rendering. |
+| Pointers | `crates/tui/src/render/mermaid_sequence.rs`; routing: `crates/tui/src/render/render_md.rs` (`render_mermaid_block`); regression tests in `mermaid_sequence.rs`. |
+
 ## 1. 2026-08-08 — Subagent model picker uses its own provider
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,45 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-06 — Account poller reports each outage once instead of every backoff tick
+
+| Field | Value |
+|-------|-------|
+| Type  | `optimization` |
+| Related | `crates/tact-ui/src/account.rs` (`poll_loop`, `spawn_poller`), `crates/tui/src/widgets/state/app/agent.rs` (`handle_account_update` flash), Ch 22 §9 |
+| Symptom / motivation | `spawn_poller` forwarded every failed balance / usage query as `AccountUpdate::Error`. On a persistent outage (e.g. network down) the TUI flashed an error every 10 s → 20 s → … → 5 min, forever — a notification storm ("骚扰") that obscured the real state of the app. |
+| Decision | Extract the loop into a testable `poll_loop(query, tx, next_delay)` and add an `error_notified` flag: only the **first** failure of a consecutive outage is forwarded; later retries stay silent while backoff continues. A successful query resets the flag, so a fresh outage after recovery reports once again. `NotSupported` still terminates the loop silently (unchanged), and the explicit startup query + `/balance` command keep their one-shot error reporting (user-triggered, not spam). |
+| Behavior after | One outage = one flash message, then silent retries with backoff until recovery; after recovery the normal 5–15 s polling resumes and the next outage flashes once again. |
+| Pointers | `poll_loop` / `spawn_poller` in `crates/tact-ui/src/account.rs`; tests `poller_forwards_error_once_per_outage_then_resumes`, `poller_stops_on_not_supported_without_error_flash`; docs `book/22_chapter_llm*.md` §9 |
+
+---
+
+## 1. 2026-08-06 — Kimi Code usage quota query restricted to the official `https://api.kimi.com/coding` endpoint
+
+| Field | Value |
+|-------|-------|
+| Type  | `bugfix` |
+| Related | `crates/tact_llm/src/account.rs` (`query_kimi_code_usage`, `kimi_usage_url_from_base_url`), `crates/tact_llm/src/provider.rs` (`is_kimi_usage_supported`, `is_account_query_supported`), `crates/tact-ui/src/account.rs` (`query_once`), Ch 22 §3 / §9 |
+| Symptom / motivation | `kimi_usage_url_from_base_url` derived `{origin}/v1/usages` from any configured base URL, so a `kimi-for-coding` model behind a custom OpenAI-compatible proxy would send the proxy's API key to a guessed usage endpoint. `is_kimi_usage_supported` was `is_kimi_coding(&model)` — true for any proxy serving `kimi-for-coding` — so the TUI quota widget polled proxies too. |
+| Decision | Mirror the DeepSeek / Kimi balance "credential boundary": `kimi_usage_url_from_base_url` returns the official URL only for HTTPS with the exact host `api.kimi.com` and a `/coding` path (a `/v1` suffix is accepted); anything else returns `None` and `query_kimi_code_usage` bails with "Kimi Code usage API is only available for the official endpoint https://api.kimi.com/coding". `ProviderInfo::is_kimi_usage_supported` requires the same official host/path, so `is_account_query_supported` is false for proxy configurations and the TUI hides the quota widget. `is_kimi_coding` itself is unchanged — it still identifies the Kimi Code platform (including proxies) for wire shape. |
+| Behavior after | Kimi Code usage polling works only when `base_url` targets the official `https://api.kimi.com/coding` endpoint. Custom proxies (even with `kimi-for-coding`) report "not supported"; the API key is never sent to `api.kimi.com` from a proxy configuration. |
+| Pointers | `kimi_usage_url_from_base_url` + test `kimi_usage_url_derivation` in `crates/tact_llm/src/account.rs`; `is_kimi_usage_supported` + test `is_kimi_usage_supported_only_for_official_endpoint` in `crates/tact_llm/src/provider.rs`; docs `book/22_chapter_llm*.md` §3 / §9 |
+
+---
+
+## 1. 2026-08-06 — DeepSeek balance query restricted to the official `https://api.deepseek.com` endpoint
+
+| Field | Value |
+|-------|-------|
+| Type  | `bugfix` |
+| Related | `crates/tact_llm/src/account.rs` (`query_deepseek_balance`, `deepseek_balance_url_from_base_url`), `crates/tact_llm/src/provider.rs` (`is_deepseek_balance_supported`, `is_account_query_supported`), `crates/tact-ui/src/account.rs` (`query_once`), Ch 22 §3 / §9 |
+| Symptom / motivation | `query_deepseek_balance` derived `{origin}/user/balance` from any configured base URL, so DeepSeek models behind a custom OpenAI-compatible proxy would send the proxy's API key to a guessed balance endpoint. DeepSeek only serves `GET /user/balance` on the official host; the fallback was wrong and could leak credentials to the wrong host or surface confusing 404/403 errors. |
+| Decision | Mirror the Kimi "credential boundary": `deepseek_balance_url_from_base_url` returns the official URL only for an empty base URL (config default) or HTTPS with the exact host `api.deepseek.com` (a `/v1` suffix is accepted); anything else returns `None` and `query_deepseek_balance` bails with "DeepSeek balance API is only available for the official endpoint https://api.deepseek.com". `ProviderInfo::is_deepseek_balance_supported` gates `is_account_query_supported`, so the TUI bottom-bar balance widget is hidden for proxy configurations instead of showing errors. |
+| Behavior after | DeepSeek balance polling / `/balance` works only when `base_url` targets the official endpoint. Custom proxies (even with a `deepseek-*` model) report "not supported"; the API key is never sent to `api.deepseek.com` from a proxy configuration. |
+| Pointers | `deepseek_balance_url_from_base_url` + test `deepseek_balance_url_derivation` in `crates/tact_llm/src/account.rs`; `is_deepseek_balance_supported` + test `is_deepseek_balance_supported_only_for_official_endpoint` in `crates/tact_llm/src/provider.rs`; docs `book/22_chapter_llm*.md` §3 / §9 |
+
+---
+
 ## 1. 2026-08-06 — `/tasks-dag` popup does not show tasks added while it is open
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,8 @@ Newest entries first. Each entry should include:
 
 ---
 
+
+
 ## 1. 2026-08-08 — Subagent model picker uses its own provider
 
 | Field | Value |
@@ -38,6 +40,28 @@ Newest entries first. Each entry should include:
 | Decision | Query the `/models` endpoint using the resolved subagent provider's `base_url` and `api_key`; keep configured provider `models = [...]` as the primary candidates and preserve cache keying by `(base_url, api_key)`. |
 | Behavior after | The subagent picker shows configured and API-discovered models belonging to the subagent provider. The main `/model` picker keeps using the main provider. |
 | Pointers | `crates/tact_llm/src/models.rs`, `crates/tui/src/handlers/select.rs`; regression test `explicit_provider_model_query_uses_subagent_credentials`; design: `docs/superpowers/specs/2026-08-08-subagent-model-picker-provider-design.md`; plan: `docs/superpowers/plans/2026-08-08-subagent-model-picker-provider.md`. |
+
+## 1. 2026-08-08 — DeepSeek and Kimi Responses remain configuration-gated
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | The generic Responses adapter can be constructed for OpenAI-compatible endpoints, but DeepSeek/Kimi native compaction and state-continuation behavior are not verified to the production contract. Allowing them through normal config would make unsupported fallback behavior look supported. |
+| Decision | Keep DeepSeek and Kimi `protocol = "responses"` rejected at config resolution. Lower-level adapter construction remains available for isolated endpoint tests; production configuration uses Chat Completions until native Responses capabilities are verified. |
+| Behavior after | DeepSeek/Kimi users receive a clear configuration error instead of entering an unverified Responses path. OpenAI and explicitly configured custom OpenAI-compatible providers retain their existing Responses routes. |
+| Pointers | `crates/tact/src/config/resolve.rs`; provider construction: `crates/tact_llm/src/provider.rs`; related design: `docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`; compaction behavior: Ch 5. |
+
+
+## 1. 2026-08-08 — OpenAI Responses preserves unknown wire items
+
+| Field | Value |
+|-------|-------|
+| Type | `bugfix` |
+| Symptom / motivation | The typed `async-openai` Responses enum rejects a newly introduced output item before Tact can preserve it, making forward-compatible provider state impossible. Tact also had no explicit request extension for Responses-only fields outside the shared Chat/Anthropic request model. |
+| Decision | Parse the raw Responses envelope before typed normalization; normalize known items while retaining unknown input/output items as raw JSON. Add a `ResponsesRequestOptions` boundary consumed only by the Responses adapter, and expose conservative provider capability metadata without forking `async-openai` until a reproducible SDK blocker exists. |
+| Behavior after | Unknown harmless stream events no longer abort a response. Unknown output items survive ordinary and streamed turns, session state serialization, and the next Responses request. Responses-only request options do not appear in Chat Completions or Anthropic payloads. |
+| Pointers | `crates/tact_llm/src/openai/responses/wire.rs`, `request_options.rs`, `stream.rs`, `provider.rs`; design: `docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`; plan: `docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md`; compaction: Ch 5 and `docs/compaction.md`. |
+
 
 ## 1. 2026-08-06 — OpenAI Responses exposes detailed reasoning summaries
 

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,19 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-06 — Recovery retry messages include the underlying error
+
+| Field | Value |
+|-------|-------|
+| Type  | `optimization` |
+| Related | `crates/tact/src/recovery.rs` (`error_summary`), `crates/tact/src/agent/mod.rs` (backoff / compact-retry emit sites), Ch 6 §Recovery messages |
+| Symptom / motivation | `[Recovery] backoff (1/10): retrying in 1.9s` said *when* the next retry happened but never *why* — the underlying transport error (timeout, connection reset, rate limit, …) was invisible, so a user watching 8+ backoff ticks had no idea what was failing. The compaction summary retries (`[compact retry 1/3] retrying in 1.9s`) had the same defect. |
+| Decision | Add `error_summary` in `recovery.rs`: collapse whitespace/newlines to a single line, truncate at 200 chars with an ellipsis. The main-loop backoff message appends the full anyhow chain (outer context → root cause, joined by `": "`); both compaction retry messages append the client error string. Existing tags, counters, and delay text are unchanged, so tests matching `contains("Recovery") && contains("backoff")` keep passing. |
+| Behavior after | Recovery retries report the reason, e.g. `[Recovery] backoff (2/10): retrying in 4.3s — http request failed: error sending request for url`. |
+| Pointers | `error_summary` + unit tests in `crates/tact/src/recovery.rs`; emit sites in `crates/tact/src/agent/mod.rs`; docs `book/06_chapter_recovery*.md` §Recovery messages |
+
+---
+
 ## 1. 2026-08-06 — Unknown provider names allowed as custom OpenAI-compatible providers
 
 | Field | Value |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,45 @@
 
 ---
 
+## 1. 2026-08-06 — 账户轮询每次故障只提示一次，而非每个退避周期都提示
+
+| 字段 | 值 |
+|------|-----|
+| 类型  | `optimization` |
+| 关联 | `crates/tact-ui/src/account.rs`（`poll_loop`、`spawn_poller`）、`crates/tui/src/widgets/state/app/agent.rs`（`handle_account_update` flash）、Ch 22 §9 |
+| 症状 / 动机 | `spawn_poller` 把每次失败的余额 / 用量查询都转发为 `AccountUpdate::Error`。在持续故障（如断网）时，TUI 每 10 s → 20 s → … → 5 min 弹一次错误提示，永不停歇——变成通知风暴（「骚扰」），掩盖了应用的真实状态。 |
+| 决策 | 把循环抽取为可测试的 `poll_loop(query, tx, next_delay)`，并加入 `error_notified` 标志：连续故障期间只转发**第一条**失败；后续重试保持静默，退避继续。一次成功查询会复位标志，因此恢复后的新一轮故障会再次提示一次。`NotSupported` 仍静默终止循环（不变）；启动查询与 `/balance` 命令保留一次性错误上报（用户主动触发，不算骚扰）。 |
+| 行为变化 | 一次故障 = 一条 flash 提示，之后静默退避重试直到恢复；恢复后恢复正常 5–15 s 轮询，下一次故障再提示一次。 |
+| 指针 | `crates/tact-ui/src/account.rs` 中的 `poll_loop` / `spawn_poller`；测试 `poller_forwards_error_once_per_outage_then_resumes`、`poller_stops_on_not_supported_without_error_flash`；文档 `book/22_chapter_llm*.md` §9 |
+
+---
+
+## 1. 2026-08-06 — Kimi Code 用量查询仅限官方 `https://api.kimi.com/coding` 端点
+
+| 字段 | 值 |
+|------|-----|
+| 类型  | `bugfix` |
+| 关联 | `crates/tact_llm/src/account.rs`（`query_kimi_code_usage`、`kimi_usage_url_from_base_url`）、`crates/tact_llm/src/provider.rs`（`is_kimi_usage_supported`、`is_account_query_supported`）、`crates/tact-ui/src/account.rs`（`query_once`）、Ch 22 §3 / §9 |
+| 症状 / 动机 | `kimi_usage_url_from_base_url` 从任意配置的 base URL 推导 `{origin}/v1/usages`，导致 `kimi-for-coding` 模型挂在自定义 OpenAI 兼容代理后时，会把代理的 API key 发往猜测出来的用量端点。`is_kimi_usage_supported` 此前等于 `is_kimi_coding(&model)`——任何提供 `kimi-for-coding` 的代理都返回 true，因此 TUI 配额组件也会轮询代理。 |
+| 决策 | 与 DeepSeek / Kimi 余额的「凭据边界」对齐：`kimi_usage_url_from_base_url` 仅在 HTTPS 且主机精确为 `api.kimi.com`、路径含 `/coding`（允许 `/v1` 后缀）时返回官方 URL；其余返回 `None`，`query_kimi_code_usage` 报错「Kimi Code usage API is only available for the official endpoint https://api.kimi.com/coding」。`ProviderInfo::is_kimi_usage_supported` 要求同样的官方主机 / 路径，因此代理配置下 `is_account_query_supported` 为 false，TUI 隐藏配额组件。`is_kimi_coding` 本身不变——它仍用于识别 Kimi Code 平台（含代理）以决定 wire shape。 |
+| 行为变化 | Kimi Code 用量轮询仅在 `base_url` 指向官方 `https://api.kimi.com/coding` 端点时可用。自定义代理（即使 model 是 `kimi-for-coding`）视为不支持；代理配置的 API key 永远不会发送到 `api.kimi.com`。 |
+| 指针 | `crates/tact_llm/src/account.rs` 中的 `kimi_usage_url_from_base_url` + 测试 `kimi_usage_url_derivation`；`crates/tact_llm/src/provider.rs` 中的 `is_kimi_usage_supported` + 测试 `is_kimi_usage_supported_only_for_official_endpoint`；文档 `book/22_chapter_llm*.md` §3 / §9 |
+
+---
+
+## 1. 2026-08-06 — DeepSeek 余额查询仅限官方 `https://api.deepseek.com` 端点
+
+| 字段 | 值 |
+|------|-----|
+| 类型  | `bugfix` |
+| 关联 | `crates/tact_llm/src/account.rs`（`query_deepseek_balance`、`deepseek_balance_url_from_base_url`）、`crates/tact_llm/src/provider.rs`（`is_deepseek_balance_supported`、`is_account_query_supported`）、`crates/tact-ui/src/account.rs`（`query_once`）、Ch 22 §3 / §9 |
+| 症状 / 动机 | `query_deepseek_balance` 从任意配置的 base URL 推导 `{origin}/user/balance`，导致 DeepSeek 模型挂在自定义 OpenAI 兼容代理后时，会把代理的 API key 发往猜测出来的余额端点。DeepSeek 只在官方主机提供 `GET /user/balance`；该回退逻辑错误，可能把凭据泄露到错误主机或产生令人困惑的 404/403。 |
+| 决策 | 与 Kimi 的「凭据边界」对齐：`deepseek_balance_url_from_base_url` 仅在 base URL 为空（配置默认）或为 HTTPS 且主机精确为 `api.deepseek.com`（允许 `/v1` 后缀）时返回官方 URL；其余返回 `None`，`query_deepseek_balance` 报错「DeepSeek balance API is only available for the official endpoint https://api.deepseek.com」。`ProviderInfo::is_deepseek_balance_supported` 门控 `is_account_query_supported`，因此代理配置下 TUI 底栏余额组件直接隐藏而非反复报错。 |
+| 行为变化 | DeepSeek 余额轮询 / `/balance` 仅在 `base_url` 指向官方端点时可用。自定义代理（即使 model 是 `deepseek-*`）视为不支持；代理配置的 API key 永远不会发送到 `api.deepseek.com`。 |
+| 指针 | `crates/tact_llm/src/account.rs` 中的 `deepseek_balance_url_from_base_url` + 测试 `deepseek_balance_url_derivation`；`crates/tact_llm/src/provider.rs` 中的 `is_deepseek_balance_supported` + 测试 `is_deepseek_balance_supported_only_for_official_endpoint`；文档 `book/22_chapter_llm*.md` §3 / §9 |
+
+---
+
 ## 1. 2026-08-06 — `/tasks-dag` 弹窗打开期间新建的任务不显示
 
 | 字段 | 值 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,19 @@
 
 ---
 
+## 1. 2026-08-06 — 恢复重试消息附带底层错误
+
+| Field | Value |
+|-------|-------|
+| Type  | `optimization` |
+| Related | `crates/tact/src/recovery.rs`（`error_summary`）、`crates/tact/src/agent/mod.rs`（backoff / compact retry 消息点）、第 6 章恢复消息 |
+| Symptom / motivation | `[Recovery] backoff (1/10): retrying in 1.9s` 只说明了*何时*重试，没有说明*为什么*——底层传输错误（超时、连接重置、限流……）完全不可见，用户看到 8 次以上退避却不知道哪里失败。压缩摘要的重试消息（`[compact retry 1/3] retrying in 1.9s`）也有同样的问题。 |
+| Decision | 在 `recovery.rs` 新增 `error_summary`：将空白/换行折叠为单行，超过 200 字符以省略号截断。主循环 backoff 消息追加完整 anyhow 链（外层上下文 → 根因，以 `": "` 连接）；两处压缩重试消息追加客户端错误字符串。原有标签、计数与延时文本保持不变，因此匹配 `contains("Recovery") && contains("backoff")` 的测试仍可通过。 |
+| Behavior after | 恢复重试会报告原因，例如 `[Recovery] backoff (2/10): retrying in 4.3s — http request failed: error sending request for url`。 |
+| Pointers | `error_summary` 及其单元测试位于 `crates/tact/src/recovery.rs`；消息点在 `crates/tact/src/agent/mod.rs`；文档 `book/06_chapter_recovery*.md` 恢复消息一节 |
+
+---
+
 ## 1. 2026-08-06 — 未知 provider 名称放行为自定义 OpenAI 兼容 provider
 
 | 字段 | 值 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,8 @@
 
 ---
 
+
+
 ## 1. 2026-08-08 — Subagent 模型选择器使用自身 provider
 
 | 字段 | 值 |
@@ -38,6 +40,28 @@
 | 决策 | 使用已解析的 subagent provider 的 `base_url` 和 `api_key` 查询 `/models`；保留 provider 配置中的 `models = [...]` 作为主要候选，并继续按 `(base_url, api_key)` 缓存。 |
 | 变更后行为 | Subagent 选择器只显示属于 subagent provider 的配置模型和 API 发现模型；主 agent 的 `/model` 选择器仍使用主 provider。 |
 | 指针 | `crates/tact_llm/src/models.rs`、`crates/tui/src/handlers/select.rs`；回归测试 `explicit_provider_model_query_uses_subagent_credentials`；设计：`docs/superpowers/specs/2026-08-08-subagent-model-picker-provider-design.md`；计划：`docs/superpowers/plans/2026-08-08-subagent-model-picker-provider.md`。 |
+
+## 1. 2026-08-08 — DeepSeek 与 Kimi Responses 保持配置门控
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 通用 Responses adapter 可以为 OpenAI-compatible 端点构造，但 DeepSeek/Kimi 的原生压缩与状态续传尚未验证达到生产契约；若直接允许正常配置，会把未支持的 fallback 行为误认为已支持。 |
+| 决策 | 继续在配置解析阶段拒绝 DeepSeek/Kimi 的 `protocol = "responses"`。底层 adapter 构造仍可用于隔离端点测试；生产配置在原生 Responses 能力验证完成前使用 Chat Completions。 |
+| 变更后行为 | DeepSeek/Kimi 用户会得到明确的配置错误，不会进入未经验证的 Responses 路径。OpenAI 与明确配置的自定义 OpenAI-compatible provider 保留现有 Responses 路由。 |
+| 指针 | `crates/tact/src/config/resolve.rs`；provider 构造：`crates/tact_llm/src/provider.rs`；相关设计：`docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`；压缩行为：第 5 章。 |
+
+
+## 1. 2026-08-08 — OpenAI Responses 保留未知 wire item
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | typed `async-openai` Responses 枚举会在 Tact 有机会保留新 output item 之前直接拒绝它，使 provider state 无法前向兼容；同时共享的 Chat/Anthropic 请求模型没有明确的 Responses 专用字段扩展边界。 |
+| 决策 | 在 typed normalization 之前先解析 raw Responses envelope；已知 item 正常转换，未知 input/output item 作为 raw JSON 保留。增加只由 Responses adapter 消费的 `ResponsesRequestOptions`，并提供保守的 provider capability metadata；只有出现可复现的 SDK 阻塞时才 fork `async-openai`。 |
+| 变更后行为 | 无害的未知流事件不再中断响应。未知 output item 可以跨普通/流式 turn、session state 序列化和下一次 Responses 请求保留。Responses 专用请求字段不会出现在 Chat Completions 或 Anthropic payload 中。 |
+| 指针 | `crates/tact_llm/src/openai/responses/wire.rs`、`request_options.rs`、`stream.rs`、`provider.rs`；设计：`docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`；计划：`docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md`；压缩：第 5 章与 `docs/compaction.md`。 |
+
 
 ## 1. 2026-08-06 — OpenAI Responses 显示详细 reasoning summary
 

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -32,6 +32,56 @@
 
 
 
+## 1. 2026-08-09 — 任务统计行 `[copy]` 复制最近一轮
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 回合结束后，用户无法从任务统计行一键复制本轮对话。 |
+| 决策 | 在每条 `📊 任务统计：` 行追加 `[copy]` 按钮；点击后复制「上一轮统计行之后（或会话开头）到当前统计行之前」的日志文本，跳过空行与任务结束分隔线。 |
+| 变更后行为 | 点击统计行的 `[copy]` → 剪贴板为本轮用户/助手内容；不包含更早回合。 |
+| 指针 | `messages.rs` 的 `add_task_stats_block` / `copy_turn_ending_at_stats`；`handlers/mouse.rs` 命中；回归测试 `copy_turn_ending_at_stats_copies_last_turn_only`。 |
+
+## 1. 2026-08-09 — Mermaid 图双击弹窗复制源码
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 成功渲染的 Mermaid 在把 ASCII 图拼进日志时丢掉了 fence 正文，用户无法再取回源码以便编辑。 |
+| 决策 | 每次成功渲染保留 `MermaidBlock { start_idx, end_idx, source }`；双击打开 Mermaid 弹窗；弹窗 `y` 复制源码。主区选区 yank 仍为 ASCII。 |
+| 变更后行为 | 双击任意 diagram 行 → 源码弹窗（`y` / `j/k` / `Esc`）；失败 Mermaid 仍走 code-card 路径。 |
+| 指针 | Spec `docs/superpowers/specs/2026-08-09-mermaid-diagram-copy-popup-design.md`；`finish_stream_code_block`；`popups/mermaid_popup.rs`；回归测试 `log_renders_streamed_mermaid_without_code_card`、`mermaid_popup_copy_uses_source_not_ascii`。 |
+
+## 1. 2026-08-09 — Mermaid 时序图自消息改为 U 形回环
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 自消息（`A->>A`）只画成单格 `<│◀`，看起来像断开的尖括号，而不像指向自己的回环箭头。 |
+| 决策 | 将自消息画成两行盒线回环（`│──┐` / `│◀─┘`；末列参与者用左侧 `┌──│` / `└─▶│`），标签放在回环旁。 |
+| 变更后行为 | 自调用在生命线上呈现清晰的 U 形折返；末列自消息向左回环，避免画出图外。 |
+| 指针 | `crates/tui/src/render/mermaid_sequence.rs`（`self_loop_rows`）；回归测试 `self_message_draws_u_shaped_loop`、`self_message_on_last_participant_loops_left`。 |
+
+## 1. 2026-08-09 — Mermaid 时序图标签不再掉字或错位
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 自有 `sequenceDiagram` 渲染器会丢弃落在生命线上的标签字形（如 `submitTask` → `ubmitTask` / `submi│Task`），且每个 2 列宽 CJK 字形后留下幽灵空格，使标签行比生命线/箭头行更宽——多参与者图上生命线看起来断裂，箭头也像缺段。 |
+| 决策 | 在 `label_row` 中把宽字形的续格清空为空 span，并将标签字符绕过已占用的生命线单元格重排，而不是直接跳过。 |
+| 变更后行为 | 长 ASCII / CJK 箭头标签保留全部字符（必要时在 `│` 两侧拆开），各行显示宽度一致，生命线保持纵向对齐。 |
+| 指针 | `crates/tui/src/render/mermaid_sequence.rs`（`label_row`）；回归测试 `cjk_label_keeps_same_display_width_as_lifeline_row`、`long_ascii_label_is_not_eaten_by_lifelines`、`self_message_keeps_lifeline_intact`。 |
+
+## 1. 2026-08-08 — TUI 使用自有渲染器绘制 Mermaid 时序图
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 上游 `ratatui-markdown` 的时序图渲染器对三类常见输入处理有误：`participant A as 用户` 别名被原样展示；`+`/`-` 激活简写（`A->>+B`）会产生幻影参与者列（`+B`、`-B` 等）；2 列宽的 CJK 箭头描述可能盖住生命线（或被丢弃），导致带描述的箭头看起来对不齐。 |
+| 决策 | 在 TUI 中把 `sequenceDiagram` 代码块路由到 Tact 自有的渲染器（`crates/tui/src/render/mermaid_sequence.rs`）；其他 Mermaid 图类型继续使用 `ratatui-markdown`。新渲染器解析 `as` 别名，在参与者查找前去除 `+`/`-` 激活前缀，并按显示列放置标签字形，仅当字形宽度内所有单元格都空闲时才绘制。 |
+| 变更后行为 | 只有声明的参与者渲染为列；`A->>+B` 指向参与者 `B`；CJK 标签在生命线之间居中，且不会覆盖 `│`。无法解析的源码仍回退到普通代码渲染。 |
+| 指针 | `crates/tui/src/render/mermaid_sequence.rs`；路由：`crates/tui/src/render/render_md.rs`（`render_mermaid_block`）；回归测试位于 `mermaid_sequence.rs`。 |
+
 ## 1. 2026-08-08 — Subagent 模型选择器使用自身 provider
 
 | 字段 | 值 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,19 @@
 
 ---
 
+## 1. 2026-08-06 — 未知 provider 名称放行为自定义 OpenAI 兼容 provider
+
+| 字段 | 值 |
+|------|-----|
+| 类型  | `optimization` |
+| 相关 | `crates/tact_llm/src/types.rs`（`ProviderKind::Custom`、`FromStr`）、`crates/tact_llm/src/provider.rs`（`build_client`、`model_uses_effort`）、`crates/tact_llm/src/hook_select.rs`（`body_hook_for`）、`crates/tact_llm/src/models.rs`（`is_models_query_supported`）、`crates/tact/src/config/resolve.rs`（`resolve_provider_kind`、`resolve_llm`、`resolve_subagent`）、Ch 21 §3–§4 |
+| 症状 / 动机 | `ProviderKind::from_str` 拒绝 `anthropic | openai | deepseek | kimi` 之外的任何名称，因此 `llm.provider = "moonshot"`（或任何自建 / 网关 provider）即使条目里配好了可用的 OpenAI 兼容 `base_url`，也会报 "unknown provider"。配置层无法表达第三方 OpenAI 兼容端点。 |
+| 决策 | 为所有非内建名称新增 `ProviderKind::Custom(String)`。自定义 provider 全链路复用 OpenAI 协议：`build_client` 派发到 OpenAI 兼容适配器（默认 `chat_completions`，可选 `responses`），`body_hook_for` 与 `openai` 使用相同的端点启发式，支持 `/v1/models` 补充，并接受 `reasoning_effort`。它们**没有默认 `base_url`**——条目未设置时 resolve 报 "base_url not configured"。内建门禁不变：`responses` 协议仍限 `openai | deepseek | custom`，`reasoning_effort` 限 OpenAI 兼容 provider（即除 anthropic 外全部）；`resolve_llm` 中的 map key 校验循环已删除（自定义 key 不再报错）。`ProviderKind` 失去 `Copy`（现在持有 `String`），方法接收者改为 `&self`。 |
+| 变更后行为 | `llm.provider` / `--provider` 接受任意名称。非内建名称按自定义 OpenAI 兼容 provider 处理，必须在 `[llm.providers.<name>]` 中显式配置 `base_url`。缺失活跃条目仍在 resolve 时报错。 |
+| 指向 | `ProviderKind` 位于 `crates/tact_llm/src/types.rs`；测试 `provider_kind_from_str_accepts_unknown_as_custom`（tact_llm）、`custom_provider_resolves_with_openai_protocol` / `custom_provider_without_base_url_errors` / `custom_provider_in_map_resolves`（tact config resolve）；文档 `book/21_chapter_config*.md` §3–§4、`config.example.toml` |
+
+---
+
 ## 1. 2026-08-06 — 账户轮询每次故障只提示一次，而非每个退避周期都提示
 
 | 字段 | 值 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,7 +29,28 @@
 
 ---
 
-## 1. 2026-08-06 — 思考 effort 与预算在状态栏 / 配置中互斥
+## 1. 2026-08-06 — OpenAI Responses 显示详细 reasoning summary
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 相关 | `crates/tact_llm/src/openai/responses/convert.rs`、Responses reasoning 请求构造 |
+| 症状 / 动机 | 普通 OpenAI Responses 请求发送 `reasoning.summary = auto`，因此即使启用了 reasoning，流式 thinking block 也可能只有 provider 自动选择的简短摘要。 |
+| 决策 | 保留 Responses API 的 `summary` 字段，但在 Tact 启用 reasoning 时请求 `ReasoningSummary::Detailed`（`"detailed"`）。流式解析无需修改，因为它已经消费 reasoning summary delta。 |
+| 变更后行为 | OpenAI Responses 的 thinking block 请求并显示详细 reasoning summary，不再使用自动摘要级别。 |
+| 指针 | 请求转换与回归断言：`crates/tact_llm/src/openai/responses/convert.rs`；相关 Responses 适配器：`crates/tact_llm/src/openai/responses/`。 |
+
+
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 相关 | `crates/tui/src/render/log.rs`、`crates/tui/src/render/cells/text.rs`、`crates/tui/src/render/log_render_tests.rs` |
+| 症状 / 动机 | 主日志区域先按整个面板内容宽度换行，绘制普通消息时再增加左侧缩进；满行消息因此会在右边界被截掉几列，且选区重绘使用了错误的换行宽度。 |
+| 决策 | 缓存换行时预先扣除该消息实际缩进；流式回复使用相同的回复缩进。`TextCell` 的选区换行直接使用扣除缩进后的可用宽度。 |
+| 变更后行为 | 主区域满行的普通、嵌套和流式文本会在实际可绘制宽度内换行，右侧字符不再丢失。 |
+| 指针 | 日志布局与换行缓存见 `render/log.rs`；文本绘制见 `render/cells/text.rs`；回归测试 `log_full_width_nested_line_wraps_before_indentation_clip`。 |
+
 
 | Field | Value |
 |-------|-------|

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,19 @@
 
 ---
 
+## 1. 2026-08-08 — 主区域 Markdown 将完整 Mermaid fence 渲染为终端图
+
+| 字段 | 值 |
+|------|-----|
+| 类型  | `optimization` |
+| 相关 | `crates/tui/src/render/render_md.rs`、`crates/tui/src/widgets/state/app/agent.rs`、`crates/tui/src/widgets/state/app/visibility.rs`、`crates/tui/src/widgets/state/stream_state.rs`、第 23 章 §6.7 |
+| 症状 / 动机 | 所有带显式语言标签的流式 fence——包括 ```mermaid——闭合时都会被提升为 `CodeBlock` card overlay，因此 Mermaid 源码只显示为语法着色的代码，而不是图。 |
+| 决策 | 在 `render_md.rs` 中把完整、顶层 `mermaid` fence 路由到共享的 `render_mermaid_block` 辅助函数（`ratatui-markdown::mermaid::render_mermaid` + 应用主题适配器）；在 `stream_state.rs` 中标记当前缓冲的流式 fence 是否为 Mermaid；`agent.rs` / `visibility.rs` 在合法闭合 fence 时直接把 diagram 行拼接进日志，而不是 push `CodeBlock`。无效、不支持或未闭合的 Mermaid 保留 code-card 回退，绝不丢弃源码。 |
+| 变更后行为 | 完整的 ```mermaid fence 以日志宽度渲染为带主题的终端图（定宽 Markdown 路径使用名义 80 列）；合法的流式 Mermaid block 闭合后不再创建 code card；无效/不支持/未闭合的 Mermaid 与普通显式语言 fence 仍走原有 code-card 路径；宽度重排与视口滚动沿用现有 log 布局/缓存行为。 |
+| 指针 | `render_md.rs`（`render_mermaid_block`、`route_mermaid_fences`）及测试 `render_mermaid_sequence_returns_terminal_lines`、`render_markdown_mermaid_flowchart_uses_box_art`、`render_markdown_invalid_mermaid_falls_back_to_code`、`render_markdown_unclosed_mermaid_fence_keeps_source`；`stream_state.rs`（`code_block_is_mermaid`）；`agent.rs`（`finish_stream_code_block`）、`visibility.rs`（`flush_stream_pending`）；`render_gap_tests.rs` 回归测试（`log_renders_streamed_mermaid_without_code_card`、`log_falls_back_to_code_card_for_invalid_streamed_mermaid`、`flush_renders_streamed_mermaid_without_trailing_newline`、`flush_falls_back_to_code_card_for_unclosed_streamed_mermaid`）、`cells/markdown.rs`（`markdown_cell_renders_mermaid_at_the_requested_width`）；spec `docs/superpowers/specs/2026-08-08-mermaid-main-rendering-design.md`；plan `docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md`；文档 `book/23_chapter_tui*.md` §6.7 |
+
+---
+
 ## 1. 2026-08-06 — OpenAI Responses 显示详细 reasoning summary
 
 | 字段 | 值 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,30 @@
 
 ---
 
+
+
+## 1. 2026-08-08 — DeepSeek 与 Kimi Responses 保持配置门控
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | 通用 Responses adapter 可以为 OpenAI-compatible 端点构造，但 DeepSeek/Kimi 的原生压缩与状态续传尚未验证达到生产契约；若直接允许正常配置，会把未支持的 fallback 行为误认为已支持。 |
+| 决策 | 继续在配置解析阶段拒绝 DeepSeek/Kimi 的 `protocol = "responses"`。底层 adapter 构造仍可用于隔离端点测试；生产配置在原生 Responses 能力验证完成前使用 Chat Completions。 |
+| 变更后行为 | DeepSeek/Kimi 用户会得到明确的配置错误，不会进入未经验证的 Responses 路径。OpenAI 与明确配置的自定义 OpenAI-compatible provider 保留现有 Responses 路由。 |
+| 指针 | `crates/tact/src/config/resolve.rs`；provider 构造：`crates/tact_llm/src/provider.rs`；相关设计：`docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`；压缩行为：第 5 章。 |
+
+
+## 1. 2026-08-08 — OpenAI Responses 保留未知 wire item
+
+| 字段 | 值 |
+|------|-----|
+| 类型 | `bugfix` |
+| 症状 / 动机 | typed `async-openai` Responses 枚举会在 Tact 有机会保留新 output item 之前直接拒绝它，使 provider state 无法前向兼容；同时共享的 Chat/Anthropic 请求模型没有明确的 Responses 专用字段扩展边界。 |
+| 决策 | 在 typed normalization 之前先解析 raw Responses envelope；已知 item 正常转换，未知 input/output item 作为 raw JSON 保留。增加只由 Responses adapter 消费的 `ResponsesRequestOptions`，并提供保守的 provider capability metadata；只有出现可复现的 SDK 阻塞时才 fork `async-openai`。 |
+| 变更后行为 | 无害的未知流事件不再中断响应。未知 output item 可以跨普通/流式 turn、session state 序列化和下一次 Responses 请求保留。Responses 专用请求字段不会出现在 Chat Completions 或 Anthropic payload 中。 |
+| 指针 | `crates/tact_llm/src/openai/responses/wire.rs`、`request_options.rs`、`stream.rs`、`provider.rs`；设计：`docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`；计划：`docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md`；压缩：第 5 章与 `docs/compaction.md`。 |
+
+
 ## 1. 2026-08-06 — OpenAI Responses 显示详细 reasoning summary
 
 | 字段 | 值 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,19 @@
 
 ---
 
+## 1. 2026-08-06 — 思考 effort 与预算在状态栏 / 配置中互斥
+
+| Field | Value |
+|-------|-------|
+| Type  | `bugfix` |
+| Related | `crates/tact/src/agent/mod.rs`（`set_thinking_budget` / `set_reasoning_effort`）、`crates/tact/src/config/mod.rs`（`update_llm_model_and_*`、`update_subagent_*`）、`crates/tact/src/config/persist.rs`（TOML 移除）、`crates/tui/src/render/bar.rs`（`format_think_segment`）、第 23 章 §6.6 |
+| Symptom / motivation | 使用 OpenAI Chat Completions（effort 语义）时，底栏显示 `think high(32K)`：`high` 是真实的 `reasoning_effort`，而 `32K` 是之前预算语义模型（claude / kimi-for-coding）残留的 `thinking_budget`。预算对 effort 模型毫无意义、也绝不会发到线上，但由于运行时 setter、内存配置更新函数、TOML 持久化路径都不会清掉另一字段，它仍会显示在 effort 旁边。 |
+| Decision | 端到端地让 effort 与预算**互斥**：`set_thinking_budget` 清掉 `reasoning_effort`，`set_reasoning_effort` 将 `thinking_budget` 归零；配置更新函数（`update_llm_model_and_thinking_budget` / `update_llm_model_and_reasoning_effort` 及其 subagent 对应项）同样处理；TOML 持久化函数从 provider/subagent 条目中移除相反键。状态栏 `format_think_segment` 改为 effort 优先（有 effort → `think high`，忽略残留预算；只有预算 → `think 32K`），且仅有 effort 时仍会渲染而不是消失。 |
+| Behavior after | effort 语义模型显示 `think high`（绝不会是 `think high(32K)`）；预算语义模型显示 `think 32K`。选择 effort 会从 config.toml 移除已存的 `thinking_budget`；选择预算会移除 `reasoning_effort`。旧配置若同时包含两个字段，显示只取 effort，并在下次 `/model` 持久化时自愈。 |
+| Pointers | `format_think_segment` 及其测试位于 `crates/tui/src/render/bar.rs`；setter 位于 `crates/tact/src/agent/mod.rs`；配置更新函数位于 `crates/tact/src/config/mod.rs`；TOML 移除及其测试位于 `crates/tact/src/config/persist.rs`；driver 测试 `set_reasoning_effort_clears_stale_thinking_budget`；TUI 测试 `applying_effort_pick_clears_stale_thinking_budget`；文档 `book/23_chapter_tui*.md` §6.6 |
+
+---
+
 ## 1. 2026-08-06 — 恢复重试消息附带底层错误
 
 | Field | Value |

--- a/config.example.toml
+++ b/config.example.toml
@@ -25,7 +25,10 @@
 # ---------------------------------------------------------------------------
 # Active provider selects which [llm.providers.*] entry is used.
 # Credentials live under providers — not as flat fields on [llm].
-# Switch with llm.provider or --provider (anthropic | openai | deepseek | kimi).
+# Switch with llm.provider or --provider.
+# Built-in identities: anthropic | openai | deepseek | kimi. Any other name
+# is accepted as a custom OpenAI-compatible provider (OpenAI Chat Completions
+# / Responses protocol) and requires an explicit base_url in its entry.
 [llm]
 provider = "deepseek"
 

--- a/crates/tact-ui/src/account.rs
+++ b/crates/tact-ui/src/account.rs
@@ -249,7 +249,7 @@ mod tests {
             .await
             .expect("timeout waiting for poller shutdown");
         assert!(
-            matches!(shutdown, None),
+            shutdown.is_none(),
             "poller must shut down silently after NotSupported, got {shutdown:?}"
         );
     }
@@ -271,7 +271,7 @@ mod tests {
             .await
             .expect("timeout waiting for poller shutdown");
         assert!(
-            matches!(shutdown, None),
+            shutdown.is_none(),
             "NotSupported must terminate silently, got {shutdown:?}"
         );
     }

--- a/crates/tact-ui/src/account.rs
+++ b/crates/tact-ui/src/account.rs
@@ -7,13 +7,14 @@
 //! its own channel and the TUI renders them independently.
 
 use std::{
+    future::Future,
     sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
 
 use tact_llm::{
-    is_account_query_supported, is_deepseek, is_kimi_balance_supported, is_kimi_usage_supported,
-    query_deepseek_balance, query_kimi_balance, query_kimi_code_usage,
+    is_account_query_supported, is_deepseek_balance_supported, is_kimi_balance_supported,
+    is_kimi_usage_supported, query_deepseek_balance, query_kimi_balance, query_kimi_code_usage,
 };
 use tact_protocol::{
     AccountError, AccountUpdate,
@@ -40,7 +41,7 @@ pub async fn query_once() -> Result<AccountQueryResult, AccountError> {
         return Err(AccountError::NotSupported);
     }
 
-    if is_deepseek() {
+    if is_deepseek_balance_supported() {
         query_deepseek_balance()
             .await
             .map(AccountQueryResult::Balance)
@@ -75,37 +76,64 @@ pub fn into_update(result: AccountQueryResult) -> AccountUpdate {
 /// 10 s → 20 s → 40 s → … → capped at ~5 min), giving the provider or
 /// network time to recover.
 ///
+/// **Error noise is capped**: only the first failure of a consecutive run is
+/// forwarded to the UI as `AccountUpdate::Error`; later retries stay silent
+/// until a query succeeds again (which resets the counter and restores the
+/// normal 5–15 s polling). A single outage therefore shows one flash message
+/// instead of one per backoff tick.
+///
 /// The task stops when the receiver drops or the provider signals
 /// [`AccountError::NotSupported`].
 pub fn spawn_poller(account_tx: UnboundedSender<AccountUpdate>) {
-    tokio::spawn(async move {
-        let mut backoff = 0u32;
-        loop {
-            let delay = if backoff > 0 {
-                // 10s, 20s, 40s, 80s, 160s, capped at 320s
-                Duration::from_secs(10u64.saturating_mul(1 << backoff.min(5)))
-            } else {
-                jitter_interval()
-            };
+    tokio::spawn(poll_loop(query_once, account_tx, |backoff| {
+        if backoff > 0 {
+            // 10s, 20s, 40s, 80s, 160s, capped at 320s
+            Duration::from_secs(10u64.saturating_mul(1 << backoff.min(5)))
+        } else {
+            jitter_interval()
+        }
+    }));
+}
 
-            tokio::time::sleep(delay).await;
-            match query_once().await {
-                Ok(result) => {
-                    backoff = 0;
-                    if account_tx.send(into_update(result)).is_err() {
-                        break;
-                    }
+/// Core poller loop, extracted for testability.
+///
+/// `query` runs every `next_delay(backoff)`; `next_delay` receives the current
+/// backoff exponent (`0` = normal, `>0` = consecutive failures so far).
+async fn poll_loop<Q, D, F>(
+    mut query: Q,
+    account_tx: UnboundedSender<AccountUpdate>,
+    mut next_delay: D,
+) where
+    Q: FnMut() -> F,
+    F: Future<Output = Result<AccountQueryResult, AccountError>>,
+    D: FnMut(u32) -> Duration,
+{
+    let mut backoff = 0u32;
+    let mut error_notified = false;
+    loop {
+        let delay = next_delay(backoff);
+        tokio::time::sleep(delay).await;
+        match query().await {
+            Ok(result) => {
+                backoff = 0;
+                error_notified = false;
+                if account_tx.send(into_update(result)).is_err() {
+                    break;
                 }
-                Err(AccountError::NotSupported) => break,
-                Err(err) => {
-                    backoff = backoff.saturating_add(1);
-                    if account_tx.send(AccountUpdate::Error(err)).is_err() {
-                        break;
-                    }
+            }
+            Err(AccountError::NotSupported) => break,
+            Err(err) => {
+                backoff = backoff.saturating_add(1);
+                if error_notified {
+                    continue;
+                }
+                error_notified = true;
+                if account_tx.send(AccountUpdate::Error(err)).is_err() {
+                    break;
                 }
             }
         }
-    });
+    }
 }
 
 /// Returns a pseudo-random interval between 5–15 seconds using a lock-free
@@ -149,5 +177,102 @@ mod tests {
     fn is_supported_delegates() {
         install_test_config();
         let _ = is_supported();
+    }
+
+    #[tokio::test]
+    async fn poller_forwards_error_once_per_outage_then_resumes() {
+        use tact_protocol::biz::{BalanceEntry, BalanceInfo};
+
+        let ok = || {
+            Ok(AccountQueryResult::Balance(BalanceInfo {
+                is_available: true,
+                balance_infos: vec![BalanceEntry {
+                    currency: "CNY".to_string(),
+                    total_balance: 10.0,
+                    granted_balance: 5.0,
+                    topped_up_balance: 5.0,
+                }],
+            }))
+        };
+        let sequence = std::sync::Mutex::new(
+            vec![
+                Err(AccountError::QueryFailed("boom".to_string())),
+                Err(AccountError::QueryFailed("boom".to_string())),
+                Err(AccountError::QueryFailed("boom".to_string())),
+                ok(),
+                Err(AccountError::QueryFailed("boom".to_string())),
+                Err(AccountError::QueryFailed("boom".to_string())),
+                ok(),
+            ]
+            .into_iter(),
+        );
+        let query = move || {
+            let mut seq = sequence.lock().expect("test sequence poisoned");
+            // Sequence exhausted → NotSupported terminates the loop cleanly.
+            std::future::ready(seq.next().unwrap_or(Err(AccountError::NotSupported)))
+        };
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        // Zero delay keeps the test fast; backoff is irrelevant to dedup.
+        tokio::spawn(poll_loop(query, tx, |_| Duration::ZERO));
+
+        // First outage: exactly one Error, silent retries after it.
+        let first = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for first update")
+            .expect("channel closed early");
+        assert!(matches!(first, AccountUpdate::Error(_)));
+
+        // Recovery: Balance arrives, error flag is reset.
+        let second = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for recovery")
+            .expect("channel closed early");
+        assert!(matches!(second, AccountUpdate::Balance(_)));
+
+        // Second outage: dedup restarted, again exactly one Error.
+        let third = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for second outage")
+            .expect("channel closed early");
+        assert!(matches!(third, AccountUpdate::Error(_)));
+
+        let fourth = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for final recovery")
+            .expect("channel closed early");
+        assert!(matches!(fourth, AccountUpdate::Balance(_)));
+
+        // Sequence exhausted → NotSupported → poller terminates, closing the
+        // channel. Assert clean shutdown with no further Error flashes.
+        let shutdown = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for poller shutdown");
+        assert!(
+            matches!(shutdown, None),
+            "poller must shut down silently after NotSupported, got {shutdown:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn poller_stops_on_not_supported_without_error_flash() {
+        let calls = std::sync::Mutex::new(0u32);
+        let query = move || {
+            let mut c = calls.lock().expect("test counter poisoned");
+            *c += 1;
+            std::future::ready(Err(AccountError::NotSupported))
+        };
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(poll_loop(query, tx, |_| Duration::ZERO));
+
+        // NotSupported terminates the poller without any message at all:
+        // the channel closes with `Ok(None)` and no Error was ever sent.
+        let shutdown = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timeout waiting for poller shutdown");
+        assert!(
+            matches!(shutdown, None),
+            "NotSupported must terminate silently, got {shutdown:?}"
+        );
     }
 }

--- a/crates/tact-ui/src/driver.rs
+++ b/crates/tact-ui/src/driver.rs
@@ -311,4 +311,40 @@ mod tests {
             "SetThinkingBudget must emit ModelInfo so the TUI bar resyncs"
         );
     }
+
+    #[tokio::test]
+    async fn set_reasoning_effort_clears_stale_thinking_budget() {
+        // Regression: switching an effort-semantic model (openai / deepseek /
+        // kimi k3) must not leave a stale thinking budget behind — the bottom
+        // bar would otherwise render a meaningless `think high(32K)`.
+        install_test_config();
+        let (agent_tx, mut agent_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (mut agent, work_dir) = build_test_agent(MockClient::new(vec![]), Some(agent_tx));
+
+        super::handle_user_command(
+            &mut agent,
+            UserCommand::SetThinkingBudget(32_000),
+            &work_dir,
+        )
+        .await;
+        super::handle_user_command(
+            &mut agent,
+            UserCommand::SetReasoningEffort(Some("high".to_string())),
+            &work_dir,
+        )
+        .await;
+
+        let mut last: Option<tact_protocol::ModelCallParams> = None;
+        while let Ok(update) = agent_rx.try_recv() {
+            if let AgentUpdate::ModelInfo(params) = update {
+                last = Some(params);
+            }
+        }
+        let last = last.expect("SetReasoningEffort must emit ModelInfo so the TUI bar resyncs");
+        assert_eq!(last.reasoning_effort, Some("high".to_string()));
+        assert_eq!(
+            last.thinking_budget, None,
+            "effort pick must clear stale thinking budget"
+        );
+    }
 }

--- a/crates/tact/src/agent/mod.rs
+++ b/crates/tact/src/agent/mod.rs
@@ -438,10 +438,9 @@ impl Agent {
 
     /// Validate a loaded Responses provider state against the active client.
     ///
-    /// The state records the provider name, base URL, and request model it was
-    /// created for. Reusing it with a different provider/base URL/model would
-    /// silently corrupt the conversation, so a mismatch is a hard error and is
-    /// never silently reset or dropped.
+    /// Provider and base URL must match. Model mismatches are intentionally
+    /// allowed for experimentation; the provider may reject incompatible
+    /// opaque state at request time.
     fn validate_provider_state_binding(&self, state: &ProviderConversationState) -> Result<()> {
         let ProviderConversationState::OpenAiResponses(inner) = state;
         let LlmProvider::OpenAiResponses(adapter) = &self.runtime.client else {
@@ -461,14 +460,6 @@ impl Agent {
                 "provider state is bound to base URL '{}', expected '{}'",
                 inner.base_url,
                 adapter.base_url()
-            );
-        }
-        let model = self.agent_settings.model.clone();
-        if inner.model != model {
-            anyhow::bail!(
-                "provider state is bound to model '{}', expected '{}'",
-                inner.model,
-                model
             );
         }
         Ok(())

--- a/crates/tact/src/agent/mod.rs
+++ b/crates/tact/src/agent/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     prompt::{SystemPrompt, responses_prompt_template},
     recovery::{
         MAX_COMPACT_ATTEMPTS, MAX_COMPACT_SUMMARY_RETRY_ATTEMPTS, MAX_CONTINUATION_ATTEMPTS,
-        MAX_TRANSPORT_ATTEMPTS, RecoveryState, backoff_delay, continuation_message,
+        MAX_TRANSPORT_ATTEMPTS, RecoveryState, backoff_delay, continuation_message, error_summary,
         is_prompt_too_long_error, is_transient_transport_error,
     },
     stats::SessionStats,
@@ -736,8 +736,15 @@ impl Agent {
                     {
                         let delay = backoff_delay(self.runtime.recovery_state.transport_attempts);
                         self.runtime.recovery_state.transport_attempts += 1;
+                        let summary = error_summary(
+                            &error
+                                .chain()
+                                .map(|cause| cause.to_string())
+                                .collect::<Vec<_>>()
+                                .join(": "),
+                        );
                         self.emit_update(AgentUpdate::Info(format!(
-                            "[Recovery] backoff ({}/{}): retrying in {:.1}s",
+                            "[Recovery] backoff ({}/{}): retrying in {:.1}s — {summary}",
                             self.runtime.recovery_state.transport_attempts,
                             MAX_TRANSPORT_ATTEMPTS,
                             delay.as_secs_f64()
@@ -1030,8 +1037,9 @@ impl Agent {
                     }
                     retry_attempt = retry_attempt.saturating_add(1);
                     let delay = backoff_delay(retry_attempt.saturating_sub(1));
+                    let summary = error_summary(&error_text);
                     self.emit_update(AgentUpdate::Info(format!(
-                        "[compact retry {retry_attempt}/{MAX_COMPACT_SUMMARY_RETRY_ATTEMPTS}] retrying in {:.1}s",
+                        "[compact retry {retry_attempt}/{MAX_COMPACT_SUMMARY_RETRY_ATTEMPTS}] retrying in {:.1}s — {summary}",
                         delay.as_secs_f64()
                     )));
                     tokio::time::sleep(delay).await;
@@ -1266,8 +1274,9 @@ impl Agent {
                     }
                     retry_attempt = retry_attempt.saturating_add(1);
                     let delay = backoff_delay(retry_attempt.saturating_sub(1));
+                    let summary = error_summary(&error_text);
                     self.emit_update(AgentUpdate::Info(format!(
-                        "[compact retry {retry_attempt}/{MAX_COMPACT_SUMMARY_RETRY_ATTEMPTS}] retrying in {:.1}s",
+                        "[compact retry {retry_attempt}/{MAX_COMPACT_SUMMARY_RETRY_ATTEMPTS}] retrying in {:.1}s — {summary}",
                         delay.as_secs_f64()
                     )));
                     tokio::time::sleep(delay).await;

--- a/crates/tact/src/agent/mod.rs
+++ b/crates/tact/src/agent/mod.rs
@@ -275,6 +275,10 @@ impl Agent {
     /// Update the thinking budget used when constructing subsequent LLM requests.
     /// An in-flight request already owns its `CreateMessageParams` and is unchanged.
     ///
+    /// Budget semantics and effort semantics are mutually exclusive: setting a
+    /// budget clears any stale reasoning effort, so the status bar never shows
+    /// a meaningless `think high(32K)` for a budget-semantic model.
+    ///
     /// If the new budget is active and not strictly smaller than the current
     /// `max_tokens`, `max_tokens` is automatically expanded to `budget + 1` and a
     /// warning is emitted to the UI channel.
@@ -285,6 +289,7 @@ impl Agent {
     /// previous budget.
     pub fn set_thinking_budget(&mut self, budget: usize) {
         self.agent_settings.thinking_budget = budget;
+        self.agent_settings.reasoning_effort = None;
         if let Some(msg) =
             Self::ensure_max_tokens_gt_thinking_budget(&mut self.agent_settings.max_tokens, budget)
         {
@@ -309,9 +314,15 @@ impl Agent {
     /// Update this agent's session reasoning effort (per-agent; never the
     /// global provider). `None` clears the explicit effort (wire omits it).
     ///
+    /// Effort semantics and budget semantics are mutually exclusive: setting an
+    /// effort clears any stale thinking budget, so the status bar never shows a
+    /// meaningless `(32K)` next to an explicit effort for effort-semantic models
+    /// (openai / deepseek / kimi k3).
+    ///
     /// Same queue semantics as [`set_thinking_budget`].
     pub fn set_reasoning_effort(&mut self, effort: Option<OpenAiReasoningEffort>) {
         self.agent_settings.reasoning_effort = effort;
+        self.agent_settings.thinking_budget = 0;
         self.emit_model_status();
     }
 

--- a/crates/tact/src/config/cli.rs
+++ b/crates/tact/src/config/cli.rs
@@ -13,7 +13,7 @@ pub struct CliArgs {
     #[arg(short, long)]
     pub config: Option<PathBuf>,
 
-    /// Active LLM provider (`anthropic` | `openai` | `deepseek` | `kimi`); selects `[llm.providers.<name>]`
+    /// Active LLM provider (built-ins: `anthropic` | `openai` | `deepseek` | `kimi`; any other name = custom OpenAI-compatible); selects `[llm.providers.<name>]`
     #[arg(long)]
     pub provider: Option<String>,
 

--- a/crates/tact/src/config/mod.rs
+++ b/crates/tact/src/config/mod.rs
@@ -143,24 +143,6 @@ pub fn builtin_model_profiles() -> std::collections::HashMap<String, ModelProfil
     BUILTIN_MODEL_PROFILES.clone()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::builtin_model_profiles;
-    use tact_llm::OpenAiReasoningEffort as E;
-
-    #[test]
-    fn gpt_5_6_luna_exposes_all_reasoning_effort_tiers() {
-        let profiles = builtin_model_profiles();
-        let profile = profiles
-            .get("gpt-5.6-luna")
-            .expect("built-in gpt-5.6-luna profile");
-        assert_eq!(
-            profile.reasoning_efforts,
-            vec![E::Minimal, E::Low, E::Medium, E::High, E::Xhigh, E::Max]
-        );
-    }
-}
-
 /// Install resolved settings for the process. Must be called once at startup.
 pub fn install(config: types::ResolvedConfig) {
     tact_llm::init_provider(config.llm.provider_info());
@@ -382,4 +364,22 @@ pub fn init_config() -> anyhow::Result<CliArgs> {
 /// Call this at the very start of `main()`.
 pub fn init() -> anyhow::Result<CliArgs> {
     init_config()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::builtin_model_profiles;
+    use tact_llm::OpenAiReasoningEffort as E;
+
+    #[test]
+    fn gpt_5_6_luna_exposes_all_reasoning_effort_tiers() {
+        let profiles = builtin_model_profiles();
+        let profile = profiles
+            .get("gpt-5.6-luna")
+            .expect("built-in gpt-5.6-luna profile");
+        assert_eq!(
+            profile.reasoning_efforts,
+            vec![E::Minimal, E::Low, E::Medium, E::High, E::Xhigh, E::Max]
+        );
+    }
 }

--- a/crates/tact/src/config/mod.rs
+++ b/crates/tact/src/config/mod.rs
@@ -207,13 +207,17 @@ pub fn update_llm_model(model: String) {
 ///
 /// Mirrors [`update_llm_model_and_thinking_budget`] for effort-semantic
 /// providers: both fields must move together so the running agent, status bar,
-/// and config-level `agent.reasoning_effort` stay consistent.
+/// and config-level `agent.reasoning_effort` stay consistent. Effort and budget
+/// semantics are mutually exclusive, so picking an effort clears any stale
+/// `thinking_budget` (otherwise the bottom bar would show `think high(32K)`
+/// with a meaningless budget for an effort-semantic model).
 pub fn update_llm_model_and_reasoning_effort(model: String, effort: Option<OpenAiReasoningEffort>) {
     let mut guard = SETTINGS.write().expect("tact config lock poisoned");
     if let Some(cfg) = guard.as_mut() {
         cfg.llm.model = model.clone();
         cfg.agent.model = model;
         cfg.agent.reasoning_effort = effort;
+        cfg.agent.thinking_budget = 0;
     }
 }
 
@@ -222,12 +226,15 @@ pub fn update_llm_model_and_reasoning_effort(model: String, effort: Option<OpenA
 /// When `thinking_budget` is active and not strictly smaller than `max_tokens`,
 /// expands `max_tokens` to `budget + 1` so the session settings match the agent
 /// auto-expand rule used by [`crate::agent::Agent::set_thinking_budget`].
+/// Budget and effort semantics are mutually exclusive, so setting a budget
+/// clears any stale `reasoning_effort`.
 pub fn update_llm_model_and_thinking_budget(model: String, thinking_budget: usize) {
     let mut guard = SETTINGS.write().expect("tact config lock poisoned");
     if let Some(cfg) = guard.as_mut() {
         cfg.llm.model = model.clone();
         cfg.agent.model = model;
         cfg.agent.thinking_budget = thinking_budget;
+        cfg.agent.reasoning_effort = None;
         if thinking_budget > 0 && (cfg.agent.max_tokens as usize) <= thinking_budget {
             cfg.agent.max_tokens = u32::try_from(thinking_budget)
                 .unwrap_or(u32::MAX)
@@ -244,6 +251,7 @@ pub fn update_subagent_model(model: String, thinking_budget: usize) {
     {
         sa.provider.model = model;
         sa.thinking_budget = thinking_budget;
+        sa.reasoning_effort = None;
     }
 }
 
@@ -254,6 +262,7 @@ pub fn update_subagent_reasoning_effort(effort: Option<OpenAiReasoningEffort>) {
         && let Some(sa) = cfg.agent.subagent.as_mut()
     {
         sa.reasoning_effort = effort;
+        sa.thinking_budget = 0;
     }
 }
 

--- a/crates/tact/src/config/mod.rs
+++ b/crates/tact/src/config/mod.rs
@@ -55,7 +55,7 @@ static BUILTIN_MODEL_PROFILES: LazyLock<std::collections::HashMap<String, ModelP
             "gpt-5.6-luna".into(),
             ModelProfileToml {
                 thinking_budgets: vec![],
-                reasoning_efforts: vec![E::Low, E::Medium],
+                reasoning_efforts: vec![E::Minimal, E::Low, E::Medium, E::High, E::Xhigh, E::Max],
             },
         );
         m.insert(
@@ -364,4 +364,22 @@ pub fn init_config() -> anyhow::Result<CliArgs> {
 /// Call this at the very start of `main()`.
 pub fn init() -> anyhow::Result<CliArgs> {
     init_config()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::builtin_model_profiles;
+    use tact_llm::OpenAiReasoningEffort as E;
+
+    #[test]
+    fn gpt_5_6_luna_exposes_all_reasoning_effort_tiers() {
+        let profiles = builtin_model_profiles();
+        let profile = profiles
+            .get("gpt-5.6-luna")
+            .expect("built-in gpt-5.6-luna profile");
+        assert_eq!(
+            profile.reasoning_efforts,
+            vec![E::Minimal, E::Low, E::Medium, E::High, E::Xhigh, E::Max]
+        );
+    }
 }

--- a/crates/tact/src/config/mod.rs
+++ b/crates/tact/src/config/mod.rs
@@ -55,7 +55,7 @@ static BUILTIN_MODEL_PROFILES: LazyLock<std::collections::HashMap<String, ModelP
             "gpt-5.6-luna".into(),
             ModelProfileToml {
                 thinking_budgets: vec![],
-                reasoning_efforts: vec![E::Low, E::Medium],
+                reasoning_efforts: vec![E::Minimal, E::Low, E::Medium, E::High, E::Xhigh, E::Max],
             },
         );
         m.insert(
@@ -141,6 +141,24 @@ static BUILTIN_MODEL_PROFILES: LazyLock<std::collections::HashMap<String, ModelP
 /// Return a copy of the built-in model profiles (fallback base for TOML merge).
 pub fn builtin_model_profiles() -> std::collections::HashMap<String, ModelProfileToml> {
     BUILTIN_MODEL_PROFILES.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::builtin_model_profiles;
+    use tact_llm::OpenAiReasoningEffort as E;
+
+    #[test]
+    fn gpt_5_6_luna_exposes_all_reasoning_effort_tiers() {
+        let profiles = builtin_model_profiles();
+        let profile = profiles
+            .get("gpt-5.6-luna")
+            .expect("built-in gpt-5.6-luna profile");
+        assert_eq!(
+            profile.reasoning_efforts,
+            vec![E::Minimal, E::Low, E::Medium, E::High, E::Xhigh, E::Max]
+        );
+    }
 }
 
 /// Install resolved settings for the process. Must be called once at startup.

--- a/crates/tact/src/config/persist.rs
+++ b/crates/tact/src/config/persist.rs
@@ -56,6 +56,9 @@ pub(super) fn update_provider_model_in_toml(
 }
 
 /// Set `llm.providers.<provider>.model` and `thinking_budget` in `path` and rewrite the file.
+///
+/// Budget and effort semantics are mutually exclusive: writing a budget also
+/// removes any stale `reasoning_effort` from the provider entry.
 pub(super) fn update_provider_model_and_thinking_budget_in_toml(
     path: &Path,
     provider: &str,
@@ -67,11 +70,15 @@ pub(super) fn update_provider_model_and_thinking_budget_in_toml(
     update_toml(path, &["llm", "providers", provider], |t| {
         t.insert("model", toml_edit::value(model));
         t.insert("thinking_budget", toml_edit::value(budget));
+        t.remove("reasoning_effort");
         Ok(())
     })
 }
 
 /// Set `agent.subagent.model` and `thinking_budget` in `path` and rewrite the file.
+///
+/// Writing a budget also removes any stale `reasoning_effort` (mutually
+/// exclusive semantics, same as the main agent).
 pub(super) fn update_subagent_model_in_toml(
     path: &Path,
     model: &str,
@@ -82,11 +89,16 @@ pub(super) fn update_subagent_model_in_toml(
     update_toml(path, &["agent", "subagent"], |t| {
         t.insert("model", toml_edit::value(model));
         t.insert("thinking_budget", toml_edit::value(budget));
+        t.remove("reasoning_effort");
         Ok(())
     })
 }
 
 /// Set `[llm.providers.<name>].model` + `reasoning_effort` in `path`.
+///
+/// Writing an effort also removes any stale `thinking_budget` from the provider
+/// entry, so a model switch to effort semantics does not leave a meaningless
+/// `think (32K)` behind in the status bar.
 pub(super) fn update_provider_model_and_reasoning_effort_in_toml(
     path: &Path,
     provider: &str,
@@ -96,11 +108,15 @@ pub(super) fn update_provider_model_and_reasoning_effort_in_toml(
     update_toml(path, &["llm", "providers", provider], |t| {
         t.insert("model", toml_edit::value(model));
         t.insert("reasoning_effort", toml_edit::value(effort));
+        t.remove("thinking_budget");
         Ok(())
     })
 }
 
 /// Set `[agent.subagent].model` + `reasoning_effort` in `path`.
+///
+/// Writing an effort also removes any stale `thinking_budget` (mutually
+/// exclusive semantics, same as the main agent).
 pub(super) fn update_subagent_model_and_reasoning_effort_in_toml(
     path: &Path,
     model: &str,
@@ -109,6 +125,7 @@ pub(super) fn update_subagent_model_and_reasoning_effort_in_toml(
     update_toml(path, &["agent", "subagent"], |t| {
         t.insert("model", toml_edit::value(model));
         t.insert("reasoning_effort", toml_edit::value(effort));
+        t.remove("thinking_budget");
         Ok(())
     })
 }
@@ -255,6 +272,84 @@ thinking_budget = 64000
         assert_eq!(
             cfg["llm"]["providers"]["kimi"]["thinking_budget"].as_integer(),
             Some(0)
+        );
+    }
+
+    #[test]
+    fn persisting_effort_removes_stale_thinking_budget() {
+        // Regression: switching an effort-semantic model must not leave a
+        // stale thinking_budget in config.toml — it would resurface as a
+        // meaningless `think high(32K)` after restart.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"[llm]
+provider = "kimi"
+
+[llm.providers.kimi]
+api_key = "sk-test"
+model = "old-model"
+thinking_budget = 32000
+"#,
+        )
+        .unwrap();
+
+        update_provider_model_and_reasoning_effort_in_toml(&path, "kimi", "k3", "high").unwrap();
+
+        let cfg: toml::Value = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(
+            cfg["llm"]["providers"]["kimi"]["model"].as_str(),
+            Some("k3")
+        );
+        assert_eq!(
+            cfg["llm"]["providers"]["kimi"]["reasoning_effort"].as_str(),
+            Some("high")
+        );
+        assert!(
+            cfg["llm"]["providers"]["kimi"]
+                .get("thinking_budget")
+                .is_none(),
+            "effort persist must remove the stale thinking_budget"
+        );
+    }
+
+    #[test]
+    fn persisting_budget_removes_stale_reasoning_effort() {
+        // Regression: switching to a budget-semantic model must not leave a
+        // stale reasoning_effort in config.toml (mutually exclusive semantics).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"[llm]
+provider = "kimi"
+
+[llm.providers.kimi]
+api_key = "sk-test"
+model = "k3"
+reasoning_effort = "high"
+"#,
+        )
+        .unwrap();
+
+        update_provider_model_and_thinking_budget_in_toml(&path, "kimi", "kimi-for-coding", 64_000)
+            .unwrap();
+
+        let cfg: toml::Value = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(
+            cfg["llm"]["providers"]["kimi"]["model"].as_str(),
+            Some("kimi-for-coding")
+        );
+        assert_eq!(
+            cfg["llm"]["providers"]["kimi"]["thinking_budget"].as_integer(),
+            Some(64_000)
+        );
+        assert!(
+            cfg["llm"]["providers"]["kimi"]
+                .get("reasoning_effort")
+                .is_none(),
+            "budget persist must remove the stale reasoning_effort"
         );
     }
 }

--- a/crates/tact/src/config/resolve.rs
+++ b/crates/tact/src/config/resolve.rs
@@ -144,7 +144,7 @@ fn resolve_provider_kind(
         .or_else(|| toml_cfg.llm.provider.clone())
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "LLM provider not configured. Set llm.provider in config.toml or pass --provider anthropic|openai|deepseek|kimi"
+                "LLM provider not configured. Set llm.provider in config.toml or pass --provider"
             )
         })?;
     raw.parse::<ProviderKind>().map_err(anyhow::Error::msg)
@@ -199,10 +199,6 @@ fn resolve_responses_compact_threshold(
 fn resolve_llm(args: &CliArgs, toml_cfg: &TactTomlConfig) -> anyhow::Result<LlmSettings> {
     let provider = resolve_provider_kind(args, toml_cfg)?;
 
-    for key in toml_cfg.llm.providers.keys() {
-        key.parse::<ProviderKind>().map_err(anyhow::Error::msg)?;
-    }
-
     let entry = toml_cfg
         .llm
         .providers
@@ -248,10 +244,14 @@ fn resolve_llm(args: &CliArgs, toml_cfg: &TactTomlConfig) -> anyhow::Result<LlmS
         .parse::<OpenAiProtocol>()
         .map_err(anyhow::Error::msg)?;
     if protocol == OpenAiProtocol::Responses
-        && provider != ProviderKind::OpenAi
-        && provider != ProviderKind::DeepSeek
+        && !matches!(
+            provider,
+            ProviderKind::OpenAi | ProviderKind::DeepSeek | ProviderKind::Custom(_)
+        )
     {
-        anyhow::bail!("protocol 'responses' is only supported for provider 'openai' or 'deepseek'");
+        anyhow::bail!(
+            "protocol 'responses' is only supported for provider 'openai', 'deepseek' or custom OpenAI-compatible providers"
+        );
     }
 
     if protocol == OpenAiProtocol::Responses && provider == ProviderKind::DeepSeek {
@@ -264,13 +264,9 @@ fn resolve_llm(args: &CliArgs, toml_cfg: &TactTomlConfig) -> anyhow::Result<LlmS
         );
     }
     let reasoning_effort = entry.reasoning_effort;
-    if reasoning_effort.is_some()
-        && provider != ProviderKind::OpenAi
-        && provider != ProviderKind::DeepSeek
-        && provider != ProviderKind::Kimi
-    {
+    if reasoning_effort.is_some() && !provider.is_openai_compatible() {
         anyhow::bail!(
-            "reasoning_effort is only supported for provider 'openai', 'deepseek' or 'kimi'"
+            "reasoning_effort is only supported for provider 'openai', 'deepseek', 'kimi' or custom OpenAI-compatible providers"
         );
     }
 
@@ -1201,7 +1197,9 @@ protocol = "responses"
         let error = resolve_config(&empty_cli_args(), &toml_cfg, None)
             .unwrap_err()
             .to_string();
-        assert!(error.contains("only supported for provider 'openai' or 'deepseek'"));
+        assert!(error.contains(
+            "only supported for provider 'openai', 'deepseek' or custom OpenAI-compatible providers"
+        ));
     }
 
     #[test]
@@ -1222,7 +1220,9 @@ protocol = "responses"
         let error = resolve_config(&empty_cli_args(), &toml_cfg, None)
             .unwrap_err()
             .to_string();
-        assert!(error.contains("only supported for provider 'openai' or 'deepseek'"));
+        assert!(error.contains(
+            "only supported for provider 'openai', 'deepseek' or custom OpenAI-compatible providers"
+        ));
     }
 
     #[test]
@@ -1501,7 +1501,7 @@ model = "gpt-4o"
     }
 
     #[test]
-    fn invalid_provider_map_key_errors() {
+    fn custom_provider_in_map_resolves() {
         let toml_cfg: TactTomlConfig = toml::from_str(
             r#"
 [llm]
@@ -1517,10 +1517,8 @@ model = "kimi-k2.5"
 "#,
         )
         .unwrap();
-        let err = resolve_config(&empty_cli_args(), &toml_cfg, None)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("unknown provider"));
+        let resolved = resolve_config(&empty_cli_args(), &toml_cfg, None).unwrap();
+        assert_eq!(resolved.llm.provider, ProviderKind::OpenAi);
     }
 
     #[test]
@@ -1543,7 +1541,7 @@ model = "kimi-k2.5"
     }
 
     #[test]
-    fn unknown_provider_name_errors() {
+    fn custom_provider_resolves_with_openai_protocol() {
         let toml_cfg: TactTomlConfig = toml::from_str(
             r#"
 [llm]
@@ -1551,14 +1549,37 @@ provider = "foo"
 
 [llm.providers.foo]
 api_key = "sk-test"
-model = "gpt-4o"
+base_url = "https://foo.example.com/v1"
+model = "foo-1"
+"#,
+        )
+        .unwrap();
+        let resolved = resolve_config(&empty_cli_args(), &toml_cfg, None).unwrap();
+        assert_eq!(
+            resolved.llm.provider,
+            ProviderKind::Custom("foo".to_string())
+        );
+        assert_eq!(resolved.llm.protocol, OpenAiProtocol::ChatCompletions);
+        assert_eq!(resolved.llm.base_url, "https://foo.example.com/v1");
+    }
+
+    #[test]
+    fn custom_provider_without_base_url_errors() {
+        let toml_cfg: TactTomlConfig = toml::from_str(
+            r#"
+[llm]
+provider = "foo"
+
+[llm.providers.foo]
+api_key = "sk-test"
+model = "foo-1"
 "#,
         )
         .unwrap();
         let err = resolve_config(&empty_cli_args(), &toml_cfg, None)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("unknown provider"));
+        assert!(err.contains("base_url not configured"));
     }
 
     #[test]

--- a/crates/tact/src/config/types.rs
+++ b/crates/tact/src/config/types.rs
@@ -246,7 +246,7 @@ impl LlmSettings {
             api_key: self.api_key.clone(),
             base_url: self.base_url.clone(),
             model: self.model.clone(),
-            provider: self.provider,
+            provider: self.provider.clone(),
             protocol: self.protocol,
             responses_compact_threshold: self.responses_compact_threshold,
         }

--- a/crates/tact/src/recovery.rs
+++ b/crates/tact/src/recovery.rs
@@ -20,6 +20,8 @@
 //!   transport categories.
 //! - [`is_prompt_too_long_error`] / [`is_transient_transport_error`]:
 //!   classify error strings to route recovery decisions.
+//! - [`error_summary`]: collapses an error into a single readable line so
+//!   recovery status messages say *why* a retry is happening.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -107,6 +109,23 @@ pub fn backoff_delay(attempt: u32) -> Duration {
     Duration::from_secs_f64(base + jitter)
 }
 
+/// Maximum length of the single-line error summary embedded in recovery
+/// status messages. Long chains are truncated so the TUI line stays readable.
+const MAX_ERROR_SUMMARY_CHARS: usize = 200;
+
+/// Collapses an error message into a single readable line for recovery
+/// status messages: runs of whitespace (including newlines) become single
+/// spaces, and overly long messages are truncated with an ellipsis.
+pub fn error_summary(error_text: &str) -> String {
+    let collapsed: String = error_text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= MAX_ERROR_SUMMARY_CHARS {
+        collapsed
+    } else {
+        let truncated: String = collapsed.chars().take(MAX_ERROR_SUMMARY_CHARS).collect();
+        format!("{truncated}…")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +172,29 @@ mod tests {
         assert!(prompt.contains("concise"));
         assert!(prompt.contains("actionable"));
         assert!(prompt.contains("repeat"));
+    }
+
+    #[test]
+    fn error_summary_preserves_short_errors() {
+        assert_eq!(error_summary("request timed out"), "request timed out");
+    }
+
+    #[test]
+    fn error_summary_collapses_whitespace_and_truncates() {
+        let long = format!("line one\nline two   line three{}", " x".repeat(300));
+        let summary = error_summary(&long);
+        assert!(!summary.contains('\n'));
+        assert!(!summary.contains("  "));
+        assert_eq!(summary.chars().count(), MAX_ERROR_SUMMARY_CHARS + 1);
+        assert!(summary.ends_with('…'));
+    }
+
+    #[test]
+    fn error_summary_keeps_chain_separators() {
+        let summary = error_summary("http request failed: error sending request for url");
+        assert_eq!(
+            summary,
+            "http request failed: error sending request for url"
+        );
     }
 }

--- a/crates/tact_llm/src/account.rs
+++ b/crates/tact_llm/src/account.rs
@@ -11,24 +11,40 @@ use crate::provider::read_provider;
 /// reuse across calls.
 static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
+/// Derive the DeepSeek balance API URL from the configured base URL.
+///
+/// Returns `None` unless the URL targets the official DeepSeek API host.
+///
+/// DeepSeek only serves `GET /user/balance` on the official endpoint; custom
+/// OpenAI-compatible proxies / gateways do not implement it. The API key is
+/// therefore never sent anywhere but `https://api.deepseek.com`.
+fn deepseek_balance_url_from_base_url(base_url: &str) -> Option<String> {
+    if base_url.is_empty() {
+        return Some("https://api.deepseek.com/user/balance".to_string());
+    }
+
+    let parsed = reqwest::Url::parse(base_url).ok()?;
+    if parsed.scheme() != "https" || parsed.host_str() != Some("api.deepseek.com") {
+        return None;
+    }
+    Some("https://api.deepseek.com/user/balance".to_string())
+}
+
 /// Query DeepSeek account balance.
 ///
 /// Calls `GET https://api.deepseek.com/user/balance` with the provided API key.
 /// Returns `BalanceInfo` on success.
+///
+/// Only supported when the configured base URL targets the official DeepSeek
+/// API host (`https://api.deepseek.com`, with or without a `/v1` suffix).
 pub async fn query_deepseek_balance() -> anyhow::Result<tact_protocol::BalanceInfo> {
     let (api_key, base_url) = read_provider(|p| (p.api_key.clone(), p.base_url.clone()));
 
-    // Construct the balance endpoint URL from the base URL
-    let balance_url = if base_url.contains("api.deepseek.com") {
-        "https://api.deepseek.com/user/balance".to_string()
-    } else {
-        // Extract origin from base_url and append /user/balance
-        let origin = base_url
-            .trim_end_matches('/')
-            .trim_end_matches("/v1")
-            .trim_end_matches("/v1/");
-        format!("{origin}/user/balance")
-    };
+    let balance_url = deepseek_balance_url_from_base_url(&base_url).ok_or_else(|| {
+        anyhow::anyhow!(
+            "DeepSeek balance API is only available for the official endpoint https://api.deepseek.com"
+        )
+    })?;
 
     let resp = CLIENT
         .get(&balance_url)
@@ -198,20 +214,25 @@ pub async fn query_kimi_balance() -> anyhow::Result<tact_protocol::BalanceInfo> 
 
 /// Derive the Kimi Code usage API URL from the configured base URL.
 ///
-/// Works for the official endpoint and for custom proxies serving the
-/// `kimi-for-coding` model. Falls back to the official endpoint when the
-/// base URL is empty.
-fn kimi_usage_url_from_base_url(base_url: &str) -> String {
-    let trimmed = base_url.trim_end_matches('/');
-    if trimmed.is_empty() {
-        return "https://api.kimi.com/coding/v1/usages".to_string();
+/// Returns `None` unless the URL targets the official Kimi Code API host
+/// (`https://api.kimi.com/coding`). Custom OpenAI-compatible proxies do not
+/// serve the usage quota API; the API key is never sent to `api.kimi.com`
+/// from a proxy configuration.
+fn kimi_usage_url_from_base_url(base_url: &str) -> Option<String> {
+    let parsed = reqwest::Url::parse(base_url).ok()?;
+    if parsed.scheme() != "https" || parsed.host_str() != Some("api.kimi.com") {
+        return None;
     }
+    if !parsed.path().contains("coding") {
+        return None;
+    }
+    let trimmed = parsed.path().trim_end_matches('/');
     let api_base = if trimmed.ends_with("/v1") {
         trimmed.to_string()
     } else {
         format!("{trimmed}/v1")
     };
-    format!("{api_base}/usages")
+    Some(format!("https://api.kimi.com{api_base}/usages"))
 }
 
 /// Parse a quota number reported as a JSON string.
@@ -296,19 +317,17 @@ fn parse_kimi_usage_response(body: &str) -> anyhow::Result<tact_protocol::UsageQ
 }
 
 /// Query Kimi Code subscription quota (`GET .../v1/usages`).
+///
+/// Only supported when the configured base URL targets the official Kimi Code
+/// endpoint (`https://api.kimi.com/coding`).
 pub async fn query_kimi_code_usage() -> anyhow::Result<tact_protocol::UsageQuotaInfo> {
-    let (api_key, base_url, is_kimi_coding) = read_provider(|p| {
-        (
-            p.api_key.clone(),
-            p.base_url.clone(),
-            p.is_kimi_coding(&p.model),
-        )
-    });
+    let (api_key, base_url) = read_provider(|p| (p.api_key.clone(), p.base_url.clone()));
 
-    if !is_kimi_coding {
-        anyhow::bail!("usage quota API is only available on Kimi Code (api.kimi.com/coding)");
-    }
-    let usage_url = kimi_usage_url_from_base_url(&base_url);
+    let usage_url = kimi_usage_url_from_base_url(&base_url).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Kimi Code usage API is only available for the official endpoint https://api.kimi.com/coding"
+        )
+    })?;
 
     let resp = CLIENT
         .get(&usage_url)
@@ -343,25 +362,72 @@ mod tests {
     use super::*;
 
     #[test]
-    fn kimi_usage_url_derivation() {
+    fn deepseek_balance_url_derivation() {
         assert_eq!(
-            kimi_usage_url_from_base_url("https://api.kimi.com/coding/v1"),
-            "https://api.kimi.com/coding/v1/usages"
+            deepseek_balance_url_from_base_url("https://api.deepseek.com"),
+            Some("https://api.deepseek.com/user/balance".to_string())
         );
         assert_eq!(
-            kimi_usage_url_from_base_url("https://api.kimi.com/coding/v1/"),
-            "https://api.kimi.com/coding/v1/usages"
+            deepseek_balance_url_from_base_url("https://api.deepseek.com/v1"),
+            Some("https://api.deepseek.com/user/balance".to_string())
         );
-        // Custom proxy serving kimi-for-coding: derive from the proxy base.
         assert_eq!(
-            kimi_usage_url_from_base_url("https://proxy.example.com"),
-            "https://proxy.example.com/v1/usages"
+            deepseek_balance_url_from_base_url("https://api.deepseek.com/v1/"),
+            Some("https://api.deepseek.com/user/balance".to_string())
         );
         // Empty base URL falls back to the official endpoint.
         assert_eq!(
-            kimi_usage_url_from_base_url(""),
-            "https://api.kimi.com/coding/v1/usages"
+            deepseek_balance_url_from_base_url(""),
+            Some("https://api.deepseek.com/user/balance".to_string())
         );
+        // Custom proxies / gateways do not serve the DeepSeek balance API.
+        assert_eq!(
+            deepseek_balance_url_from_base_url("https://proxy.example.com/v1"),
+            None
+        );
+        // Host-name spoofing and plain HTTP are rejected too.
+        assert_eq!(
+            deepseek_balance_url_from_base_url("https://api.deepseek.com.evil.example/v1"),
+            None
+        );
+        assert_eq!(
+            deepseek_balance_url_from_base_url("http://api.deepseek.com/v1"),
+            None
+        );
+    }
+
+    #[test]
+    fn kimi_usage_url_derivation() {
+        assert_eq!(
+            kimi_usage_url_from_base_url("https://api.kimi.com/coding/v1"),
+            Some("https://api.kimi.com/coding/v1/usages".to_string())
+        );
+        assert_eq!(
+            kimi_usage_url_from_base_url("https://api.kimi.com/coding/v1/"),
+            Some("https://api.kimi.com/coding/v1/usages".to_string())
+        );
+        assert_eq!(
+            kimi_usage_url_from_base_url("https://api.kimi.com/coding"),
+            Some("https://api.kimi.com/coding/v1/usages".to_string())
+        );
+        // Custom proxy serving kimi-for-coding has no usage quota API.
+        assert_eq!(
+            kimi_usage_url_from_base_url("https://proxy.example.com/v1"),
+            None
+        );
+        // Official host without the /coding path is not the Kimi Code API.
+        assert_eq!(kimi_usage_url_from_base_url("https://api.kimi.com"), None);
+        // Host-name spoofing and plain HTTP are rejected too.
+        assert_eq!(
+            kimi_usage_url_from_base_url("https://api.kimi.com.evil.example/coding/v1"),
+            None
+        );
+        assert_eq!(
+            kimi_usage_url_from_base_url("http://api.kimi.com/coding/v1"),
+            None
+        );
+        // Empty base URL has no coding default (Kimi defaults to Moonshot).
+        assert_eq!(kimi_usage_url_from_base_url(""), None);
     }
 
     #[test]

--- a/crates/tact_llm/src/hook_select.rs
+++ b/crates/tact_llm/src/hook_select.rs
@@ -23,12 +23,13 @@ pub fn body_hook_for(
     user_id: Option<&str>,
 ) -> Result<Arc<dyn OpenAiBodyHook>, LlmError> {
     let deepseek = || DeepSeekBodyHook::new(user_id.map(str::to_owned));
-    match info.provider {
+    match &info.provider {
         ProviderKind::DeepSeek => Ok(Arc::new(deepseek())),
         ProviderKind::Kimi => Ok(Arc::new(KimiBodyHook)),
-        ProviderKind::OpenAi => {
+        ProviderKind::OpenAi | ProviderKind::Custom(_) => {
             // `provider = openai` may still point at a Moonshot/DeepSeek-compatible
-            // base URL or model id — follow endpoint heuristics.
+            // base URL or model id — follow endpoint heuristics. Custom
+            // providers reuse the same OpenAI-compatible heuristics.
             if info.is_kimi_with(model) {
                 Ok(Arc::new(KimiBodyHook))
             } else if info.base_url.contains("deepseek") || model.contains("deepseek") {

--- a/crates/tact_llm/src/lib.rs
+++ b/crates/tact_llm/src/lib.rs
@@ -46,8 +46,9 @@ pub use models::{
 pub use openai::OpenAiBodyHook;
 pub use provider::{
     ProviderInfo, get_llm_client, get_provider, init_provider, is_account_query_supported,
-    is_deepseek, is_kimi, is_kimi_balance_supported, is_kimi_coding, is_kimi_k2x, is_kimi_k3,
-    is_kimi_k27, is_kimi_usage_supported, model_uses_effort, read_provider, supports_vision,
+    is_deepseek, is_deepseek_balance_supported, is_kimi, is_kimi_balance_supported, is_kimi_coding,
+    is_kimi_k2x, is_kimi_k3, is_kimi_k27, is_kimi_usage_supported, model_uses_effort,
+    read_provider, supports_vision,
 };
 pub use provider_state::{
     ProviderConversationState, ProviderStateUpdate, ResponsesConversationState, context_hash,

--- a/crates/tact_llm/src/models.rs
+++ b/crates/tact_llm/src/models.rs
@@ -46,8 +46,11 @@ pub fn merge_model_candidates(config: &[String], api: &[String]) -> Vec<String> 
 pub fn is_models_query_supported() -> bool {
     read_provider(|p| {
         matches!(
-            p.provider,
-            ProviderKind::OpenAi | ProviderKind::DeepSeek | ProviderKind::Kimi
+            &p.provider,
+            ProviderKind::OpenAi
+                | ProviderKind::DeepSeek
+                | ProviderKind::Kimi
+                | ProviderKind::Custom(_)
         )
     })
 }

--- a/crates/tact_llm/src/openai/responses/capabilities.rs
+++ b/crates/tact_llm/src/openai/responses/capabilities.rs
@@ -1,0 +1,80 @@
+use std::collections::BTreeSet;
+
+/// Responses tool families recognized by the wire adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ResponsesToolKind {
+    WebSearch,
+    FileSearch,
+    CodeInterpreter,
+    ImageGeneration,
+    Computer,
+    LocalShell,
+    Shell,
+    Custom,
+    Namespace,
+    ApplyPatch,
+    ToolSearch,
+    RemoteMcp,
+}
+
+/// Capabilities available on a Responses endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponsesCapabilities {
+    pub responses: bool,
+    pub streaming: bool,
+    pub compact: bool,
+    pub hosted_tools: BTreeSet<ResponsesToolKind>,
+}
+
+impl ResponsesCapabilities {
+    /// Capabilities currently implemented for the official OpenAI adapter.
+    pub fn official_openai() -> Self {
+        Self {
+            responses: true,
+            streaming: true,
+            compact: true,
+            hosted_tools: BTreeSet::new(),
+        }
+    }
+
+    /// Conservative defaults for an arbitrary OpenAI-compatible endpoint.
+    pub fn custom_provider() -> Self {
+        Self {
+            responses: true,
+            streaming: true,
+            compact: false,
+            hosted_tools: BTreeSet::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResponsesCapabilities, ResponsesToolKind};
+
+    #[test]
+    fn official_openai_defaults_to_core_responses_only() {
+        let capabilities = ResponsesCapabilities::official_openai();
+        assert!(capabilities.responses);
+        assert!(capabilities.streaming);
+        assert!(capabilities.compact);
+        assert!(capabilities.hosted_tools.is_empty());
+    }
+
+    #[test]
+    fn custom_provider_defaults_to_core_streaming_without_hosted_tools() {
+        let capabilities = ResponsesCapabilities::custom_provider();
+        assert!(capabilities.responses);
+        assert!(capabilities.streaming);
+        assert!(!capabilities.compact);
+        assert!(capabilities.hosted_tools.is_empty());
+    }
+
+    #[test]
+    fn hosted_tool_kind_is_hashable_and_ordered() {
+        let mut tools = std::collections::BTreeSet::new();
+        tools.insert(ResponsesToolKind::WebSearch);
+        tools.insert(ResponsesToolKind::FileSearch);
+        assert_eq!(tools.len(), 2);
+    }
+}

--- a/crates/tact_llm/src/openai/responses/convert.rs
+++ b/crates/tact_llm/src/openai/responses/convert.rs
@@ -177,10 +177,10 @@ fn normalize_assistant_history_items(input: &mut [serde_json::Value]) {
 }
 
 /// Validates that a persisted Responses state may be reused for the given
-/// request. The state version must be exactly 1, the provider and model must
-/// match, and the logical-message prefix represented by the state must hash
-/// to the recorded value. A mismatch is a hard protocol error; Tact must
-/// never silently duplicate, truncate, or reconstruct the baseline.
+/// request. The state version and provider must match, and the logical-message
+/// prefix represented by the state must hash to the recorded value. The model
+/// is intentionally not checked here so callers can experiment with model
+/// changes; the provider may still reject incompatible wire state.
 fn validate_conversion_state(
     state: &ResponsesConversationState,
     request: &CreateMessageParams,
@@ -195,12 +195,6 @@ fn validate_conversion_state(
         return Err(LlmError::Unsupported(format!(
             "provider state is bound to provider '{}', expected 'openai_responses'",
             state.provider
-        )));
-    }
-    if state.model != request.model {
-        return Err(LlmError::Unsupported(format!(
-            "provider state is bound to model '{}', expected '{}'",
-            state.model, request.model
         )));
     }
     if state.logical_message_count > request.messages.len() {
@@ -699,18 +693,16 @@ mod tests {
     }
 
     #[test]
-    fn state_with_mismatched_model_is_rejected() {
+    fn state_with_mismatched_model_is_allowed_for_experiment() {
         let request = request_with_history();
         let mut state = state_covering_first_message(&request);
         state.model = "other-model".to_string();
-        let error = create_response(
+        create_response(
             &request,
             Some(&crate::ProviderConversationState::OpenAiResponses(state)),
             None,
         )
-        .unwrap_err()
-        .to_string();
-        assert!(error.contains("other-model"));
+        .expect("model mismatch should not be rejected by local state validation");
     }
 
     #[test]

--- a/crates/tact_llm/src/openai/responses/convert.rs
+++ b/crates/tact_llm/src/openai/responses/convert.rs
@@ -294,6 +294,9 @@ pub(crate) fn create_response(
         LlmError::Unsupported(format!("build OpenAI Responses request: {error}"))
     })?;
     let mut body = serde_json::to_value(typed_request)?;
+    if let Some(options) = &request.responses_options {
+        options.apply_to(&mut body)?;
+    }
 
     // The exact input for this request: the state baseline (verbatim JSON)
     // followed by the newly converted uncovered items. Only the newly
@@ -326,6 +329,7 @@ pub(crate) fn create_response(
 
 #[cfg(test)]
 mod tests {
+    use super::super::ResponsesRequestOptions;
     use super::super::normalize::parse_compact_resource;
     use super::{create_response, message_to_input};
     use crate::{
@@ -690,6 +694,26 @@ mod tests {
         assert_eq!(parsed.compaction_id, "cmp_sanitized_01");
         // The retained function-call outputs survive verbatim.
         assert_eq!(parsed.input_items[0]["call_id"], "call_sanitized_1");
+    }
+
+    #[test]
+    fn responses_request_options_are_patched_into_wire_body() {
+        let request = request_with_history().with_responses_options(ResponsesRequestOptions {
+            parallel_tool_calls: Some(false),
+            ..Default::default()
+        });
+        let (body, _) = create_response(&request, None, None).unwrap();
+        assert_eq!(body["parallel_tool_calls"], false);
+    }
+
+    #[test]
+    fn responses_options_are_not_serialized_as_anthropic_fields() {
+        let request = request_with_history().with_responses_options(ResponsesRequestOptions {
+            user: Some("user-1".into()),
+            ..Default::default()
+        });
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert!(serialized.get("responses_options").is_none());
     }
 
     #[test]

--- a/crates/tact_llm/src/openai/responses/convert.rs
+++ b/crates/tact_llm/src/openai/responses/convert.rs
@@ -292,7 +292,7 @@ pub(crate) fn create_response(
     if request.thinking.is_some() || request.reasoning_effort.is_some() {
         builder.reasoning(Reasoning {
             effort: None,
-            summary: Some(ReasoningSummary::Auto),
+            summary: Some(ReasoningSummary::Detailed),
         });
     }
 
@@ -473,7 +473,7 @@ mod tests {
         let (body, _) = create_response(&request_with_history(), None, None).unwrap();
 
         assert_eq!(body["include"][0], "reasoning.encrypted_content");
-        assert_eq!(body["reasoning"]["summary"], "auto");
+        assert_eq!(body["reasoning"]["summary"], "detailed");
         let input = body["input"].as_array().unwrap();
         assert!(input.iter().all(|item| item["type"] != "reasoning"));
     }

--- a/crates/tact_llm/src/openai/responses/convert.rs
+++ b/crates/tact_llm/src/openai/responses/convert.rs
@@ -177,10 +177,10 @@ fn normalize_assistant_history_items(input: &mut [serde_json::Value]) {
 }
 
 /// Validates that a persisted Responses state may be reused for the given
-/// request. The state version must be exactly 1, the provider and model must
-/// match, and the logical-message prefix represented by the state must hash
-/// to the recorded value. A mismatch is a hard protocol error; Tact must
-/// never silently duplicate, truncate, or reconstruct the baseline.
+/// request. The state version and provider must match, and the logical-message
+/// prefix represented by the state must hash to the recorded value. The model
+/// is intentionally not checked here so callers can experiment with model
+/// changes; the provider may still reject incompatible wire state.
 fn validate_conversion_state(
     state: &ResponsesConversationState,
     request: &CreateMessageParams,
@@ -195,12 +195,6 @@ fn validate_conversion_state(
         return Err(LlmError::Unsupported(format!(
             "provider state is bound to provider '{}', expected 'openai_responses'",
             state.provider
-        )));
-    }
-    if state.model != request.model {
-        return Err(LlmError::Unsupported(format!(
-            "provider state is bound to model '{}', expected '{}'",
-            state.model, request.model
         )));
     }
     if state.logical_message_count > request.messages.len() {
@@ -300,6 +294,9 @@ pub(crate) fn create_response(
         LlmError::Unsupported(format!("build OpenAI Responses request: {error}"))
     })?;
     let mut body = serde_json::to_value(typed_request)?;
+    if let Some(options) = &request.responses_options {
+        options.apply_to(&mut body)?;
+    }
 
     // The exact input for this request: the state baseline (verbatim JSON)
     // followed by the newly converted uncovered items. Only the newly
@@ -332,6 +329,7 @@ pub(crate) fn create_response(
 
 #[cfg(test)]
 mod tests {
+    use super::super::ResponsesRequestOptions;
     use super::super::normalize::parse_compact_resource;
     use super::{create_response, message_to_input};
     use crate::{
@@ -699,18 +697,36 @@ mod tests {
     }
 
     #[test]
-    fn state_with_mismatched_model_is_rejected() {
+    fn responses_request_options_are_patched_into_wire_body() {
+        let request = request_with_history().with_responses_options(ResponsesRequestOptions {
+            parallel_tool_calls: Some(false),
+            ..Default::default()
+        });
+        let (body, _) = create_response(&request, None, None).unwrap();
+        assert_eq!(body["parallel_tool_calls"], false);
+    }
+
+    #[test]
+    fn responses_options_are_not_serialized_as_anthropic_fields() {
+        let request = request_with_history().with_responses_options(ResponsesRequestOptions {
+            user: Some("user-1".into()),
+            ..Default::default()
+        });
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert!(serialized.get("responses_options").is_none());
+    }
+
+    #[test]
+    fn state_with_mismatched_model_is_allowed_for_experiment() {
         let request = request_with_history();
         let mut state = state_covering_first_message(&request);
         state.model = "other-model".to_string();
-        let error = create_response(
+        create_response(
             &request,
             Some(&crate::ProviderConversationState::OpenAiResponses(state)),
             None,
         )
-        .unwrap_err()
-        .to_string();
-        assert!(error.contains("other-model"));
+        .expect("model mismatch should not be rejected by local state validation");
     }
 
     #[test]

--- a/crates/tact_llm/src/openai/responses/fixtures/unknown_event_stream.jsonl
+++ b/crates/tact_llm/src/openai/responses/fixtures/unknown_event_stream.jsonl
@@ -1,0 +1,6 @@
+data: {"type":"response.future.event","sequence_number":1,"payload":{"ignored":true}}
+
+data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg-1","output_index":1,"content_index":0,"delta":"hello","logprobs":[]}
+
+data: {"type":"response.completed","sequence_number":3,"response":{"created_at":1,"completed_at":2,"id":"resp_unknown_stream","model":"gpt-5","object":"response","output":[{"type":"future_item","id":"future-1","payload":{"x":1}},{"type":"message","id":"msg-1","role":"assistant","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":null,"text":"hello"}]}],"status":"completed","usage":{"input_tokens":1,"input_tokens_details":{"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2}}}
+

--- a/crates/tact_llm/src/openai/responses/fixtures/unknown_event_stream.jsonl
+++ b/crates/tact_llm/src/openai/responses/fixtures/unknown_event_stream.jsonl
@@ -1,0 +1,7 @@
+data: {"type":"response.future.event","sequence_number":1,"payload":{"ignored":true}}
+
+data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg-1","output_index":1,"content_index":0,"delta":"hello","logprobs":[]}
+
+data: {"type":"response.completed","sequence_number":3,"response":{"created_at":1,"completed_at":2,"id":"resp_unknown_stream","model":"gpt-5","object":"response","output":[{"type":"future_item","id":"future-1","payload":{"x":1}},{"type":"message","id":"msg-1","role":"assistant","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":null,"text":"hello"}]}],"status":"completed","usage":{"input_tokens":1,"input_tokens_details":{"cached_tokens":0},"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2}}}
+
+: end-of-stream

--- a/crates/tact_llm/src/openai/responses/fixtures/unknown_output_item.json
+++ b/crates/tact_llm/src/openai/responses/fixtures/unknown_output_item.json
@@ -1,0 +1,36 @@
+{
+  "created_at": 1,
+  "completed_at": 2,
+  "id": "resp_unknown_item",
+  "model": "gpt-5",
+  "object": "response",
+  "output": [
+    {
+      "type": "future_item",
+      "id": "future-1",
+      "payload": {"x": 1}
+    },
+    {
+      "type": "message",
+      "id": "msg-1",
+      "role": "assistant",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": null,
+          "text": "hello"
+        }
+      ]
+    }
+  ],
+  "status": "completed",
+  "usage": {
+    "input_tokens": 1,
+    "input_tokens_details": {"cached_tokens": 0},
+    "output_tokens": 1,
+    "output_tokens_details": {"reasoning_tokens": 0},
+    "total_tokens": 2
+  }
+}

--- a/crates/tact_llm/src/openai/responses/mod.rs
+++ b/crates/tact_llm/src/openai/responses/mod.rs
@@ -1,13 +1,15 @@
+mod capabilities;
 mod convert;
 mod history;
 mod normalize;
+mod request_options;
 mod stream;
+mod wire;
 
-use async_openai_responses::{
-    Client,
-    config::OpenAIConfig,
-    types::responses::{Response, ResponseStreamEvent},
-};
+pub use capabilities::{ResponsesCapabilities, ResponsesToolKind};
+pub use request_options::ResponsesRequestOptions;
+
+use async_openai_responses::{Client, config::OpenAIConfig, types::responses::ResponseStreamEvent};
 use futures_util::StreamExt;
 use serde_json::Value;
 use tact_protocol::AgentUpdate;
@@ -17,6 +19,7 @@ use self::{
     convert::create_response,
     normalize::{NormalizedResponse, parse_compact_resource},
     stream::ResponsesStreamState,
+    wire::parse_response_envelope,
 };
 use crate::{
     CreateMessageParams, LlmClient, LlmError, LlmRequestBody, LlmResponse,
@@ -81,14 +84,19 @@ fn normalize_stream_event_json(mut event: Value) -> Value {
     event
 }
 
-fn parse_stream_event(event: Value) -> Result<Option<ResponseStreamEvent>, LlmError> {
-    let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+struct ParsedStreamEvent {
+    event: ResponseStreamEvent,
+    raw_output_items: Option<Vec<Value>>,
+}
+
+fn parse_stream_event_with_raw(event: Value) -> Result<Option<ParsedStreamEvent>, LlmError> {
+    let Some(event_type) = event.get("type").and_then(Value::as_str).map(str::to_owned) else {
         return Err(LlmError::StreamParse(
             "missing field `type` in OpenAI Responses stream event".to_string(),
         ));
     };
     let consumed = matches!(
-        event_type,
+        event_type.as_str(),
         "error"
             | "response.reasoning_summary_text.delta"
             | "response.reasoning_text.delta"
@@ -103,13 +111,41 @@ fn parse_stream_event(event: Value) -> Result<Option<ResponseStreamEvent>, LlmEr
     if !consumed {
         return Ok(None);
     }
-    serde_json::from_value(normalize_stream_event_json(event))
-        .map(Some)
+
+    let mut event = normalize_stream_event_json(event);
+    let raw_output_items = if matches!(
+        event_type.as_str(),
+        "response.completed" | "response.incomplete" | "response.failed"
+    ) {
+        let Some(response) = event.get("response").cloned() else {
+            return Err(LlmError::StreamParse(
+                "terminal OpenAI Responses event is missing response".to_string(),
+            ));
+        };
+        let envelope = wire::parse_response_envelope(response)?;
+        event["response"] = serde_json::to_value(envelope.typed)?;
+        Some(envelope.output_items)
+    } else {
+        None
+    };
+
+    serde_json::from_value(event)
+        .map(|event| {
+            Some(ParsedStreamEvent {
+                event,
+                raw_output_items,
+            })
+        })
         .map_err(|error| {
             LlmError::StreamParse(format!(
                 "deserialize OpenAI Responses stream event: {error}"
             ))
         })
+}
+
+#[cfg(test)]
+fn parse_stream_event(event: Value) -> Result<Option<ResponseStreamEvent>, LlmError> {
+    Ok(parse_stream_event_with_raw(event)?.map(|parsed| parsed.event))
 }
 
 /// OpenAI Responses API adapter backed by async-openai 0.41.x.
@@ -232,8 +268,8 @@ impl LlmClient for OpenAiResponsesAdapter {
 
         while let Some(result) = response_stream.next().await {
             let event = match result {
-                Ok(event) => match parse_stream_event(event)? {
-                    Some(event) => event,
+                Ok(event) => match parse_stream_event_with_raw(event)? {
+                    Some(parsed) => (parsed.event, parsed.raw_output_items),
                     None => continue,
                 },
                 Err(error) => {
@@ -245,7 +281,7 @@ impl LlmClient for OpenAiResponsesAdapter {
                     return Err(LlmError::from(error));
                 }
             };
-            let updates = match state.apply(event) {
+            let updates = match state.apply_with_raw(event.0, event.1) {
                 Ok(updates) => updates,
                 Err(error) => {
                     if let Some(update) = state.close_thinking()
@@ -292,10 +328,19 @@ impl LlmClient for OpenAiResponsesAdapter {
         let response = self
             .client
             .responses()
-            .create_byot::<_, Response>(wire_request)
+            .create_byot::<_, Value>(wire_request)
             .await
             .map_err(LlmError::from)?;
-        let normalized = normalize::normalize_response(response)?;
+        let envelope = parse_response_envelope(response)?;
+        let wire::RawResponseEnvelope {
+            value,
+            typed,
+            output_items,
+            unknown_output_items,
+        } = envelope;
+        drop((value, unknown_output_items));
+        let mut normalized = normalize::normalize_response(typed)?;
+        normalized.output_items = output_items;
         let state_update = self.state_update(&normalized, request, input_items)?;
         Ok(Self::into_result(normalized, request_body, state_update))
     }
@@ -355,7 +400,8 @@ impl LlmClient for OpenAiResponsesAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_stream_event_json, parse_stream_event};
+    use super::stream::ResponsesStreamState;
+    use super::{normalize_stream_event_json, parse_stream_event, parse_stream_event_with_raw};
     use crate::{
         ContentBlock, CreateMessageParams, LlmClient, Message, RequiredMessageParams, Role,
         StopReason, Tool,
@@ -392,6 +438,54 @@ mod tests {
         .unwrap();
 
         assert!(event.is_none());
+    }
+
+    #[test]
+    fn parses_terminal_unknown_item_with_raw_output_metadata() {
+        let mut response = super::normalize::tests::completed_response_json();
+        response["output"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({
+                "type": "future_item",
+                "id": "future-1",
+                "payload": {"x": 1}
+            }),
+        );
+        let parsed = parse_stream_event_with_raw(serde_json::json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": response
+        }))
+        .unwrap()
+        .unwrap();
+        assert!(parsed.raw_output_items.is_some());
+        assert_eq!(parsed.raw_output_items.unwrap()[0]["type"], "future_item");
+    }
+
+    #[test]
+    fn stream_finish_retains_unknown_terminal_items_for_state() {
+        let mut response = super::normalize::tests::completed_response_json();
+        response["output"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({
+                "type": "future_item",
+                "id": "future-1",
+                "payload": {"x": 1}
+            }),
+        );
+        let parsed = parse_stream_event_with_raw(serde_json::json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": response
+        }))
+        .unwrap()
+        .unwrap();
+        let mut state = ResponsesStreamState::default();
+        state
+            .apply_with_raw(parsed.event, parsed.raw_output_items)
+            .unwrap();
+        let normalized = state.finish().unwrap();
+        assert_eq!(normalized.output_items[0]["type"], "future_item");
     }
 
     #[test]
@@ -813,6 +907,59 @@ mod tests {
         serde_json::from_slice(&requests[0].body).unwrap()
     }
 
+    #[test]
+    fn unknown_output_fixture_is_well_formed() {
+        let fixture: serde_json::Value =
+            serde_json::from_str(include_str!("fixtures/unknown_output_item.json")).unwrap();
+        assert_eq!(fixture["output"][0]["type"], "future_item");
+        assert_eq!(fixture["output"][1]["type"], "message");
+    }
+
+    #[tokio::test]
+    async fn ordinary_response_state_update_retains_unknown_output_item() {
+        let server = MockServer::start().await;
+        let mut response = completed_response_value();
+        response["output"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({
+                "type": "future_item",
+                "id": "future-1",
+                "payload": {"x": 1}
+            }),
+        );
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let info = crate::ProviderInfo {
+            api_key: "test-key".to_string(),
+            base_url: server.uri(),
+            model: "gpt-5".to_string(),
+            provider: crate::ProviderKind::OpenAi,
+            protocol: crate::OpenAiProtocol::Responses,
+            responses_compact_threshold: None,
+        };
+        let crate::LlmProvider::OpenAiResponses(adapter) = info.build_client().unwrap() else {
+            panic!("expected OpenAiResponses adapter");
+        };
+        let response = adapter
+            .create_message(&simple_request(), None)
+            .await
+            .expect("unknown output item must not abort ordinary response");
+        let crate::ProviderStateUpdate::Replace(crate::ProviderConversationState::OpenAiResponses(
+            state,
+        )) = response.state_update
+        else {
+            panic!("expected Responses state replacement");
+        };
+        assert_eq!(state.input_items[0]["type"], "message");
+        assert_eq!(state.input_items[1]["type"], "future_item");
+        server.verify().await;
+    }
+
     #[tokio::test]
     async fn ordinary_responses_request_includes_context_management_when_threshold_configured() {
         let server = MockServer::start().await;
@@ -898,6 +1045,39 @@ mod tests {
             body["context_management"][0]["compact_threshold"],
             serde_json::json!(160_000),
             "streamed ordinary request must carry the configured threshold, got: {body}"
+        );
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn unknown_stream_fixture_keeps_visible_text_and_state_item() {
+        let server = MockServer::start().await;
+        let sse = include_str!("fixtures/unknown_event_stream.jsonl");
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse, "text/event-stream"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let adapter = super::OpenAiResponsesAdapter::new("test-key", server.uri(), None);
+        let response = adapter
+            .stream_message(&simple_request(), None, None)
+            .await
+            .expect("unknown stream event must not abort response");
+        assert!(response.blocks.iter().any(|block| {
+            matches!(block, crate::ContentBlock::Text { text } if text == "hello")
+        }));
+        let crate::ProviderStateUpdate::Replace(crate::ProviderConversationState::OpenAiResponses(
+            state,
+        )) = response.state_update
+        else {
+            panic!("expected Responses state replacement");
+        };
+        assert!(
+            state
+                .input_items
+                .iter()
+                .any(|item| item["type"] == "future_item")
         );
         server.verify().await;
     }

--- a/crates/tact_llm/src/openai/responses/mod.rs
+++ b/crates/tact_llm/src/openai/responses/mod.rs
@@ -1,13 +1,15 @@
+mod capabilities;
 mod convert;
 mod history;
 mod normalize;
+mod request_options;
 mod stream;
+mod wire;
 
-use async_openai_responses::{
-    Client,
-    config::OpenAIConfig,
-    types::responses::{Response, ResponseStreamEvent},
-};
+pub use capabilities::{ResponsesCapabilities, ResponsesToolKind};
+pub use request_options::ResponsesRequestOptions;
+
+use async_openai_responses::{Client, config::OpenAIConfig, types::responses::ResponseStreamEvent};
 use futures_util::StreamExt;
 use serde_json::Value;
 use tact_protocol::AgentUpdate;
@@ -17,6 +19,7 @@ use self::{
     convert::create_response,
     normalize::{NormalizedResponse, parse_compact_resource},
     stream::ResponsesStreamState,
+    wire::parse_response_envelope,
 };
 use crate::{
     CreateMessageParams, LlmClient, LlmError, LlmRequestBody, LlmResponse,
@@ -81,14 +84,19 @@ fn normalize_stream_event_json(mut event: Value) -> Value {
     event
 }
 
-fn parse_stream_event(event: Value) -> Result<Option<ResponseStreamEvent>, LlmError> {
-    let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+struct ParsedStreamEvent {
+    event: ResponseStreamEvent,
+    raw_output_items: Option<Vec<Value>>,
+}
+
+fn parse_stream_event_with_raw(event: Value) -> Result<Option<ParsedStreamEvent>, LlmError> {
+    let Some(event_type) = event.get("type").and_then(Value::as_str).map(str::to_owned) else {
         return Err(LlmError::StreamParse(
             "missing field `type` in OpenAI Responses stream event".to_string(),
         ));
     };
     let consumed = matches!(
-        event_type,
+        event_type.as_str(),
         "error"
             | "response.reasoning_summary_text.delta"
             | "response.reasoning_text.delta"
@@ -103,13 +111,41 @@ fn parse_stream_event(event: Value) -> Result<Option<ResponseStreamEvent>, LlmEr
     if !consumed {
         return Ok(None);
     }
-    serde_json::from_value(normalize_stream_event_json(event))
-        .map(Some)
+
+    let mut event = normalize_stream_event_json(event);
+    let raw_output_items = if matches!(
+        event_type.as_str(),
+        "response.completed" | "response.incomplete" | "response.failed"
+    ) {
+        let Some(response) = event.get("response").cloned() else {
+            return Err(LlmError::StreamParse(
+                "terminal OpenAI Responses event is missing response".to_string(),
+            ));
+        };
+        let envelope = wire::parse_response_envelope(response)?;
+        event["response"] = serde_json::to_value(envelope.typed)?;
+        Some(envelope.output_items)
+    } else {
+        None
+    };
+
+    serde_json::from_value(event)
+        .map(|event| {
+            Some(ParsedStreamEvent {
+                event,
+                raw_output_items,
+            })
+        })
         .map_err(|error| {
             LlmError::StreamParse(format!(
                 "deserialize OpenAI Responses stream event: {error}"
             ))
         })
+}
+
+#[cfg(test)]
+fn parse_stream_event(event: Value) -> Result<Option<ResponseStreamEvent>, LlmError> {
+    Ok(parse_stream_event_with_raw(event)?.map(|parsed| parsed.event))
 }
 
 /// OpenAI Responses API adapter backed by async-openai 0.41.x.
@@ -160,12 +196,10 @@ impl OpenAiResponsesAdapter {
     }
 
     /// Validates that a persisted Responses state is bound to this adapter's
-    /// provider, base URL, and request model before it is reused.
-    fn validate_state_binding(
-        &self,
-        state: &ResponsesConversationState,
-        model: &str,
-    ) -> Result<(), LlmError> {
+    /// provider and base URL. Model mismatches are intentionally allowed for
+    /// experimentation; the provider may reject incompatible opaque state at
+    /// request time.
+    fn validate_state_binding(&self, state: &ResponsesConversationState) -> Result<(), LlmError> {
         if state.provider != "openai_responses" {
             return Err(LlmError::Unsupported(format!(
                 "provider state is bound to provider '{}', expected 'openai_responses'",
@@ -176,12 +210,6 @@ impl OpenAiResponsesAdapter {
             return Err(LlmError::Unsupported(format!(
                 "provider state is bound to base URL '{}', expected '{}'",
                 state.base_url, self.base_url
-            )));
-        }
-        if state.model != model {
-            return Err(LlmError::Unsupported(format!(
-                "provider state is bound to model '{}', expected '{}'",
-                state.model, model
             )));
         }
         Ok(())
@@ -225,7 +253,7 @@ impl LlmClient for OpenAiResponsesAdapter {
         ui_tx: Option<UnboundedSender<AgentUpdate>>,
     ) -> Result<LlmResponse, LlmError> {
         if let Some(ProviderConversationState::OpenAiResponses(state)) = provider_state {
-            self.validate_state_binding(state, &request.model)?;
+            self.validate_state_binding(state)?;
         }
         let (mut wire_request, input_items) = self.build_wire_request(request, provider_state)?;
         wire_request["stream"] = serde_json::Value::Bool(true);
@@ -240,8 +268,8 @@ impl LlmClient for OpenAiResponsesAdapter {
 
         while let Some(result) = response_stream.next().await {
             let event = match result {
-                Ok(event) => match parse_stream_event(event)? {
-                    Some(event) => event,
+                Ok(event) => match parse_stream_event_with_raw(event)? {
+                    Some(parsed) => (parsed.event, parsed.raw_output_items),
                     None => continue,
                 },
                 Err(error) => {
@@ -253,7 +281,7 @@ impl LlmClient for OpenAiResponsesAdapter {
                     return Err(LlmError::from(error));
                 }
             };
-            let updates = match state.apply(event) {
+            let updates = match state.apply_with_raw(event.0, event.1) {
                 Ok(updates) => updates,
                 Err(error) => {
                     if let Some(update) = state.close_thinking()
@@ -292,7 +320,7 @@ impl LlmClient for OpenAiResponsesAdapter {
         provider_state: Option<&ProviderConversationState>,
     ) -> Result<LlmResponse, LlmError> {
         if let Some(ProviderConversationState::OpenAiResponses(state)) = provider_state {
-            self.validate_state_binding(state, &request.model)?;
+            self.validate_state_binding(state)?;
         }
         let (mut wire_request, input_items) = self.build_wire_request(request, provider_state)?;
         wire_request["stream"] = serde_json::Value::Bool(false);
@@ -300,10 +328,19 @@ impl LlmClient for OpenAiResponsesAdapter {
         let response = self
             .client
             .responses()
-            .create_byot::<_, Response>(wire_request)
+            .create_byot::<_, Value>(wire_request)
             .await
             .map_err(LlmError::from)?;
-        let normalized = normalize::normalize_response(response)?;
+        let envelope = parse_response_envelope(response)?;
+        let wire::RawResponseEnvelope {
+            value,
+            typed,
+            output_items,
+            unknown_output_items,
+        } = envelope;
+        drop((value, unknown_output_items));
+        let mut normalized = normalize::normalize_response(typed)?;
+        normalized.output_items = output_items;
         let state_update = self.state_update(&normalized, request, input_items)?;
         Ok(Self::into_result(normalized, request_body, state_update))
     }
@@ -314,7 +351,7 @@ impl LlmClient for OpenAiResponsesAdapter {
         provider_state: Option<&ProviderConversationState>,
     ) -> Result<LlmResponse, LlmError> {
         if let Some(ProviderConversationState::OpenAiResponses(state)) = provider_state {
-            self.validate_state_binding(state, &request.model)?;
+            self.validate_state_binding(state)?;
         }
         // The compact request carries the current protocol baseline plus any
         // logical messages not yet represented in it. The exact JSON input
@@ -363,7 +400,8 @@ impl LlmClient for OpenAiResponsesAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_stream_event_json, parse_stream_event};
+    use super::stream::ResponsesStreamState;
+    use super::{normalize_stream_event_json, parse_stream_event, parse_stream_event_with_raw};
     use crate::{
         ContentBlock, CreateMessageParams, LlmClient, Message, RequiredMessageParams, Role,
         StopReason, Tool,
@@ -400,6 +438,54 @@ mod tests {
         .unwrap();
 
         assert!(event.is_none());
+    }
+
+    #[test]
+    fn parses_terminal_unknown_item_with_raw_output_metadata() {
+        let mut response = super::normalize::tests::completed_response_json();
+        response["output"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({
+                "type": "future_item",
+                "id": "future-1",
+                "payload": {"x": 1}
+            }),
+        );
+        let parsed = parse_stream_event_with_raw(serde_json::json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": response
+        }))
+        .unwrap()
+        .unwrap();
+        assert!(parsed.raw_output_items.is_some());
+        assert_eq!(parsed.raw_output_items.unwrap()[0]["type"], "future_item");
+    }
+
+    #[test]
+    fn stream_finish_retains_unknown_terminal_items_for_state() {
+        let mut response = super::normalize::tests::completed_response_json();
+        response["output"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({
+                "type": "future_item",
+                "id": "future-1",
+                "payload": {"x": 1}
+            }),
+        );
+        let parsed = parse_stream_event_with_raw(serde_json::json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": response
+        }))
+        .unwrap()
+        .unwrap();
+        let mut state = ResponsesStreamState::default();
+        state
+            .apply_with_raw(parsed.event, parsed.raw_output_items)
+            .unwrap();
+        let normalized = state.finish().unwrap();
+        assert_eq!(normalized.output_items[0]["type"], "future_item");
     }
 
     #[test]
@@ -544,10 +630,10 @@ mod tests {
     }
 
     #[test]
-    fn state_binding_accepts_matching_provider_base_url_and_model() {
+    fn state_binding_accepts_matching_provider_and_base_url() {
         let (adapter, state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         adapter
-            .validate_state_binding(&state, "gpt-5")
+            .validate_state_binding(&state)
             .expect("matching binding is valid");
     }
 
@@ -556,7 +642,7 @@ mod tests {
         let (adapter, mut state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         state.provider = "anthropic".to_string();
         let error = adapter
-            .validate_state_binding(&state, "gpt-5")
+            .validate_state_binding(&state)
             .unwrap_err()
             .to_string();
         assert!(error.contains("anthropic"));
@@ -568,21 +654,19 @@ mod tests {
         let (adapter, mut state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         state.base_url = "https://other.example.com/v1".to_string();
         let error = adapter
-            .validate_state_binding(&state, "gpt-5")
+            .validate_state_binding(&state)
             .unwrap_err()
             .to_string();
         assert!(error.contains("other.example.com"));
     }
 
     #[test]
-    fn state_binding_rejects_another_model() {
+    fn state_binding_allows_another_model_for_experiment() {
         let (adapter, mut state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         state.model = "gpt-4o".to_string();
-        let error = adapter
-            .validate_state_binding(&state, "gpt-5")
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("gpt-4o"));
+        adapter
+            .validate_state_binding(&state)
+            .expect("model mismatch should not be rejected by local state validation");
     }
 
     /// Run with:
@@ -823,6 +907,59 @@ mod tests {
         serde_json::from_slice(&requests[0].body).unwrap()
     }
 
+    #[test]
+    fn unknown_output_fixture_is_well_formed() {
+        let fixture: serde_json::Value =
+            serde_json::from_str(include_str!("fixtures/unknown_output_item.json")).unwrap();
+        assert_eq!(fixture["output"][0]["type"], "future_item");
+        assert_eq!(fixture["output"][1]["type"], "message");
+    }
+
+    #[tokio::test]
+    async fn ordinary_response_state_update_retains_unknown_output_item() {
+        let server = MockServer::start().await;
+        let mut response = completed_response_value();
+        response["output"].as_array_mut().unwrap().insert(
+            0,
+            serde_json::json!({
+                "type": "future_item",
+                "id": "future-1",
+                "payload": {"x": 1}
+            }),
+        );
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let info = crate::ProviderInfo {
+            api_key: "test-key".to_string(),
+            base_url: server.uri(),
+            model: "gpt-5".to_string(),
+            provider: crate::ProviderKind::OpenAi,
+            protocol: crate::OpenAiProtocol::Responses,
+            responses_compact_threshold: None,
+        };
+        let crate::LlmProvider::OpenAiResponses(adapter) = info.build_client().unwrap() else {
+            panic!("expected OpenAiResponses adapter");
+        };
+        let response = adapter
+            .create_message(&simple_request(), None)
+            .await
+            .expect("unknown output item must not abort ordinary response");
+        let crate::ProviderStateUpdate::Replace(crate::ProviderConversationState::OpenAiResponses(
+            state,
+        )) = response.state_update
+        else {
+            panic!("expected Responses state replacement");
+        };
+        assert_eq!(state.input_items[0]["type"], "message");
+        assert_eq!(state.input_items[1]["type"], "future_item");
+        server.verify().await;
+    }
+
     #[tokio::test]
     async fn ordinary_responses_request_includes_context_management_when_threshold_configured() {
         let server = MockServer::start().await;
@@ -908,6 +1045,39 @@ mod tests {
             body["context_management"][0]["compact_threshold"],
             serde_json::json!(160_000),
             "streamed ordinary request must carry the configured threshold, got: {body}"
+        );
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn unknown_stream_fixture_keeps_visible_text_and_state_item() {
+        let server = MockServer::start().await;
+        let sse = include_str!("fixtures/unknown_event_stream.jsonl");
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(sse, "text/event-stream"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let adapter = super::OpenAiResponsesAdapter::new("test-key", server.uri(), None);
+        let response = adapter
+            .stream_message(&simple_request(), None, None)
+            .await
+            .expect("unknown stream event must not abort response");
+        assert!(response.blocks.iter().any(|block| {
+            matches!(block, crate::ContentBlock::Text { text } if text == "hello")
+        }));
+        let crate::ProviderStateUpdate::Replace(crate::ProviderConversationState::OpenAiResponses(
+            state,
+        )) = response.state_update
+        else {
+            panic!("expected Responses state replacement");
+        };
+        assert!(
+            state
+                .input_items
+                .iter()
+                .any(|item| item["type"] == "future_item")
         );
         server.verify().await;
     }

--- a/crates/tact_llm/src/openai/responses/mod.rs
+++ b/crates/tact_llm/src/openai/responses/mod.rs
@@ -160,12 +160,10 @@ impl OpenAiResponsesAdapter {
     }
 
     /// Validates that a persisted Responses state is bound to this adapter's
-    /// provider, base URL, and request model before it is reused.
-    fn validate_state_binding(
-        &self,
-        state: &ResponsesConversationState,
-        model: &str,
-    ) -> Result<(), LlmError> {
+    /// provider and base URL. Model mismatches are intentionally allowed for
+    /// experimentation; the provider may reject incompatible opaque state at
+    /// request time.
+    fn validate_state_binding(&self, state: &ResponsesConversationState) -> Result<(), LlmError> {
         if state.provider != "openai_responses" {
             return Err(LlmError::Unsupported(format!(
                 "provider state is bound to provider '{}', expected 'openai_responses'",
@@ -176,12 +174,6 @@ impl OpenAiResponsesAdapter {
             return Err(LlmError::Unsupported(format!(
                 "provider state is bound to base URL '{}', expected '{}'",
                 state.base_url, self.base_url
-            )));
-        }
-        if state.model != model {
-            return Err(LlmError::Unsupported(format!(
-                "provider state is bound to model '{}', expected '{}'",
-                state.model, model
             )));
         }
         Ok(())
@@ -225,7 +217,7 @@ impl LlmClient for OpenAiResponsesAdapter {
         ui_tx: Option<UnboundedSender<AgentUpdate>>,
     ) -> Result<LlmResponse, LlmError> {
         if let Some(ProviderConversationState::OpenAiResponses(state)) = provider_state {
-            self.validate_state_binding(state, &request.model)?;
+            self.validate_state_binding(state)?;
         }
         let (mut wire_request, input_items) = self.build_wire_request(request, provider_state)?;
         wire_request["stream"] = serde_json::Value::Bool(true);
@@ -292,7 +284,7 @@ impl LlmClient for OpenAiResponsesAdapter {
         provider_state: Option<&ProviderConversationState>,
     ) -> Result<LlmResponse, LlmError> {
         if let Some(ProviderConversationState::OpenAiResponses(state)) = provider_state {
-            self.validate_state_binding(state, &request.model)?;
+            self.validate_state_binding(state)?;
         }
         let (mut wire_request, input_items) = self.build_wire_request(request, provider_state)?;
         wire_request["stream"] = serde_json::Value::Bool(false);
@@ -314,7 +306,7 @@ impl LlmClient for OpenAiResponsesAdapter {
         provider_state: Option<&ProviderConversationState>,
     ) -> Result<LlmResponse, LlmError> {
         if let Some(ProviderConversationState::OpenAiResponses(state)) = provider_state {
-            self.validate_state_binding(state, &request.model)?;
+            self.validate_state_binding(state)?;
         }
         // The compact request carries the current protocol baseline plus any
         // logical messages not yet represented in it. The exact JSON input
@@ -544,10 +536,10 @@ mod tests {
     }
 
     #[test]
-    fn state_binding_accepts_matching_provider_base_url_and_model() {
+    fn state_binding_accepts_matching_provider_and_base_url() {
         let (adapter, state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         adapter
-            .validate_state_binding(&state, "gpt-5")
+            .validate_state_binding(&state)
             .expect("matching binding is valid");
     }
 
@@ -556,7 +548,7 @@ mod tests {
         let (adapter, mut state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         state.provider = "anthropic".to_string();
         let error = adapter
-            .validate_state_binding(&state, "gpt-5")
+            .validate_state_binding(&state)
             .unwrap_err()
             .to_string();
         assert!(error.contains("anthropic"));
@@ -568,21 +560,19 @@ mod tests {
         let (adapter, mut state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         state.base_url = "https://other.example.com/v1".to_string();
         let error = adapter
-            .validate_state_binding(&state, "gpt-5")
+            .validate_state_binding(&state)
             .unwrap_err()
             .to_string();
         assert!(error.contains("other.example.com"));
     }
 
     #[test]
-    fn state_binding_rejects_another_model() {
+    fn state_binding_allows_another_model_for_experiment() {
         let (adapter, mut state) = adapter_with_state("https://api.openai.com/v1", "gpt-5");
         state.model = "gpt-4o".to_string();
-        let error = adapter
-            .validate_state_binding(&state, "gpt-5")
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("gpt-4o"));
+        adapter
+            .validate_state_binding(&state)
+            .expect("model mismatch should not be rejected by local state validation");
     }
 
     /// Run with:

--- a/crates/tact_llm/src/openai/responses/normalize.rs
+++ b/crates/tact_llm/src/openai/responses/normalize.rs
@@ -182,10 +182,9 @@ pub(crate) fn normalize_response(response: Response) -> Result<NormalizedRespons
             OutputItem::Compaction(_) => {}
             // Unmapped output items known to the typed SDK (file search, web
             // search, computer use, …) produce no ContentBlock but are
-            // retained as JSON in `output_items`. A truly unknown future item
-            // type is rejected earlier by the typed SDK boundary (async-openai
-            // `OutputItem` has no `Unknown` variant): hard protocol error,
-            // never a silent drop or fallback.
+            // retained as JSON in `output_items`. Truly unknown future items
+            // are filtered by the raw wire boundary before this typed
+            // normalization path and are restored from the raw sequence.
             _ => {}
         }
     }

--- a/crates/tact_llm/src/openai/responses/request_options.rs
+++ b/crates/tact_llm/src/openai/responses/request_options.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::LlmError;
+
+/// Responses-only request fields that do not belong in the shared
+/// Anthropic/Chat Completions-shaped request model.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResponsesRequestOptions {
+    pub parallel_tool_calls: Option<bool>,
+    pub truncation: Option<String>,
+    pub metadata: Option<Map<String, Value>>,
+    pub user: Option<String>,
+    pub prompt_cache_key: Option<String>,
+    pub text: Option<Value>,
+    pub extra: Map<String, Value>,
+}
+
+impl ResponsesRequestOptions {
+    pub(crate) fn apply_to(&self, body: &mut Value) -> Result<(), LlmError> {
+        let object = body.as_object_mut().ok_or_else(|| {
+            LlmError::Unsupported("Responses request body must be a JSON object".to_string())
+        })?;
+
+        if let Some(value) = self.parallel_tool_calls {
+            object.insert("parallel_tool_calls".to_string(), Value::Bool(value));
+        }
+        if let Some(value) = &self.truncation {
+            object.insert("truncation".to_string(), Value::String(value.clone()));
+        }
+        if let Some(value) = &self.metadata {
+            object.insert("metadata".to_string(), Value::Object(value.clone()));
+        }
+        if let Some(value) = &self.user {
+            object.insert("user".to_string(), Value::String(value.clone()));
+        }
+        if let Some(value) = &self.prompt_cache_key {
+            object.insert("prompt_cache_key".to_string(), Value::String(value.clone()));
+        }
+        if let Some(value) = &self.text {
+            object.insert("text".to_string(), value.clone());
+        }
+
+        const RESERVED: &[&str] = &[
+            "parallel_tool_calls",
+            "truncation",
+            "metadata",
+            "user",
+            "prompt_cache_key",
+            "text",
+            "model",
+            "input",
+            "instructions",
+            "tools",
+            "tool_choice",
+            "reasoning",
+            "include",
+            "max_output_tokens",
+            "temperature",
+            "top_p",
+            "store",
+            "context_management",
+            "stream",
+        ];
+        for (key, value) in &self.extra {
+            if RESERVED.contains(&key.as_str()) || object.contains_key(key) {
+                return Err(LlmError::Unsupported(format!(
+                    "Responses request option '{key}' conflicts with an existing field"
+                )));
+            }
+            object.insert(key.clone(), value.clone());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResponsesRequestOptions;
+
+    #[test]
+    fn responses_options_patch_only_populates_responses_fields() {
+        let options = ResponsesRequestOptions {
+            parallel_tool_calls: Some(false),
+            truncation: Some("auto".into()),
+            metadata: Some(serde_json::Map::from_iter([(
+                "ticket".into(),
+                serde_json::json!("r-1"),
+            )])),
+            user: Some("user-1".into()),
+            prompt_cache_key: Some("cache-1".into()),
+            text: Some(serde_json::json!({"format": {"type": "text"}})),
+            extra: Default::default(),
+        };
+        let mut body = serde_json::json!({"model": "gpt-5", "input": []});
+        options.apply_to(&mut body).unwrap();
+        assert_eq!(body["parallel_tool_calls"], false);
+        assert_eq!(body["truncation"], "auto");
+        assert_eq!(body["metadata"]["ticket"], "r-1");
+        assert_eq!(body["user"], "user-1");
+        assert_eq!(body["prompt_cache_key"], "cache-1");
+        assert_eq!(body["text"]["format"]["type"], "text");
+    }
+
+    #[test]
+    fn responses_options_rejects_extra_collision() {
+        let options = ResponsesRequestOptions {
+            extra: serde_json::Map::from_iter([("text".into(), serde_json::json!("bad"))]),
+            ..Default::default()
+        };
+        let mut body = serde_json::json!({});
+        let error = options.apply_to(&mut body).unwrap_err().to_string();
+        assert!(error.contains("Responses request option 'text'"));
+    }
+}

--- a/crates/tact_llm/src/openai/responses/stream.rs
+++ b/crates/tact_llm/src/openai/responses/stream.rs
@@ -24,6 +24,7 @@ pub(crate) struct ResponsesStreamState {
     /// hard-fail in `finish()` rather than fall back to visible-text recovery,
     /// which would silently drop the compacted baseline.
     pending_compactions: BTreeSet<u32>,
+    raw_terminal_output: Option<Vec<serde_json::Value>>,
 }
 
 impl ResponsesStreamState {
@@ -73,10 +74,22 @@ impl ResponsesStreamState {
         Ok(self.close_thinking().into_iter().collect())
     }
 
+    #[cfg(test)]
     pub(crate) fn apply(
         &mut self,
         event: ResponseStreamEvent,
     ) -> Result<Vec<AgentUpdate>, LlmError> {
+        self.apply_with_raw(event, None)
+    }
+
+    pub(crate) fn apply_with_raw(
+        &mut self,
+        event: ResponseStreamEvent,
+        raw_output_items: Option<Vec<serde_json::Value>>,
+    ) -> Result<Vec<AgentUpdate>, LlmError> {
+        if raw_output_items.is_some() {
+            self.raw_terminal_output = raw_output_items;
+        }
         if let ResponseStreamEvent::ResponseError(event) = event {
             let code = event.code.as_deref().unwrap_or("unknown_error");
             let param = event
@@ -142,6 +155,7 @@ impl ResponsesStreamState {
             done_items,
             pending_added,
             pending_compactions,
+            raw_terminal_output,
             ..
         } = self;
         let response = terminal.ok_or_else(|| {
@@ -204,6 +218,9 @@ impl ResponsesStreamState {
             normalized
                 .blocks
                 .push(crate::ContentBlock::Text { text: output_text });
+        }
+        if let Some(raw_output_items) = raw_terminal_output {
+            normalized.output_items = raw_output_items;
         }
         Ok(normalized)
     }

--- a/crates/tact_llm/src/openai/responses/wire.rs
+++ b/crates/tact_llm/src/openai/responses/wire.rs
@@ -1,0 +1,143 @@
+use async_openai_responses::types::responses::{OutputItem, Response};
+use serde_json::Value;
+
+use crate::LlmError;
+
+pub(crate) struct RawResponseEnvelope {
+    pub(crate) value: Value,
+    pub(crate) typed: Response,
+    pub(crate) output_items: Vec<Value>,
+    pub(crate) unknown_output_items: Vec<Value>,
+}
+
+pub(crate) fn raw_output_items(value: &Value) -> Result<Vec<Value>, LlmError> {
+    let object = value.as_object().ok_or_else(|| {
+        LlmError::Unsupported("OpenAI Responses response must be a JSON object".to_string())
+    })?;
+    let output = object.get("output").ok_or_else(|| {
+        LlmError::Unsupported("OpenAI Responses response is missing output".to_string())
+    })?;
+    let output = output.as_array().ok_or_else(|| {
+        LlmError::Unsupported("OpenAI Responses response output must be an array".to_string())
+    })?;
+    Ok(output.clone())
+}
+
+fn known_output_type(type_name: &str) -> bool {
+    matches!(
+        type_name,
+        "message"
+            | "file_search_call"
+            | "function_call"
+            | "function_call_output"
+            | "web_search_call"
+            | "computer_call"
+            | "computer_call_output"
+            | "reasoning"
+            | "compaction"
+            | "image_generation_call"
+            | "code_interpreter_call"
+            | "local_shell_call"
+            | "shell_call"
+            | "shell_call_output"
+            | "apply_patch_call"
+            | "apply_patch_call_output"
+            | "mcp_call"
+            | "mcp_list_tools"
+            | "mcp_approval_request"
+            | "custom_tool_call"
+            | "custom_tool_call_output"
+            | "tool_search_call"
+            | "tool_search_output"
+    )
+}
+
+pub(crate) fn parse_response_envelope(value: Value) -> Result<RawResponseEnvelope, LlmError> {
+    let output_items = raw_output_items(&value)?;
+    let mut typed_items = Vec::with_capacity(output_items.len());
+    let mut unknown_output_items = Vec::new();
+
+    for item in &output_items {
+        let type_name = item.get("type").and_then(Value::as_str).ok_or_else(|| {
+            LlmError::Unsupported("OpenAI Responses output item is missing type".to_string())
+        })?;
+        match serde_json::from_value::<OutputItem>(item.clone()) {
+            Ok(parsed) => typed_items.push(parsed),
+            Err(_error) if !known_output_type(type_name) => {
+                unknown_output_items.push(item.clone());
+            }
+            Err(error) => {
+                return Err(LlmError::Unsupported(format!(
+                    "deserialize known OpenAI Responses output item '{type_name}': {error}"
+                )));
+            }
+        }
+    }
+
+    let mut typed_value = value.clone();
+    typed_value["output"] = Value::Array(
+        output_items
+            .iter()
+            .filter(|item| {
+                item.get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(known_output_type)
+            })
+            .cloned()
+            .collect(),
+    );
+    let typed: Response = serde_json::from_value(typed_value).map_err(|error| {
+        LlmError::Unsupported(format!(
+            "deserialize OpenAI Responses response envelope: {error}"
+        ))
+    })?;
+
+    // Keep the parsed values alive in the same order as the raw wire response;
+    // the typed surrogate is only for known-item normalization.
+    debug_assert_eq!(typed.output.len(), typed_items.len());
+    Ok(RawResponseEnvelope {
+        value,
+        typed,
+        output_items,
+        unknown_output_items,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_response_envelope;
+    use async_openai_responses::types::responses::OutputItem;
+
+    fn response_with_unknown_output_item() -> serde_json::Value {
+        serde_json::json!({
+            "created_at": 1,
+            "completed_at": 2,
+            "id": "resp_unknown_item",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5",
+            "output": [
+                {"type": "future_item", "id": "future-1", "payload": {"x": 1}},
+                {"type": "message", "id": "msg-1", "status": "completed", "role": "assistant",
+                 "content": [{"type": "output_text", "text": "hello", "annotations": []}]}
+            ],
+            "usage": {"input_tokens": 1, "input_tokens_details": {"cached_tokens": 0},
+                      "output_tokens": 1, "output_tokens_details": {"reasoning_tokens": 0},
+                      "total_tokens": 2}
+        })
+    }
+
+    #[test]
+    fn unknown_output_item_is_retained_before_typed_normalization() {
+        let parsed = parse_response_envelope(response_with_unknown_output_item()).unwrap();
+        assert_eq!(parsed.value["id"], "resp_unknown_item");
+        assert_eq!(parsed.output_items.len(), 2);
+        assert_eq!(
+            parsed.unknown_output_items,
+            vec![serde_json::json!({
+                "type": "future_item", "id": "future-1", "payload": {"x": 1}
+            })]
+        );
+        assert!(matches!(parsed.typed.output[0], OutputItem::Message(_)));
+    }
+}

--- a/crates/tact_llm/src/provider.rs
+++ b/crates/tact_llm/src/provider.rs
@@ -44,6 +44,20 @@ impl Default for ProviderInfo {
 }
 
 impl ProviderInfo {
+    /// Returns the conservative capabilities for the configured Responses endpoint.
+    pub fn responses_capabilities(&self) -> Option<openai::responses::ResponsesCapabilities> {
+        if self.protocol != OpenAiProtocol::Responses {
+            return None;
+        }
+        Some(match self.provider {
+            ProviderKind::OpenAi => openai::responses::ResponsesCapabilities::official_openai(),
+            ProviderKind::Anthropic => return None,
+            ProviderKind::DeepSeek | ProviderKind::Kimi | ProviderKind::Custom(_) => {
+                openai::responses::ResponsesCapabilities::custom_provider()
+            }
+        })
+    }
+
     /// Build an LLM client for this provider configuration.
     pub fn build_client(&self) -> anyhow::Result<LlmProvider> {
         match self.provider {
@@ -457,6 +471,23 @@ mod tests {
             panic!("expected OpenAi adapter for openai");
         };
         assert_eq!(adapter.base_url(), "https://api.openai.com/v1");
+    }
+
+    #[test]
+    fn openai_responses_exposes_core_capabilities() {
+        let info = ProviderInfo {
+            api_key: "key".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            model: "gpt-5".into(),
+            provider: ProviderKind::OpenAi,
+            protocol: OpenAiProtocol::Responses,
+            responses_compact_threshold: None,
+        };
+        let capabilities = info.responses_capabilities().unwrap();
+        assert!(capabilities.responses);
+        assert!(capabilities.streaming);
+        assert!(capabilities.compact);
+        assert!(capabilities.hosted_tools.is_empty());
     }
 
     #[test]

--- a/crates/tact_llm/src/provider.rs
+++ b/crates/tact_llm/src/provider.rs
@@ -212,15 +212,44 @@ impl ProviderInfo {
     }
 
     /// Returns true when Kimi Code usage quota queries are supported.
+    ///
+    /// Kimi Code serves `GET /v1/usages` only on the official endpoint
+    /// (`https://api.kimi.com/coding`); custom proxies / gateways are treated
+    /// as unsupported so their API keys are never sent to `api.kimi.com`.
     pub fn is_kimi_usage_supported(&self) -> bool {
-        self.is_kimi_coding(&self.model)
+        if !self.is_kimi_coding(&self.model) {
+            return false;
+        }
+        reqwest::Url::parse(&self.base_url).is_ok_and(|url| {
+            url.scheme() == "https"
+                && url.host_str() == Some("api.kimi.com")
+                && url.path().contains("coding")
+        })
+    }
+
+    /// Returns true when DeepSeek balance queries are supported for the configured endpoint.
+    ///
+    /// DeepSeek serves `GET /user/balance` only on the official endpoint;
+    /// custom proxies / gateways are treated as unsupported so their API keys
+    /// are never sent to `api.deepseek.com`.
+    pub fn is_deepseek_balance_supported(&self) -> bool {
+        let is_deepseekish = self.provider == ProviderKind::DeepSeek
+            || self.base_url.contains("deepseek")
+            || self.model.contains("deepseek");
+        if !is_deepseekish {
+            return false;
+        }
+        if self.base_url.is_empty() {
+            return self.provider == ProviderKind::DeepSeek;
+        }
+        reqwest::Url::parse(&self.base_url).is_ok_and(|url| {
+            url.scheme() == "https" && url.host_str() == Some("api.deepseek.com")
+        })
     }
 
     /// Returns true when account balance or usage quota queries are supported.
     pub fn is_account_query_supported(&self) -> bool {
-        self.provider == ProviderKind::DeepSeek
-            || self.base_url.contains("deepseek")
-            || self.model.contains("deepseek")
+        self.is_deepseek_balance_supported()
             || self.is_kimi_balance_supported()
             || self.is_kimi_usage_supported()
     }
@@ -323,6 +352,11 @@ pub fn is_kimi_k27() -> bool {
 /// Returns true for the Kimi Code platform (`api.kimi.com/coding`).
 pub fn is_kimi_coding() -> bool {
     read_provider(|p| p.is_kimi_coding(&p.model))
+}
+
+/// Returns true when DeepSeek balance queries are supported for the configured endpoint.
+pub fn is_deepseek_balance_supported() -> bool {
+    read_provider(|p| p.is_deepseek_balance_supported())
 }
 
 /// Returns true when Kimi balance queries are supported for the configured endpoint.
@@ -552,8 +586,8 @@ mod tests {
         assert!(!proxy_balance.is_kimi_balance_supported());
         assert!(!proxy_balance.is_account_query_supported());
 
-        // kimi-for-coding behind a custom proxy is still Kimi Code:
-        // no balance API, usage quota supported.
+        // kimi-for-coding behind a custom proxy is still Kimi Code for wire
+        // shape, but has no usage quota API: no account queries at all.
         let proxy = provider_info(
             ProviderKind::OpenAi,
             "",
@@ -562,7 +596,8 @@ mod tests {
         );
         assert!(proxy.is_kimi_coding("kimi-for-coding"));
         assert!(!proxy.is_kimi_balance_supported());
-        assert!(proxy.is_kimi_usage_supported());
+        assert!(!proxy.is_kimi_usage_supported());
+        assert!(!proxy.is_account_query_supported());
 
         assert!(coding.is_account_query_supported());
         assert!(cn.is_account_query_supported());
@@ -574,6 +609,125 @@ mod tests {
             "claude-sonnet-4",
         );
         assert!(!anthropic.is_account_query_supported());
+    }
+
+    #[test]
+    fn is_deepseek_balance_supported_only_for_official_endpoint() {
+        let official = provider_info(
+            ProviderKind::DeepSeek,
+            "",
+            "https://api.deepseek.com",
+            "deepseek-chat",
+        );
+        assert!(official.is_deepseek_balance_supported());
+        assert!(official.is_account_query_supported());
+
+        // `/v1` suffix resolves to the same official host.
+        let official_v1 = provider_info(
+            ProviderKind::DeepSeek,
+            "",
+            "https://api.deepseek.com/v1",
+            "deepseek-chat",
+        );
+        assert!(official_v1.is_deepseek_balance_supported());
+
+        // Empty base URL defaults to the official endpoint (config resolution).
+        let empty_base = provider_info(ProviderKind::DeepSeek, "", "", "deepseek-chat");
+        assert!(empty_base.is_deepseek_balance_supported());
+
+        // A DeepSeek model served through a custom proxy has no balance API.
+        let proxy = provider_info(
+            ProviderKind::OpenAi,
+            "",
+            "https://proxy.example.com/v1",
+            "deepseek-chat",
+        );
+        assert!(!proxy.is_deepseek_balance_supported());
+        assert!(!proxy.is_account_query_supported());
+
+        // Host-name spoofing and plain HTTP are rejected.
+        let spoofed = provider_info(
+            ProviderKind::DeepSeek,
+            "",
+            "https://api.deepseek.com.evil.example/v1",
+            "deepseek-chat",
+        );
+        assert!(!spoofed.is_deepseek_balance_supported());
+
+        let http = provider_info(
+            ProviderKind::DeepSeek,
+            "",
+            "http://api.deepseek.com/v1",
+            "deepseek-chat",
+        );
+        assert!(!http.is_deepseek_balance_supported());
+
+        let anthropic = provider_info(
+            ProviderKind::Anthropic,
+            "",
+            "https://api.anthropic.com",
+            "claude-sonnet-4",
+        );
+        assert!(!anthropic.is_deepseek_balance_supported());
+    }
+
+    #[test]
+    fn is_kimi_usage_supported_only_for_official_endpoint() {
+        let official = provider_info(
+            ProviderKind::OpenAi,
+            "",
+            "https://api.kimi.com/coding/v1",
+            "kimi-for-coding",
+        );
+        assert!(official.is_kimi_usage_supported());
+        assert!(official.is_account_query_supported());
+
+        // Custom proxy serving kimi-for-coding: wire shape is still coding,
+        // but there is no usage quota API behind a proxy.
+        let proxy = provider_info(
+            ProviderKind::OpenAi,
+            "",
+            "https://proxy.example.com/v1",
+            "kimi-for-coding",
+        );
+        assert!(proxy.is_kimi_coding("kimi-for-coding"));
+        assert!(!proxy.is_kimi_usage_supported());
+        assert!(!proxy.is_account_query_supported());
+
+        // Official host without the /coding path is not the Kimi Code API.
+        let bare_host = provider_info(
+            ProviderKind::OpenAi,
+            "",
+            "https://api.kimi.com",
+            "kimi-for-coding",
+        );
+        assert!(!bare_host.is_kimi_usage_supported());
+
+        // Host-name spoofing and plain HTTP are rejected.
+        let spoofed = provider_info(
+            ProviderKind::OpenAi,
+            "",
+            "https://api.kimi.com.evil.example/coding/v1",
+            "kimi-for-coding",
+        );
+        assert!(!spoofed.is_kimi_usage_supported());
+
+        let http = provider_info(
+            ProviderKind::OpenAi,
+            "",
+            "http://api.kimi.com/coding/v1",
+            "kimi-for-coding",
+        );
+        assert!(!http.is_kimi_usage_supported());
+
+        // Moonshot (non-coding) endpoint: no usage quota API.
+        let cn = provider_info(
+            ProviderKind::Kimi,
+            "",
+            "https://api.moonshot.cn/v1",
+            "kimi-k2.5",
+        );
+        assert!(!cn.is_kimi_usage_supported());
     }
 
     #[test]

--- a/crates/tact_llm/src/provider.rs
+++ b/crates/tact_llm/src/provider.rs
@@ -57,6 +57,11 @@ impl ProviderInfo {
                 OpenAiProtocol::ChatCompletions => self.build_openai_compatible(),
                 OpenAiProtocol::Responses => self.build_openai_responses(),
             },
+            // Custom providers reuse the OpenAI protocol end to end.
+            ProviderKind::Custom(_) => match self.protocol {
+                OpenAiProtocol::ChatCompletions => self.build_openai_compatible(),
+                OpenAiProtocol::Responses => self.build_openai_responses(),
+            },
         }
     }
 
@@ -389,11 +394,11 @@ pub fn supports_vision() -> bool {
 /// - kimi k3 / k3-256k → effort; kimi coding 系 → budget (Thinking:ON)
 /// - anthropic → budget (native)
 pub fn model_uses_effort(model: &str, info: &ProviderInfo) -> bool {
-    match info.provider {
+    match &info.provider {
         ProviderKind::DeepSeek => true,
         ProviderKind::Anthropic => false,
         ProviderKind::Kimi => is_kimi_k3(model),
-        ProviderKind::OpenAi => {
+        ProviderKind::OpenAi | ProviderKind::Custom(_) => {
             if info.is_kimi_with(model) {
                 is_kimi_k3(model)
             } else {

--- a/crates/tact_llm/src/provider.rs
+++ b/crates/tact_llm/src/provider.rs
@@ -242,9 +242,8 @@ impl ProviderInfo {
         if self.base_url.is_empty() {
             return self.provider == ProviderKind::DeepSeek;
         }
-        reqwest::Url::parse(&self.base_url).is_ok_and(|url| {
-            url.scheme() == "https" && url.host_str() == Some("api.deepseek.com")
-        })
+        reqwest::Url::parse(&self.base_url)
+            .is_ok_and(|url| url.scheme() == "https" && url.host_str() == Some("api.deepseek.com"))
     }
 
     /// Returns true when account balance or usage quota queries are supported.

--- a/crates/tact_llm/src/provider_state.rs
+++ b/crates/tact_llm/src/provider_state.rs
@@ -4,11 +4,10 @@
 //! from the wire-level protocol state required to continue an OpenAI Responses
 //! conversation. [`ProviderConversationState`] is that opaque, versioned
 //! boundary: it stores the exact Responses input-item baseline as JSON so
-//! unknown fields and future item types survive SDK upgrades **once they are
-//! part of the input baseline**. Terminal *output* parsing is typed
-//! (async-openai `OutputItem` has no `Unknown` variant), so a truly unknown
-//! output item type is rejected as a hard protocol error at the adapter
-//! boundary — never silently dropped or replaced by a fallback.
+//! unknown fields and future input/output item types survive SDK upgrades.
+//! The Responses adapter parses raw output envelopes before typed
+//! normalization, so unknown terminal items are retained in the next input
+//! baseline instead of being silently dropped.
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -28,11 +27,10 @@ pub enum ProviderConversationState {
 ///
 /// `input_items` is the exact wire-level protocol baseline for the next
 /// request. It may contain compaction, reasoning, function-call,
-/// function-call-output, message, and other SDK-known item types. The state is
+/// function-call-output, message, and unknown future item types. The state is
 /// stored as JSON rather than an SDK-specific binary format so unknown fields
-/// and future input item types survive SDK upgrades; terminal *output* item
-/// types unknown to the typed SDK are rejected earlier as a hard protocol
-/// error (see the adapter boundary), never silently dropped.
+/// and future input/output item types survive SDK upgrades.
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResponsesConversationState {
     pub version: u32,

--- a/crates/tact_llm/src/types.rs
+++ b/crates/tact_llm/src/types.rs
@@ -217,6 +217,9 @@ pub struct CreateMessageParams {
     /// never read from a global provider state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<OpenAiReasoningEffort>,
+    /// Responses-only request fields; ignored by non-Responses adapters.
+    #[serde(skip)]
+    pub responses_options: Option<crate::openai::responses::ResponsesRequestOptions>,
 }
 
 impl From<RequiredMessageParams> for CreateMessageParams {
@@ -283,6 +286,15 @@ impl CreateMessageParams {
     /// Set the explicit per-request reasoning effort (openai / deepseek / kimi k3).
     pub fn with_reasoning_effort(mut self, effort: Option<OpenAiReasoningEffort>) -> Self {
         self.reasoning_effort = effort;
+        self
+    }
+
+    /// Set Responses-only request options. Other adapters ignore this field.
+    pub fn with_responses_options(
+        mut self,
+        options: crate::openai::responses::ResponsesRequestOptions,
+    ) -> Self {
+        self.responses_options = Some(options);
         self
     }
 }

--- a/crates/tact_llm/src/types.rs
+++ b/crates/tact_llm/src/types.rs
@@ -11,12 +11,18 @@ use serde::{Deserialize, Serialize};
 use crate::Message;
 
 /// Typed LLM provider identity (config / CLI / runtime).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// [`ProviderKind::Custom`] accepts any name not covered by the built-ins and
+/// behaves as an OpenAI-compatible provider (Chat Completions / Responses).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ProviderKind {
     Anthropic,
     OpenAi,
     DeepSeek,
     Kimi,
+    /// Arbitrary provider name from config (e.g. "moonshot", "xai", "ollama").
+    /// Reuses the OpenAI protocol; `base_url` must be configured explicitly.
+    Custom(String),
 }
 
 /// Wire protocol used by an OpenAI provider entry.
@@ -112,25 +118,29 @@ impl fmt::Display for OpenAiProtocol {
 }
 
 impl ProviderKind {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         match self {
             Self::Anthropic => "anthropic",
             Self::OpenAi => "openai",
             Self::DeepSeek => "deepseek",
             Self::Kimi => "kimi",
+            Self::Custom(name) => name,
         }
     }
 
-    pub fn default_base_url(self) -> Option<&'static str> {
+    pub fn default_base_url(&self) -> Option<&'static str> {
         match self {
             Self::Anthropic => None,
             Self::OpenAi => Some("https://api.openai.com/v1"),
             Self::DeepSeek => Some("https://api.deepseek.com"),
             Self::Kimi => Some("https://api.moonshot.cn/v1"),
+            // Custom providers are arbitrary OpenAI-compatible endpoints; the
+            // user must configure `base_url` explicitly.
+            Self::Custom(_) => None,
         }
     }
 
-    pub fn is_openai_compatible(self) -> bool {
+    pub fn is_openai_compatible(&self) -> bool {
         !matches!(self, Self::Anthropic)
     }
 
@@ -138,7 +148,8 @@ impl ProviderKind {
     ///
     /// DeepSeek V4 (chat/reasoner/v4/v4-pro) is a text-only model.
     /// Anthropic Claude 3+, OpenAI GPT-4o/V, and Kimi K2.x all support vision.
-    pub fn supports_vision(self) -> bool {
+    /// Custom OpenAI-compatible providers default to vision support.
+    pub fn supports_vision(&self) -> bool {
         !matches!(self, Self::DeepSeek)
     }
 }
@@ -152,9 +163,9 @@ impl FromStr for ProviderKind {
             "openai" => Ok(Self::OpenAi),
             "deepseek" => Ok(Self::DeepSeek),
             "kimi" => Ok(Self::Kimi),
-            other => Err(format!(
-                "unknown provider '{other}'; expected anthropic|openai|deepseek|kimi"
-            )),
+            "" => Err("provider name must not be empty".to_string()),
+            // Unknown providers are allowed and reuse the OpenAI protocol.
+            other => Ok(Self::Custom(other.to_string())),
         }
     }
 }
@@ -454,9 +465,17 @@ mod tests {
     }
 
     #[test]
-    fn provider_kind_from_str_rejects_unknown() {
-        assert!(ProviderKind::from_str("foo").is_err());
-        assert!(ProviderKind::from_str("moonshot").is_err());
+    fn provider_kind_from_str_accepts_unknown_as_custom() {
+        for name in ["foo", "moonshot", "xai", "ollama"] {
+            let kind = ProviderKind::from_str(name).unwrap();
+            assert_eq!(kind, ProviderKind::Custom(name.to_string()));
+            assert_eq!(kind.as_str(), name);
+            assert_eq!(kind.to_string(), name);
+            assert!(kind.is_openai_compatible());
+            assert_eq!(kind.default_base_url(), None);
+            assert!(kind.supports_vision());
+        }
+        assert!(ProviderKind::from_str("").is_err());
     }
 
     #[test]

--- a/crates/tui/src/handlers/mouse.rs
+++ b/crates/tui/src/handlers/mouse.rs
@@ -211,9 +211,22 @@ fn handle_log_click(app: &mut App, mouse: MouseEvent) {
     app.mouse.last_click_time = Some(now);
     app.mouse.last_click_pos = Some(pos);
 
-    let Some(_phys_idx) = app.visible_message_index(line_idx) else {
+    let Some(phys_idx) = app.visible_message_index(line_idx) else {
         return;
     };
+
+    // Task-stats `[copy]` button: copy this turn's log text.
+    if let Some(raw) = app.raw_messages.get(phys_idx)
+        && crate::widgets::state::is_task_stats_line(raw)
+        && let Some(btn_at) = raw.find(crate::widgets::state::TASK_STATS_COPY_BTN)
+        && let Some((_, byte)) = app.byte_offset_from_log_position(line_idx, visual_row, col)
+        && byte >= btn_at
+    {
+        app.copy_turn_ending_at_stats(phys_idx);
+        app.mouse.log_selection = None;
+        app.mouse.dragging_log = false;
+        return;
+    }
 
     let thinking_hit = app
         .find_thinking_at_logical(line_idx)
@@ -264,6 +277,27 @@ fn handle_log_click(app: &mut App, mouse: MouseEvent) {
     }
 
     app.mouse.last_click_code = None;
+    let mermaid_hit = app.mermaid_blocks.iter().enumerate().find(|(_, b)| {
+        app.phys_to_logical_fast(b.start_idx)
+            .is_some_and(|si| line_idx >= si)
+            && app
+                .phys_to_logical_fast(b.end_idx)
+                .is_some_and(|ei| line_idx < ei)
+    });
+    if let Some((mermaid_idx, _block)) = mermaid_hit {
+        if app.mouse.click_count == 1 {
+            app.mouse.last_click_mermaid = Some(mermaid_idx);
+            app.mouse.log_selection = None;
+            app.mouse.dragging_log = false;
+        } else if app.mouse.click_count == 2 && app.mouse.last_click_mermaid == Some(mermaid_idx) {
+            app.open_mermaid_popup(mermaid_idx);
+        } else if app.mouse.click_count >= 3 {
+            handle_log_triple_click(app, line_idx, false);
+        }
+        return;
+    }
+
+    app.mouse.last_click_mermaid = None;
     if app.mouse.click_count == 2 {
         if let Some((phys, byte)) = app.byte_offset_from_log_position(line_idx, visual_row, col)
             && let Some((ws, we)) = app.find_word_bounds(line_idx, byte)

--- a/crates/tui/src/handlers/overlay.rs
+++ b/crates/tui/src/handlers/overlay.rs
@@ -29,10 +29,14 @@ pub(crate) fn handle_overlay_key(app: &mut App, key: KeyEvent) -> bool {
         KeyCode::Char('k') | KeyCode::Up => app.overlay_popup_scroll_up(),
         KeyCode::Char('G')
             if app.code_popup.is_some()
+                || app.mermaid_popup.is_some()
                 || app.task_dag_popup.is_some()
                 || app.subagent_popup.is_some() =>
         {
             if let Some(ref mut p) = app.code_popup {
+                p.scroll = u16::MAX;
+            }
+            if let Some(ref mut p) = app.mermaid_popup {
                 p.scroll = u16::MAX;
             }
             if let Some(ref mut p) = app.task_dag_popup {
@@ -44,10 +48,14 @@ pub(crate) fn handle_overlay_key(app: &mut App, key: KeyEvent) -> bool {
         }
         KeyCode::Char('g')
             if app.code_popup.is_some()
+                || app.mermaid_popup.is_some()
                 || app.task_dag_popup.is_some()
                 || app.subagent_popup.is_some() =>
         {
             if let Some(ref mut p) = app.code_popup {
+                p.scroll = 0;
+            }
+            if let Some(ref mut p) = app.mermaid_popup {
                 p.scroll = 0;
             }
             if let Some(ref mut p) = app.task_dag_popup {

--- a/crates/tui/src/handlers/select.rs
+++ b/crates/tui/src/handlers/select.rs
@@ -12,7 +12,7 @@ const THINKING_BUDGETS: [usize; 5] = [0, 8_000, 32_000, 64_000, 128_000];
 /// kimi k3 family: low/high/max (default high).
 fn default_effort_tiers(info: &tact_llm::ProviderInfo) -> Vec<tact_llm::OpenAiReasoningEffort> {
     use tact_llm::OpenAiReasoningEffort as E;
-    match info.provider {
+    match &info.provider {
         tact_llm::ProviderKind::DeepSeek | tact_llm::ProviderKind::Kimi => {
             vec![E::Low, E::High, E::Max]
         }

--- a/crates/tui/src/handlers/select.rs
+++ b/crates/tui/src/handlers/select.rs
@@ -1237,6 +1237,40 @@ thinking_budget = {thinking_budget}
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn applying_effort_pick_clears_stale_thinking_budget() {
+        // Regression: an effort pick for an effort-semantic model (k3) must
+        // clear a stale thinking_budget left over from a budget-semantic model
+        // (kimi-for-coding) — otherwise the bottom bar renders `think high(32K)`.
+        let _lock = MODELS_TEST_LOCK.lock().await;
+        tact_llm::clear_models_cache_for_tests();
+        install_models_config_with_budget(vec!["k3"], "k3", 32_000);
+        tact_llm::seed_models_cache_for_tests(
+            "https://api.moonshot.cn/v1",
+            "sk-test",
+            vec!["k3".into()],
+        );
+        let mut app = make_app();
+        start_model_picker(&mut app);
+        handle_select_mode(&mut app, key(KeyCode::Enter)); // k3 (single model)
+        handle_select_mode(&mut app, key(KeyCode::Enter)); // first effort (Low)
+
+        assert_eq!(
+            tact::config::settings().agent.reasoning_effort,
+            Some(tact_llm::OpenAiReasoningEffort::Low)
+        );
+        assert_eq!(
+            tact::config::settings().agent.thinking_budget,
+            0,
+            "effort pick must clear stale thinking budget"
+        );
+        assert_eq!(app.status_bar.model_thinking_budget, None);
+        assert_eq!(
+            app.status_bar.model_reasoning_effort,
+            Some("low".to_string())
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn confirmed_budget_applies_model_and_budget_for_this_session() {
         let _lock = MODELS_TEST_LOCK.lock().await;
         install_models_config_with_budget(

--- a/crates/tui/src/render/bar.rs
+++ b/crates/tui/src/render/bar.rs
@@ -136,14 +136,18 @@ fn format_out_tokens(label: &str, max_tokens: u32) -> Option<String> {
     }
 }
 
-/// Thinking segment: `"think high(32K)"`, `"think 32K"`, or `None`.
+/// Thinking segment: `"think high"`, `"think 32K"`, or `None`.
+///
+/// Effort takes precedence over budget: effort and budget are mutually
+/// exclusive semantics (effort-semantic models never send a budget), so a
+/// stale `thinking_budget` left over from a budget-semantic model must not
+/// render a meaningless `think high(32K)` next to an explicit effort.
 fn format_think_segment(label: &str, effort: Option<&str>, budget: Option<u32>) -> Option<String> {
-    let budget = budget.filter(|b| *b > 0)?;
-    let b = format_tokens_compact(budget as u64);
-    match effort.filter(|e| !e.is_empty()) {
-        Some(level) => Some(format!("{label} {level}({b})")),
-        None => Some(format!("{label} {b}")),
+    if let Some(level) = effort.filter(|e| !e.is_empty()) {
+        return Some(format!("{label} {level}"));
     }
+    let budget = budget.filter(|b| *b > 0)?;
+    Some(format!("{label} {}", format_tokens_compact(budget as u64)))
 }
 
 /// Format one balance entry: `"¤ CNY 9.60"`.
@@ -674,14 +678,14 @@ mod render_tests {
     }
 
     #[test]
-    fn format_think_with_effort_and_budget() {
+    fn format_think_with_effort_takes_precedence_over_stale_budget() {
         assert_eq!(
             super::format_think_segment("思考", Some("high"), Some(32_000)),
-            Some("思考 high(32K)".into())
+            Some("思考 high".into())
         );
         assert_eq!(
             super::format_think_segment("think", Some("medium"), Some(8_000)),
-            Some("think medium(8K)".into())
+            Some("think medium".into())
         );
     }
 
@@ -695,12 +699,18 @@ mod render_tests {
 
     #[test]
     fn format_think_omitted_without_budget() {
-        assert_eq!(
-            super::format_think_segment("think", Some("high"), None),
-            None
-        );
         assert_eq!(super::format_think_segment("think", None, Some(0)), None);
         assert_eq!(super::format_think_segment("think", None, None), None);
+    }
+
+    #[test]
+    fn format_think_shows_effort_without_budget() {
+        // Effort-semantic models (openai / deepseek / kimi k3) have no budget;
+        // the effort alone must still render so the bar does not lose the info.
+        assert_eq!(
+            super::format_think_segment("think", Some("high"), None),
+            Some("think high".into())
+        );
     }
 
     #[test]
@@ -870,9 +880,7 @@ mod render_tests {
 
         let text = buffer_text(terminal.backend().buffer());
         assert!(
-            text.contains("mock-model")
-                && text.contains("out 128K")
-                && text.contains("think high(32K)"),
+            text.contains("mock-model") && text.contains("out 128K") && text.contains("think high"),
             "bottom bar should show model + out + think effort, got:\n{text}"
         );
     }

--- a/crates/tui/src/render/cells/markdown.rs
+++ b/crates/tui/src/render/cells/markdown.rs
@@ -5,9 +5,11 @@
 //! through the shared width-aware pipeline (`render_markdown_with_tables`):
 //! pipe-table rows are extracted and laid out against the panel width via
 //! `format_table` (columns shrink, long cells wrap inside the table, pipes
-//! stay aligned), everything else goes to tui-markdown directly
-//! (`render_markdown_tui`, the themed `from_str` pipeline), so headings /
-//! lists / blockquotes / fenced code keep their theme styling.
+//! stay aligned), complete top-level ` ```mermaid ` fences are rendered as
+//! terminal diagrams at the same content width, and everything else goes to
+//! tui-markdown directly (`render_markdown_tui`, the themed `from_str`
+//! pipeline), so headings / lists / blockquotes / fenced code keep their
+//! theme styling.
 //!
 //! Rendering is lazy and cached per content width: the cell stores only the
 //! source text until the log renderer asks for its height, and re-layouts
@@ -230,6 +232,24 @@ mod tests {
         assert!(text.contains("Title"), "{text}");
         assert!(text.contains("item one"), "{text}");
         assert!(text.contains("item two"), "{text}");
+    }
+
+    #[test]
+    fn markdown_cell_renders_mermaid_at_the_requested_width() {
+        let cell = MarkdownCell::new(
+            "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```",
+            &dark(),
+        );
+        let text = render_text(&cell, 60);
+
+        assert!(
+            text.contains("Alice") && text.contains("Bob"),
+            "diagram missing: {text}"
+        );
+        assert!(
+            !text.contains("sequenceDiagram"),
+            "raw Mermaid leaked: {text}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/render/cells/text.rs
+++ b/crates/tui/src/render/cells/text.rs
@@ -64,7 +64,7 @@ impl TextCell {
 
     /// Build the visual line list for rendering (selection overlay or cache).
     fn build_lines(&self, width: u16) -> Vec<Line<'_>> {
-        let wrap_width = width + self.indent_cols;
+        let wrap_width = width;
         if let Some((sel_start, sel_end)) = self.selection_range {
             // Whole-line selection can reuse the cached wrap and only flip style.
             if sel_start == 0 && sel_end == self.raw_text.len() {

--- a/crates/tui/src/render/layout.rs
+++ b/crates/tui/src/render/layout.rs
@@ -65,6 +65,9 @@ pub(crate) fn render_main_area(frame: &mut Frame, area: Rect, app: &mut App) {
     if app.code_popup.is_some() {
         super::popups::code_popup::render_code_popup(frame, area, app);
     }
+    if app.mermaid_popup.is_some() {
+        super::popups::mermaid_popup::render_mermaid_popup(frame, area, app);
+    }
     if app.task_dag_popup.is_some() {
         super::popups::task_dag_popup::render_task_dag_popup(frame, area, app);
     }

--- a/crates/tui/src/render/log.rs
+++ b/crates/tui/src/render/log.rs
@@ -188,10 +188,13 @@ pub(crate) fn render_log_panel_with_borders(
                 if super::cells::separator::is_task_end_separator(&app.raw_messages[phys_idx]) {
                     vec![Line::default()]
                 } else {
-                    wrap_line(&line, wrap_width)
+                    let indent = app.nested_log_indent(phys_idx) as usize;
+                    wrap_line(&line, wrap_width.saturating_sub(indent).max(1))
                 }
             } else {
-                wrap_line(&line, wrap_width)
+                // The stream row uses the same reply indent as its TextCell.
+                let indent = (super::util::LOG_THINKING_INDENT + 1) as usize;
+                wrap_line(&line, wrap_width.saturating_sub(indent).max(1))
             };
             app.log_scroll.visual_cache.extend(wrapped);
             app.log_scroll

--- a/crates/tui/src/render/log_render_tests.rs
+++ b/crates/tui/src/render/log_render_tests.rs
@@ -276,6 +276,20 @@ fn log_sys_tool_message_uses_extra_indent() {
 }
 
 #[test]
+fn log_full_width_nested_line_wraps_before_indentation_clip() {
+    let mut app = make_app();
+    let line = "abcdefghijklmnopqrstuvwxyz";
+    app.append_msg(Line::from(line), line.into(), RawMessageType::SysTool);
+
+    let text = render_log_panel_text(&mut app, 30, 12);
+
+    assert!(
+        text.contains("yz"),
+        "right edge must not lose characters: {text}"
+    );
+    assert_eq!(app.log_scroll.visual_cache.len(), 2);
+}
+#[test]
 fn log_narrow_width_wraps_long_paragraph() {
     let mut app = make_app();
     app.add_system_message("word ".repeat(40));

--- a/crates/tui/src/render/mermaid_sequence.rs
+++ b/crates/tui/src/render/mermaid_sequence.rs
@@ -341,8 +341,8 @@ fn label_row(
                 spans[cx] = Span::styled(ch.to_string(), label_style);
                 // Consume the remaining display columns of a wide glyph so a
                 // leftover space does not inflate the row.
-                for p in (cx + 1)..(cx + cw) {
-                    spans[p] = Span::styled(String::new(), label_style);
+                for span in spans.iter_mut().take(cx + cw).skip(cx + 1) {
+                    *span = Span::styled(String::new(), label_style);
                 }
                 cx += cw;
                 placed = true;
@@ -483,8 +483,8 @@ fn place_label_from(
             let free = (cx..cx + cw).all(|p| p < spans.len() && spans[p].content == " ");
             if free {
                 spans[cx] = Span::styled(ch.to_string(), label_style);
-                for p in (cx + 1)..(cx + cw) {
-                    spans[p] = Span::styled(String::new(), label_style);
+                for span in spans.iter_mut().take(cx + cw).skip(cx + 1) {
+                    *span = Span::styled(String::new(), label_style);
                 }
                 cx += cw;
                 placed = true;
@@ -514,8 +514,8 @@ fn place_label_end_at(spans: &mut [Span<'static>], end: usize, text: &str, label
             break;
         }
         spans[cx] = Span::styled(ch.to_string(), label_style);
-        for p in (cx + 1)..(cx + cw) {
-            spans[p] = Span::styled(String::new(), label_style);
+        for span in spans.iter_mut().take(cx + cw).skip(cx + 1) {
+            *span = Span::styled(String::new(), label_style);
         }
         cx += cw;
     }
@@ -683,7 +683,8 @@ mod tests {
         let label_w: usize = label.spans.iter().map(|s| s.content.width()).sum();
         let life_w: usize = life.spans.iter().map(|s| s.content.width()).sum();
         assert_eq!(
-            label_w, life_w,
+            label_w,
+            life_w,
             "CJK ghost cells inflated label row (label={label_w} life={life_w}):\n{}",
             lines
                 .iter()

--- a/crates/tui/src/render/mermaid_sequence.rs
+++ b/crates/tui/src/render/mermaid_sequence.rs
@@ -1,0 +1,801 @@
+//! Terminal rendering for Mermaid `sequenceDiagram` blocks.
+//!
+//! Tact renders sequence diagrams with its own renderer instead of the
+//! upstream `ratatui-markdown` one because the upstream sequence renderer
+//! has three problems that produce visibly broken diagrams:
+//!
+//! 1. `participant A as 名称` aliases are not parsed — the whole declaration
+//!    string ends up as the participant name in the header.
+//! 2. The `+`/`-` activation shorthand on arrow endpoints (`A->>+B`) is not
+//!    understood, so `+B`/`-B` are auto-added as phantom participant columns.
+//! 3. Arrow labels are placed by display column but only the start cell is
+//!    checked, so a 2-column CJK glyph can overwrite a lifeline (or be
+//!    dropped when its start cell is a lifeline), making labelled arrows
+//!    look misaligned.
+//!
+//! This renderer also clears the continuation cell of each width-2 glyph and
+//! reflows label characters past lifelines, so long / CJK labels neither
+//! inflate row display width nor silently drop letters on `│` columns.
+//!
+//! Other diagram types still go through `ratatui-markdown`; only
+//! `sequenceDiagram` fences are routed here (see `render_mermaid_block`).
+
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::theme::Theme;
+
+const HLINE: char = '─';
+const DLINE: char = '╌';
+const VLINE: char = '│';
+const CORNER_TL: char = '┌';
+const CORNER_TR: char = '┐';
+const CORNER_BL: char = '└';
+const CORNER_BR: char = '┘';
+/// Horizontal cells between the lifeline and the self-loop corner.
+const SELF_LOOP_ARM: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArrowKind {
+    /// `->`
+    Solid,
+    /// `-->`
+    Dotted,
+    /// `->>`
+    SolidOpen,
+    /// `-->>`
+    DottedOpen,
+}
+
+#[derive(Debug, Clone)]
+struct Participant {
+    id: String,
+    label: String,
+}
+
+#[derive(Debug, Clone)]
+struct Message {
+    from: String,
+    to: String,
+    text: String,
+    kind: ArrowKind,
+}
+
+#[derive(Debug)]
+struct Diagram {
+    participants: Vec<Participant>,
+    messages: Vec<Message>,
+}
+
+/// Parse a `sequenceDiagram` block.
+///
+/// Returns `None` when no participant could be found so callers can fall back
+/// to ordinary code rendering.
+fn parse(source: &str) -> Option<Diagram> {
+    let mut participants: Vec<Participant> = Vec::new();
+    let mut messages: Vec<Message> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for raw in source.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line == "sequenceDiagram" {
+            continue;
+        }
+
+        if let Some(rest) = line
+            .strip_prefix("participant ")
+            .or_else(|| line.strip_prefix("actor "))
+        {
+            // `participant A as 用户` → id `A`, header label `用户`.
+            let (id, label) = match rest.split_once(" as ") {
+                Some((id, label)) => (id.trim(), label.trim()),
+                None => (rest.trim(), ""),
+            };
+            if !id.is_empty() {
+                let label = if label.is_empty() { id } else { label };
+                ensure_participant(&mut participants, &mut seen, id, label);
+            }
+            continue;
+        }
+
+        if let Some(msg) = parse_message(line) {
+            ensure_participant(&mut participants, &mut seen, &msg.from, &msg.from);
+            ensure_participant(&mut participants, &mut seen, &msg.to, &msg.to);
+            messages.push(msg);
+        }
+    }
+
+    if participants.is_empty() {
+        return None;
+    }
+    Some(Diagram {
+        participants,
+        messages,
+    })
+}
+
+fn ensure_participant(
+    participants: &mut Vec<Participant>,
+    seen: &mut std::collections::HashSet<String>,
+    id: &str,
+    label: &str,
+) {
+    if seen.insert(id.to_string()) {
+        participants.push(Participant {
+            id: id.to_string(),
+            label: label.to_string(),
+        });
+    }
+}
+
+fn parse_message(line: &str) -> Option<Message> {
+    for arrow in ["-->>", "->>", "-->", "->"] {
+        if let Some(idx) = line.find(arrow) {
+            let kind = match arrow {
+                "-->>" => ArrowKind::DottedOpen,
+                "->>" => ArrowKind::SolidOpen,
+                "-->" => ArrowKind::Dotted,
+                _ => ArrowKind::Solid,
+            };
+            let from = strip_activation(&line[..idx]);
+            let to_and_text = line[idx + arrow.len()..].trim();
+            let (to, text) = match to_and_text.find(':') {
+                Some(p) => (
+                    strip_activation(&to_and_text[..p]),
+                    to_and_text[p + 1..].trim().to_string(),
+                ),
+                None => (strip_activation(to_and_text), String::new()),
+            };
+            if from.is_empty() || to.is_empty() {
+                return None;
+            }
+            return Some(Message {
+                from,
+                to,
+                text,
+                kind,
+            });
+        }
+    }
+    None
+}
+
+/// Strip Mermaid's `+`/`-` activation shorthand from an arrow endpoint
+/// (`A->>+B` targets participant `B`, not a participant named `+B`).
+fn strip_activation(s: &str) -> String {
+    let s = s.trim();
+    let s = s
+        .strip_prefix('+')
+        .or_else(|| s.strip_prefix('-'))
+        .unwrap_or(s);
+    s.trim().to_string()
+}
+
+/// Render a `sequenceDiagram` block as terminal lines, or `None` when the
+/// source does not parse into a diagram.
+pub(crate) fn render_sequence_diagram(
+    source: &str,
+    max_width: usize,
+    theme: &Theme,
+) -> Option<Vec<Line<'static>>> {
+    let diagram = parse(source)?;
+    Some(render(&diagram, max_width, theme))
+}
+
+fn render(diagram: &Diagram, max_width: usize, theme: &Theme) -> Vec<Line<'static>> {
+    let n = diagram.participants.len();
+    let col_width = ((max_width.saturating_sub(2)) / n).clamp(6, 20);
+    let line_width = n * col_width + (n - 1);
+
+    let header_style = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
+    let line_style = Style::default().fg(theme.muted_fg());
+    let label_style = Style::default()
+        .fg(theme.heading)
+        .add_modifier(Modifier::ITALIC);
+    let arrow_style = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header row: centered participant labels.
+    {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        for (i, p) in diagram.participants.iter().enumerate() {
+            let tw = p.label.width();
+            let pad = col_width.saturating_sub(tw);
+            let left_pad = pad / 2;
+            let right_pad = pad - left_pad;
+            spans.push(Span::styled(" ".repeat(left_pad), header_style));
+            spans.push(Span::styled(p.label.clone(), header_style));
+            spans.push(Span::styled(" ".repeat(right_pad), header_style));
+            if i + 1 < n {
+                spans.push(Span::styled(" ".to_string(), line_style));
+            }
+        }
+        lines.push(Line::from(spans));
+    }
+
+    for msg in &diagram.messages {
+        let from_idx = diagram
+            .participants
+            .iter()
+            .position(|p| p.id == msg.from)
+            .unwrap_or(0);
+        let to_idx = diagram
+            .participants
+            .iter()
+            .position(|p| p.id == msg.to)
+            .unwrap_or(0);
+
+        lines.push(Line::from(lifeline_row(n, col_width, line_style)));
+
+        if from_idx == to_idx {
+            for row in self_loop_rows(
+                n,
+                col_width,
+                line_width,
+                from_idx,
+                &msg.text,
+                msg.kind,
+                line_style,
+                label_style,
+                arrow_style,
+            ) {
+                lines.push(Line::from(row));
+            }
+            continue;
+        }
+
+        if !msg.text.is_empty() {
+            lines.push(Line::from(label_row(
+                n,
+                col_width,
+                line_width,
+                from_idx,
+                to_idx,
+                &msg.text,
+                line_style,
+                label_style,
+            )));
+        }
+
+        lines.push(Line::from(arrow_row(
+            n,
+            col_width,
+            from_idx,
+            to_idx,
+            msg.kind,
+            line_style,
+            arrow_style,
+        )));
+    }
+
+    lines.push(Line::from(lifeline_row(n, col_width, line_style)));
+    lines
+}
+
+/// Column index of participant `i`'s lifeline.
+fn lifeline_x(i: usize, col_width: usize) -> usize {
+    i * (col_width + 1) + col_width / 2
+}
+
+/// One row of lifelines (`│` at each participant's center column).
+fn lifeline_row(n: usize, col_width: usize, style: Style) -> Vec<Span<'static>> {
+    let mut spans = Vec::with_capacity(n * (col_width + 1));
+    for i in 0..n {
+        let center = col_width / 2;
+        for c in 0..col_width {
+            spans.push(Span::styled(
+                if c == center {
+                    VLINE.to_string()
+                } else {
+                    " ".to_string()
+                },
+                style,
+            ));
+        }
+        if i + 1 < n {
+            spans.push(Span::styled(" ".to_string(), style));
+        }
+    }
+    spans
+}
+
+/// Row holding the arrow label, centered between the two lifelines.
+///
+/// Wide (CJK) glyphs are placed by display column. Continuation cells of a
+/// width-2 glyph are cleared to empty spans so the row's display width stays
+/// aligned with neighbouring lifeline/arrow rows. Glyphs that would land on a
+/// lifeline reflow to the next free cell instead of being dropped.
+#[allow(clippy::too_many_arguments)]
+fn label_row(
+    n: usize,
+    col_width: usize,
+    line_width: usize,
+    from_idx: usize,
+    to_idx: usize,
+    text: &str,
+    line_style: Style,
+    label_style: Style,
+) -> Vec<Span<'static>> {
+    let mut spans = lifeline_row(n, col_width, line_style);
+
+    let text_w = text.width();
+    let from_x = lifeline_x(from_idx, col_width);
+    let to_x = lifeline_x(to_idx, col_width);
+    let center = (from_x + to_x) / 2;
+    let mut cx = center.saturating_sub(text_w / 2);
+
+    for ch in text.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(1).max(1);
+        let mut placed = false;
+        while cx + cw <= line_width {
+            let free = (cx..cx + cw).all(|p| spans[p].content == " ");
+            if free {
+                spans[cx] = Span::styled(ch.to_string(), label_style);
+                // Consume the remaining display columns of a wide glyph so a
+                // leftover space does not inflate the row.
+                for p in (cx + 1)..(cx + cw) {
+                    spans[p] = Span::styled(String::new(), label_style);
+                }
+                cx += cw;
+                placed = true;
+                break;
+            }
+            cx += 1;
+        }
+        if !placed {
+            break;
+        }
+    }
+    spans
+}
+
+/// Two-row U-shaped self-message loop beside the participant lifeline.
+///
+/// Right side (preferred when there is room):
+/// ```text
+/// │──┐ label
+/// │◀─┘
+/// ```
+/// Left side (last column / no room on the right):
+/// ```text
+/// label ┌──│
+///      └──▶│
+/// ```
+#[allow(clippy::too_many_arguments)]
+fn self_loop_rows(
+    n: usize,
+    col_width: usize,
+    line_width: usize,
+    idx: usize,
+    text: &str,
+    kind: ArrowKind,
+    line_style: Style,
+    label_style: Style,
+    arrow_style: Style,
+) -> Vec<Vec<Span<'static>>> {
+    let x = lifeline_x(idx, col_width);
+    let arm = SELF_LOOP_ARM.min(col_width.saturating_sub(1).max(1));
+    // Prefer the right side (Mermaid-style), but the last participant loops
+    // left so the U-shape stays inside the diagram instead of clipping.
+    let go_right = if idx + 1 >= n {
+        x < arm + 1
+    } else {
+        x + arm + 1 < line_width
+    };
+    let line_ch = match kind {
+        ArrowKind::Solid | ArrowKind::SolidOpen => HLINE,
+        ArrowKind::Dotted | ArrowKind::DottedOpen => DLINE,
+    };
+    let head = match (go_right, kind) {
+        (true, ArrowKind::Solid | ArrowKind::Dotted) => '◄',
+        (true, ArrowKind::SolidOpen | ArrowKind::DottedOpen) => '◀',
+        (false, ArrowKind::Solid | ArrowKind::Dotted) => '►',
+        (false, ArrowKind::SolidOpen | ArrowKind::DottedOpen) => '▶',
+    };
+
+    let mut top = lifeline_row(n, col_width, line_style);
+    let mut bottom = lifeline_row(n, col_width, line_style);
+
+    if go_right {
+        // │──┐
+        // │◀─┘
+        for i in 1..=arm {
+            let cell = x + i;
+            if cell < top.len() {
+                top[cell] = Span::styled(line_ch.to_string(), arrow_style);
+            }
+        }
+        let corner = x + arm + 1;
+        if corner < top.len() {
+            top[corner] = Span::styled(CORNER_TR.to_string(), arrow_style);
+        }
+        if x + 1 < bottom.len() {
+            bottom[x + 1] = Span::styled(head.to_string(), arrow_style);
+        }
+        for i in 2..=arm {
+            let cell = x + i;
+            if cell < bottom.len() {
+                bottom[cell] = Span::styled(line_ch.to_string(), arrow_style);
+            }
+        }
+        if corner < bottom.len() {
+            bottom[corner] = Span::styled(CORNER_BR.to_string(), arrow_style);
+        }
+        if !text.is_empty() {
+            place_label_from(&mut top, corner + 2, text, line_width, label_style);
+        }
+    } else {
+        // ┌──│
+        // └──▶│
+        let corner = x.saturating_sub(arm + 1);
+        if corner < top.len() && top[corner].content == " " {
+            top[corner] = Span::styled(CORNER_TL.to_string(), arrow_style);
+        }
+        for i in 1..=arm {
+            let cell = x - i;
+            if cell < top.len() && cell > corner {
+                top[cell] = Span::styled(line_ch.to_string(), arrow_style);
+            }
+        }
+        if corner < bottom.len() && bottom[corner].content == " " {
+            bottom[corner] = Span::styled(CORNER_BL.to_string(), arrow_style);
+        }
+        for i in 2..=arm {
+            let cell = x - i;
+            if cell < bottom.len() && cell > corner {
+                bottom[cell] = Span::styled(line_ch.to_string(), arrow_style);
+            }
+        }
+        if x > 0 {
+            bottom[x - 1] = Span::styled(head.to_string(), arrow_style);
+        }
+        if !text.is_empty() && corner > 1 {
+            let label_end = corner.saturating_sub(1);
+            place_label_end_at(&mut top, label_end, text, label_style);
+        }
+    }
+
+    vec![top, bottom]
+}
+
+/// Place `text` starting at `start`, skipping occupied cells, without
+/// overwriting lifelines or loop artwork.
+fn place_label_from(
+    spans: &mut [Span<'static>],
+    start: usize,
+    text: &str,
+    line_width: usize,
+    label_style: Style,
+) {
+    let mut cx = start;
+    for ch in text.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(1).max(1);
+        let mut placed = false;
+        while cx + cw <= line_width && cx < spans.len() {
+            let free = (cx..cx + cw).all(|p| p < spans.len() && spans[p].content == " ");
+            if free {
+                spans[cx] = Span::styled(ch.to_string(), label_style);
+                for p in (cx + 1)..(cx + cw) {
+                    spans[p] = Span::styled(String::new(), label_style);
+                }
+                cx += cw;
+                placed = true;
+                break;
+            }
+            cx += 1;
+        }
+        if !placed {
+            break;
+        }
+    }
+}
+
+/// Right-align `text` so its last display column ends at `end` (exclusive of
+/// occupied cells), used for left-side self-loops.
+fn place_label_end_at(spans: &mut [Span<'static>], end: usize, text: &str, label_style: Style) {
+    let text_w = text.width();
+    let start = end.saturating_sub(text_w);
+    let mut cx = start;
+    for ch in text.chars() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(1).max(1);
+        if cx + cw > end || cx >= spans.len() {
+            break;
+        }
+        let free = (cx..cx + cw).all(|p| p < spans.len() && spans[p].content == " ");
+        if !free {
+            break;
+        }
+        spans[cx] = Span::styled(ch.to_string(), label_style);
+        for p in (cx + 1)..(cx + cw) {
+            spans[p] = Span::styled(String::new(), label_style);
+        }
+        cx += cw;
+    }
+}
+
+/// Row holding the arrow between two lifelines.
+fn arrow_row(
+    n: usize,
+    col_width: usize,
+    from_idx: usize,
+    to_idx: usize,
+    kind: ArrowKind,
+    line_style: Style,
+    arrow_style: Style,
+) -> Vec<Span<'static>> {
+    let mut spans = lifeline_row(n, col_width, line_style);
+
+    let from_x = lifeline_x(from_idx, col_width);
+    let to_x = lifeline_x(to_idx, col_width);
+
+    // Self-messages are rendered by `self_loop_rows`; keep a tiny stub here
+    // only as a defensive fallback if a caller still hits this path.
+    if from_x == to_x {
+        return spans;
+    }
+
+    let go_right = to_x > from_x;
+    let left_x = from_x.min(to_x);
+    let right_x = from_x.max(to_x);
+
+    let line_ch = match kind {
+        ArrowKind::Solid | ArrowKind::SolidOpen => HLINE,
+        ArrowKind::Dotted | ArrowKind::DottedOpen => DLINE,
+    };
+    for cell in spans.iter_mut().take(right_x).skip(left_x + 1) {
+        if cell.content == " " {
+            *cell = Span::styled(line_ch.to_string(), arrow_style);
+        }
+    }
+
+    let head_x = if go_right { right_x - 1 } else { left_x + 1 };
+    let head = match kind {
+        ArrowKind::Solid | ArrowKind::Dotted => {
+            if go_right {
+                '►'
+            } else {
+                '◄'
+            }
+        }
+        ArrowKind::SolidOpen | ArrowKind::DottedOpen => {
+            if go_right {
+                '▶'
+            } else {
+                '◀'
+            }
+        }
+    };
+    spans[head_x] = Span::styled(head.to_string(), arrow_style);
+
+    let tail_x = if go_right { left_x + 1 } else { right_x - 1 };
+    if spans[tail_x].content == " " {
+        spans[tail_x] = Span::styled(if go_right { '>' } else { '<' }.to_string(), arrow_style);
+    }
+
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::theme::ThemeName;
+
+    fn theme() -> Theme {
+        Theme::from(ThemeName::from_str("ink").unwrap())
+    }
+
+    /// Compare labels after stripping whitespace and lifeline glyphs so
+    /// punched-through `│` characters do not break substring checks.
+    fn compact(text: &str) -> String {
+        text.chars()
+            .filter(|c| !c.is_whitespace() && *c != VLINE)
+            .collect()
+    }
+
+    fn render_text(source: &str, width: usize) -> String {
+        let lines = render_sequence_diagram(source, width, &theme()).expect("valid diagram");
+        lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn aliases_and_activation_shorthand_render_three_columns() {
+        let source = "sequenceDiagram
+    participant A as 用户
+    participant B as 客户端
+    participant C as 服务端
+    A->>+B: 发起请求
+    B->>+C: 发送请求
+    C-->>-B: 返回结果
+    B-->>-A: 返回结果";
+        let text = render_text(source, 80);
+
+        assert!(text.contains("用户"), "alias missing: {text}");
+        assert!(text.contains("客户端"), "alias missing: {text}");
+        assert!(text.contains("服务端"), "alias missing: {text}");
+        assert!(!text.contains("+B"), "phantom participant leaked: {text}");
+        assert!(!text.contains("-B"), "phantom participant leaked: {text}");
+        assert!(!text.contains("-A"), "phantom participant leaked: {text}");
+        let labels = compact(&text);
+        assert!(labels.contains("发起请求"), "label missing: {text}");
+        assert!(labels.contains("发送请求"), "label missing: {text}");
+        assert!(labels.contains("返回结果"), "label missing: {text}");
+        assert!(
+            text.contains('▶') || text.contains('►'),
+            "arrow missing: {text}"
+        );
+
+        // Every non-header row keeps exactly one lifeline per participant.
+        for line in text.lines().skip(1) {
+            assert_eq!(
+                line.matches('│').count(),
+                3,
+                "expected 3 lifelines, got: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cjk_label_never_overwrites_a_lifeline() {
+        let text = render_text("sequenceDiagram\n  Alice->>Bob: 你好世界", 80);
+
+        assert!(compact(&text).contains("你好世界"), "label missing: {text}");
+        for line in text.lines().skip(1) {
+            assert_eq!(
+                line.matches('│').count(),
+                2,
+                "lifeline overwritten by label: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cjk_label_keeps_same_display_width_as_lifeline_row() {
+        // Placing a width-2 glyph must clear the next cell; leaving a ghost
+        // space inflates the row and shifts every lifeline to the right.
+        let lines =
+            render_sequence_diagram("sequenceDiagram\n  Alice->>Bob: 你好世界", 80, &theme())
+                .expect("valid diagram");
+        let label = lines
+            .iter()
+            .find(|l| l.to_string().contains('你'))
+            .expect("label row");
+        let life = lines
+            .iter()
+            .find(|l| {
+                let s = l.to_string();
+                s.matches('│').count() == 2 && !s.contains('你')
+            })
+            .expect("lifeline row");
+        let label_w: usize = label.spans.iter().map(|s| s.content.width()).sum();
+        let life_w: usize = life.spans.iter().map(|s| s.content.width()).sum();
+        assert_eq!(
+            label_w, life_w,
+            "CJK ghost cells inflated label row (label={label_w} life={life_w}):\n{}",
+            lines
+                .iter()
+                .map(Line::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    #[test]
+    fn long_ascii_label_is_not_eaten_by_lifelines() {
+        // Narrow columns + a long label centered over an arrow will land
+        // characters on │ cells; those glyphs must reflow past the lifeline
+        // instead of being dropped (e.g. "submitTask" → "ubmitTask").
+        let source = "sequenceDiagram
+    participant A
+    participant B
+    participant C
+    A->>C: submitTask";
+        let text = render_text(source, 48);
+        assert!(
+            compact(&text).contains("submitTask"),
+            "label chars dropped on lifeline: {text}"
+        );
+        for line in text.lines().skip(1) {
+            assert_eq!(
+                line.matches('│').count(),
+                3,
+                "lifeline overwritten: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ascii_label_is_centered_between_lifelines() {
+        let text = render_text("sequenceDiagram\n  Alice->>Bob: Hello", 80);
+
+        assert!(text.contains("Hello"), "label missing: {text}");
+        for line in text.lines().skip(1) {
+            assert_eq!(
+                line.matches('│').count(),
+                2,
+                "lifeline overwritten: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn undeclared_message_participants_are_auto_added() {
+        let text = render_text("sequenceDiagram\n  Alice->>Bob: Hi", 80);
+
+        assert!(text.contains("Alice"), "participant missing: {text}");
+        assert!(text.contains("Bob"), "participant missing: {text}");
+        assert!(text.contains("Hi"), "label missing: {text}");
+    }
+
+    #[test]
+    fn self_message_draws_u_shaped_loop() {
+        let text = render_text("sequenceDiagram\n  Alice->>Alice: Loop", 80);
+
+        assert!(
+            text.contains("│──┐") || text.contains("┌──│"),
+            "missing self-loop top: {text}"
+        );
+        assert!(
+            text.contains("│◀─┘")
+                || text.contains("│◄─┘")
+                || text.contains("└─▶│")
+                || text.contains("└─►│"),
+            "missing self-loop return: {text}"
+        );
+        assert!(compact(&text).contains("Loop"), "label missing: {text}");
+        // Label sits beside the loop, not punched through the lifeline.
+        assert!(
+            !text.contains("Lo│op"),
+            "label should not straddle lifeline: {text}"
+        );
+        for line in text.lines().skip(1) {
+            assert_eq!(
+                line.matches('│').count(),
+                1,
+                "lifeline overwritten: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn self_message_on_last_participant_loops_left() {
+        let source = "sequenceDiagram
+    participant A
+    participant B
+    B->>B: Refresh";
+        let text = render_text(source, 40);
+        assert!(
+            text.contains("┌──│") || text.contains("┌─│"),
+            "last column should loop left: {text}"
+        );
+        assert!(
+            text.contains("└─▶│")
+                || text.contains("└─►│")
+                || text.contains("└──▶│")
+                || text.contains("└──►│"),
+            "missing left-side return arrow: {text}"
+        );
+        assert!(compact(&text).contains("Refresh"), "label missing: {text}");
+    }
+
+    #[test]
+    fn unparseable_source_returns_none() {
+        assert!(render_sequence_diagram("sequenceDiagram\n", 80, &theme()).is_none());
+        assert!(
+            render_sequence_diagram("sequenceDiagram\n  just some prose", 80, &theme()).is_none()
+        );
+    }
+}

--- a/crates/tui/src/render/mod.rs
+++ b/crates/tui/src/render/mod.rs
@@ -7,6 +7,7 @@ mod layout;
 mod log;
 mod log_column;
 mod log_style;
+mod mermaid_sequence;
 pub(crate) mod popups;
 pub(crate) mod render_md;
 pub(crate) mod renderable;

--- a/crates/tui/src/render/popups/mermaid_popup.rs
+++ b/crates/tui/src/render/popups/mermaid_popup.rs
@@ -1,0 +1,84 @@
+//! Mermaid source popup — double-click a rendered diagram in the log to copy
+//! the original fence body (`y`).
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{Paragraph, Scrollbar, ScrollbarState, Wrap},
+};
+
+use crate::widgets::state::App;
+
+pub(crate) fn render_mermaid_popup(frame: &mut Frame, area: Rect, app: &mut App) {
+    let popup = match &app.mermaid_popup {
+        Some(p) => p,
+        None => return,
+    };
+    if popup.block_idx >= app.mermaid_blocks.len() {
+        return;
+    }
+    let source = app.mermaid_blocks[popup.block_idx].source.clone();
+    let lines: Vec<&str> = source.lines().collect();
+    let total = lines.len().max(1);
+
+    let popup_area = super::centered_popup_area(area);
+    let footer: &[super::FooterHint] = &[
+        super::FooterHint {
+            key: "y",
+            label: " copy ",
+        },
+        super::FooterHint {
+            key: "j/k",
+            label: " scroll ",
+        },
+        super::FooterHint {
+            key: "Esc",
+            label: " close ",
+        },
+    ];
+    let inner =
+        super::render_popup_chrome(frame, popup_area, &app.theme, " mermaid ", Some(footer));
+
+    let content_height = inner.height as usize;
+    let max_scroll = total.saturating_sub(1);
+    let scroll = (popup.scroll as usize).min(max_scroll);
+    let start_line = scroll;
+    let end_line = (scroll + content_height).min(total);
+
+    let mut text = Text::default();
+    let title_style = Style::default()
+        .fg(app.theme.accent)
+        .add_modifier(Modifier::BOLD);
+    text.push_line(Line::from(Span::styled(
+        format!("```mermaid ({} lines)", lines.len()),
+        title_style,
+    )));
+    text.push_line(Line::from(""));
+
+    let max_chars = popup_area.width.saturating_sub(4) as usize;
+    if lines.is_empty() {
+        text.push_line(Line::from(""));
+    } else {
+        for &line in &lines[start_line..end_line] {
+            let display: String = line.chars().take(max_chars).collect();
+            text.push_line(Line::from(Span::styled(
+                display,
+                Style::default().fg(app.theme.fg),
+            )));
+        }
+    }
+
+    let para = Paragraph::new(text).wrap(Wrap { trim: false });
+    frame.render_widget(para, inner);
+
+    let scrollbar =
+        Scrollbar::default().orientation(ratatui::widgets::ScrollbarOrientation::VerticalRight);
+    let mut state = ScrollbarState::new(total)
+        .viewport_content_length(content_height)
+        .position(scroll);
+    frame.render_stateful_widget(scrollbar, popup_area, &mut state);
+
+    app.mouse.mermaid_popup_area = popup_area;
+}

--- a/crates/tui/src/render/popups/mod.rs
+++ b/crates/tui/src/render/popups/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod diff_popup;
 pub(crate) mod file_picker;
 pub(crate) mod help;
 pub(crate) mod history;
+pub(crate) mod mermaid_popup;
 pub(crate) mod select;
 pub(crate) mod selectable_text;
 pub(crate) mod slash_command;

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -288,6 +288,35 @@ fn flush_renders_streamed_mermaid_without_trailing_newline() {
     assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
 }
 
+#[test]
+fn flush_falls_back_to_code_card_for_unclosed_streamed_mermaid() {
+    // The Mermaid body is fully parseable, but the closing fence never
+    // arrives: the stream was interrupted, so the buffered block must take
+    // the code-card fallback and retain its source — never splice a diagram.
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert_eq!(
+        app.code_blocks.len(),
+        1,
+        "unclosed Mermaid must use code fallback"
+    );
+    let content = &app.code_blocks[0].content;
+    assert!(
+        content.contains("sequenceDiagram") && content.contains("Alice->>Bob: Hello"),
+        "fallback lost source: {content:?}"
+    );
+    assert!(
+        text.contains("mermaid"),
+        "code card should still render in the log, got:\n{text}"
+    );
+}
+
 // --- P1: Normal mode, plan states, popup scroll, file picker highlight, focus ---
 
 #[test]

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -356,6 +356,59 @@ fn flush_falls_back_to_code_card_for_unclosed_streamed_mermaid() {
     );
 }
 
+#[test]
+fn flush_falls_back_to_code_card_for_unclosed_streamed_mermaid_with_nested_fence() {
+    // The buffered Mermaid source itself contains a literal ```mermaid fence
+    // line. The fallback preview must be rendered through the plain code path
+    // exactly once: re-routing the reconstructed preview fence through the
+    // Mermaid router would parse the nested fence as a real diagram and draw
+    // box-art inside the code card.
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```mermaid\nflowchart TD\n  A --> B\n"
+            .into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert_eq!(
+        app.code_blocks.len(),
+        1,
+        "unclosed Mermaid must use code fallback"
+    );
+    let block = &app.code_blocks[0];
+    assert_eq!(
+        block.lang, "mermaid",
+        "card must keep the original language metadata"
+    );
+    assert!(
+        block.content.contains("sequenceDiagram") && block.content.contains("A --> B"),
+        "fallback lost source: {:?}",
+        block.content
+    );
+    let preview = block
+        .styled
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        preview.contains("sequenceDiagram")
+            && preview.contains("Alice")
+            && preview.contains("A --> B"),
+        "styled preview must contain the raw source, got:\n{preview}"
+    );
+    assert!(
+        !preview.contains('─') && !preview.contains('│'),
+        "styled preview must not contain diagram box-art, got:\n{preview}"
+    );
+    assert!(
+        text.contains("mermaid"),
+        "code card should still render in the log, got:\n{text}"
+    );
+}
+
 // --- P1: Normal mode, plan states, popup scroll, file picker highlight, focus ---
 
 #[test]

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -203,6 +203,35 @@ fn log_renders_streamed_code_block_card() {
 }
 
 #[test]
+fn log_renders_streamed_mermaid_without_code_card() {
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```\n".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert!(app.code_blocks.is_empty(), "valid Mermaid must not become a code card");
+    assert!(text.contains("Alice") && text.contains("Bob"), "diagram missing: {text}");
+    assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
+}
+
+#[test]
+fn log_falls_back_to_code_card_for_invalid_streamed_mermaid() {
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nnot valid Mermaid\n```\n".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert_eq!(app.code_blocks.len(), 1, "invalid Mermaid should use code fallback");
+    assert!(text.contains("not valid Mermaid"), "fallback lost source: {text}");
+}
+
+#[test]
 fn flush_consumes_closing_fence_without_trailing_newline() {
     // Stream ends with ``` and no final \n — the close fence stays in stream.buffer.
     // Flush must treat it as a close, not re-render it as leaked ``` lines.
@@ -237,6 +266,26 @@ fn flush_consumes_closing_fence_without_trailing_newline() {
         text.contains("Commit: abc") && (text.contains("当前状态") || text.contains("a")),
         "cards/content should still render, got:\n{text}"
     );
+}
+
+#[test]
+fn flush_renders_streamed_mermaid_without_trailing_newline() {
+    // Stream ends with ``` and no final \n — the close fence stays in
+    // stream.buffer and flush must finalize a valid diagram, never a code card.
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert!(
+        app.code_blocks.is_empty(),
+        "valid Mermaid must not become a code card"
+    );
+    assert!(text.contains("Alice") && text.contains("Bob"), "diagram missing: {text}");
+    assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
 }
 
 // --- P1: Normal mode, plan states, popup scroll, file picker highlight, focus ---

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -212,9 +212,18 @@ fn log_renders_streamed_mermaid_without_code_card() {
 
     let text = render_main_area_text(&mut app, 100, 30);
 
-    assert!(app.code_blocks.is_empty(), "valid Mermaid must not become a code card");
-    assert!(text.contains("Alice") && text.contains("Bob"), "diagram missing: {text}");
-    assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
+    assert!(
+        app.code_blocks.is_empty(),
+        "valid Mermaid must not become a code card"
+    );
+    assert!(
+        text.contains("Alice") && text.contains("Bob"),
+        "diagram missing: {text}"
+    );
+    assert!(
+        !text.contains("sequenceDiagram"),
+        "raw Mermaid leaked: {text}"
+    );
 }
 
 #[test]
@@ -227,8 +236,15 @@ fn log_falls_back_to_code_card_for_invalid_streamed_mermaid() {
 
     let text = render_main_area_text(&mut app, 100, 30);
 
-    assert_eq!(app.code_blocks.len(), 1, "invalid Mermaid should use code fallback");
-    assert!(text.contains("not valid Mermaid"), "fallback lost source: {text}");
+    assert_eq!(
+        app.code_blocks.len(),
+        1,
+        "invalid Mermaid should use code fallback"
+    );
+    assert!(
+        text.contains("not valid Mermaid"),
+        "fallback lost source: {text}"
+    );
 }
 
 #[test]
@@ -284,8 +300,14 @@ fn flush_renders_streamed_mermaid_without_trailing_newline() {
         app.code_blocks.is_empty(),
         "valid Mermaid must not become a code card"
     );
-    assert!(text.contains("Alice") && text.contains("Bob"), "diagram missing: {text}");
-    assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
+    assert!(
+        text.contains("Alice") && text.contains("Bob"),
+        "diagram missing: {text}"
+    );
+    assert!(
+        !text.contains("sequenceDiagram"),
+        "raw Mermaid leaked: {text}"
+    );
 }
 
 #[test]

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -216,6 +216,18 @@ fn log_renders_streamed_mermaid_without_code_card() {
         app.code_blocks.is_empty(),
         "valid Mermaid must not become a code card"
     );
+    assert_eq!(
+        app.mermaid_blocks.len(),
+        1,
+        "valid Mermaid must retain source metadata"
+    );
+    assert!(
+        app.mermaid_blocks[0]
+            .source
+            .contains("Alice->>Bob: Hello"),
+        "mermaid source missing: {}",
+        app.mermaid_blocks[0].source
+    );
     assert!(
         text.contains("Alice") && text.contains("Bob"),
         "diagram missing: {text}"
@@ -224,6 +236,31 @@ fn log_renders_streamed_mermaid_without_code_card() {
         !text.contains("sequenceDiagram"),
         "raw Mermaid leaked: {text}"
     );
+}
+
+#[test]
+fn mermaid_popup_copy_uses_source_not_ascii() {
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```\n".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    assert_eq!(app.mermaid_blocks.len(), 1);
+    let ascii = app.raw_messages[app.mermaid_blocks[0].start_idx].clone();
+    assert!(
+        !ascii.contains("sequenceDiagram"),
+        "raw_messages should hold ASCII diagram, got: {ascii}"
+    );
+
+    app.open_mermaid_popup(0);
+    let popup = app.mermaid_popup.as_ref().expect("popup open");
+    assert_eq!(
+        app.mermaid_blocks[popup.block_idx].source, "sequenceDiagram\n  Alice->>Bob: Hello",
+        "popup must point at Mermaid source"
+    );
+    // Exercise the copy path (system clipboard may or may not be available).
+    app.copy_mermaid_popup();
 }
 
 #[test]
@@ -240,6 +277,10 @@ fn log_falls_back_to_code_card_for_invalid_streamed_mermaid() {
         app.code_blocks.len(),
         1,
         "invalid Mermaid should use code fallback"
+    );
+    assert!(
+        app.mermaid_blocks.is_empty(),
+        "invalid Mermaid must not register a MermaidBlock"
     );
     assert!(
         text.contains("not valid Mermaid"),

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -222,9 +222,7 @@ fn log_renders_streamed_mermaid_without_code_card() {
         "valid Mermaid must retain source metadata"
     );
     assert!(
-        app.mermaid_blocks[0]
-            .source
-            .contains("Alice->>Bob: Hello"),
+        app.mermaid_blocks[0].source.contains("Alice->>Bob: Hello"),
         "mermaid source missing: {}",
         app.mermaid_blocks[0].source
     );

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -328,10 +328,27 @@ fn flush_falls_back_to_code_card_for_unclosed_streamed_mermaid() {
         1,
         "unclosed Mermaid must use code fallback"
     );
-    let content = &app.code_blocks[0].content;
+    let block = &app.code_blocks[0];
     assert!(
-        content.contains("sequenceDiagram") && content.contains("Alice->>Bob: Hello"),
-        "fallback lost source: {content:?}"
+        block.content.contains("sequenceDiagram") && block.content.contains("Alice->>Bob: Hello"),
+        "fallback lost source: {:?}",
+        block.content
+    );
+    // The card preview must show the readable raw source, not a diagram drawn
+    // from a fence that never actually closed.
+    let preview = block
+        .styled
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        preview.contains("sequenceDiagram") && preview.contains("Alice"),
+        "styled preview must contain the raw source, got:\n{preview}"
+    );
+    assert!(
+        !preview.contains('─') && !preview.contains('│'),
+        "styled preview must not contain diagram box-art, got:\n{preview}"
     );
     assert!(
         text.contains("mermaid"),

--- a/crates/tui/src/render/render_md.rs
+++ b/crates/tui/src/render/render_md.rs
@@ -145,6 +145,11 @@ impl RichTextTheme for TuiRichTextTheme<'_> {
 
 /// Render a Mermaid diagram through ratatui-markdown with the app theme.
 ///
+/// Sequence diagrams are handled by Tact's own renderer (see
+/// [`mermaid_sequence`]) because the upstream sequence renderer mishandles
+/// `participant X as 名称` aliases, the `+`/`-` activation shorthand, and
+/// CJK arrow labels.
+///
 /// Returns `None` when the source cannot be parsed or rendered so callers can
 /// fall back to ordinary code rendering.
 pub(crate) fn render_mermaid_block(
@@ -152,7 +157,16 @@ pub(crate) fn render_mermaid_block(
     theme: &Theme,
     width: usize,
 ) -> Option<Vec<Line<'static>>> {
-    render_mermaid(source, width.max(1), None, &TuiRichTextTheme { theme })
+    let width = width.max(1);
+    if source
+        .lines()
+        .next()
+        .map(str::trim)
+        .is_some_and(|l| l.starts_with("sequenceDiagram"))
+    {
+        return super::mermaid_sequence::render_sequence_diagram(source, width, theme);
+    }
+    render_mermaid(source, width, None, &TuiRichTextTheme { theme })
 }
 
 /// Layout width used when a caller has no explicit width to pass.

--- a/crates/tui/src/render/render_md.rs
+++ b/crates/tui/src/render/render_md.rs
@@ -172,13 +172,17 @@ type SegmentRenderer = fn(&str, &Theme, Option<usize>) -> (Vec<Line<'static>>, V
 /// delegated to `render_segment` with the caller's width passed through
 /// unchanged — `None` keeps meaning "unlimited" for table layout. Only
 /// *top-level* Mermaid fences are routed: while scanning, non-Mermaid fenced
-/// blocks ( ` ```rust `, ` ```text `, bare ` ``` `, …) are tracked so a
-/// literal ` ```mermaid ` line inside ordinary code is passed through
-/// unchanged until its matching closing fence — it is code content, never a
-/// diagram. When a Mermaid fence cannot be rendered (or is never closed) the
-/// original fence text goes through the existing code renderer instead, so no
-/// source is ever dropped. Returns styled lines plus their raw text, keeping
-/// the same shape as the existing renderers.
+/// blocks ( ` ```rust `, ` ```text `, bare ` ``` `, `~~~text`, ` ````text `,
+/// …) are tracked with their opener marker (`` ` `` or `~`) and run length so
+/// a literal ` ```mermaid ` line inside ordinary code is passed through
+/// unchanged until a matching closing fence — it is code content, never a
+/// diagram. A fence closes only on a line of the same marker with at least
+/// the opener's run length and a whitespace-only suffix, so an inner ` ``` `
+/// inside a ` ````text ` block is content, not the close. When a Mermaid
+/// fence cannot be rendered (or is never closed) the original fence text goes
+/// through the existing code renderer instead, so no source is ever dropped.
+/// Returns styled lines plus their raw text, keeping the same shape as the
+/// existing renderers.
 fn route_mermaid_fences(
     text: &str,
     theme: &Theme,
@@ -194,16 +198,18 @@ fn route_mermaid_fences(
     let mermaid_width = width.unwrap_or(DEFAULT_RENDER_WIDTH).max(1);
 
     let mut lines = text.lines();
-    let mut in_non_mermaid_fence = false;
+    let mut fence: Option<Fence> = None;
     while let Some(line) = lines.next() {
-        if in_non_mermaid_fence {
-            // Inside an ordinary fenced block: pass everything through until
-            // its closing fence, so a literal ```mermaid inside e.g. ```rust
-            // is never mistaken for a top-level diagram.
+        if let Some(opener) = fence {
+            // Inside an ordinary fenced block: pass everything through until a
+            // matching closing fence (same marker, at least the opener's run
+            // length, whitespace-only suffix), so a literal ```mermaid inside
+            // e.g. ~~~text or ````text is never mistaken for a top-level
+            // diagram.
             chunk.push_str(line);
             chunk.push('\n');
-            if line.trim() == "```" {
-                in_non_mermaid_fence = false;
+            if is_fence_closer(line, opener) {
+                fence = None;
             }
             continue;
         }
@@ -259,10 +265,11 @@ fn route_mermaid_fences(
             continue;
         }
 
-        if is_fence_opener(line) {
-            // Ordinary (non-Mermaid) fence opener: track the block so any
-            // Mermaid-looking line inside it stays literal code content.
-            in_non_mermaid_fence = true;
+        if let Some(opener) = parse_fence_opener(line) {
+            // Ordinary (non-Mermaid) fence opener — backtick or tilde, run
+            // length ≥ 3: track the block so any Mermaid-looking line inside
+            // it stays literal code content.
+            fence = Some(opener);
             chunk.push_str(line);
             chunk.push('\n');
             continue;
@@ -311,13 +318,50 @@ fn mermaid_fence_opener(line: &str) -> Option<()> {
     lang.eq_ignore_ascii_case("mermaid").then_some(())
 }
 
-/// Detect any Markdown fence opener.
+/// A Markdown fenced-block descriptor: the fence marker character (`` ` `` or
+/// `~`) and the length of its opening run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Fence {
+    marker: char,
+    run_len: usize,
+}
+
+/// Minimum fence run length required by CommonMark (``` / ~~~).
+const MIN_FENCE_RUN: usize = 3;
+
+/// Parse a valid CommonMark-style fence opener.
 ///
-/// A line whose trimmed form starts with three backticks opens a fence,
-/// whether its language is `mermaid`, another language (`rust`, `text`, …),
-/// or absent (a bare ` ``` ` with no info string).
-fn is_fence_opener(line: &str) -> bool {
-    line.trim().starts_with("```")
+/// A line whose trimmed form starts with at least three backticks or tildes
+/// opens a fence; the remainder is the info string. Backtick fences reject an
+/// info string containing a backtick (CommonMark); tilde fences accept any
+/// info string.
+fn parse_fence_opener(line: &str) -> Option<Fence> {
+    let trimmed = line.trim();
+    let marker = trimmed.chars().next()?;
+    if marker != '`' && marker != '~' {
+        return None;
+    }
+    let run_len = trimmed.chars().take_while(|&c| c == marker).count();
+    if run_len < MIN_FENCE_RUN {
+        return None;
+    }
+    if marker == '`' && trimmed[run_len..].contains('`') {
+        return None;
+    }
+    Some(Fence { marker, run_len })
+}
+
+/// Recognize a closing fence for `opener`.
+///
+/// The closing line must start (after trimming) with the same marker, have a
+/// run at least as long as the opener's, and contain only whitespace after the
+/// run — a shorter run, a different marker, or any non-whitespace suffix is
+/// content, not a close. (Marker runs are ASCII, so byte indices equal char
+/// indices.)
+fn is_fence_closer(line: &str, opener: Fence) -> bool {
+    let trimmed = line.trim();
+    let run_len = trimmed.chars().take_while(|&c| c == opener.marker).count();
+    run_len >= opener.run_len && trimmed[run_len..].chars().all(char::is_whitespace)
 }
 
 /// Renders Markdown text into ratatui Line list and raw text list using tui-markdown.
@@ -911,6 +955,49 @@ mod tests {
                 "nested Mermaid fence must not render a diagram (```{lang}): {text}"
             );
         }
+    }
+
+    #[test]
+    fn render_markdown_mermaid_fence_inside_tilde_fence_is_literal() {
+        // A literal ```mermaid block inside a non-Mermaid tilde fence
+        // (~~~text) is code content, never a diagram: the router must track
+        // tilde fences just like backtick fences.
+        let md = "~~~text\n```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```\n~~~\n";
+        let (lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(
+            text.contains("sequenceDiagram") && text.contains("Alice->>Bob: Hello"),
+            "literal Mermaid fence inside ~~~text must stay code content: {text}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.to_string().contains('─') || l.to_string().contains('│')),
+            "literal Mermaid fence inside ~~~text must not render a diagram: {text}"
+        );
+    }
+
+    #[test]
+    fn render_markdown_mermaid_fence_inside_longer_backtick_fence_is_literal() {
+        // A four-backtick ```text fence containing a literal ```mermaid line
+        // and an inner ``` line must stay literal code until the four-backtick
+        // close: the inner three-backtick line is content, not the closing
+        // fence, and no diagram may be routed.
+        let md = "````text\n```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```\n````\n";
+        let (lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(
+            text.contains("sequenceDiagram") && text.contains("Alice->>Bob: Hello"),
+            "literal Mermaid fence inside ````text must stay code content: {text}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.to_string().contains('─') || l.to_string().contains('│')),
+            "literal Mermaid fence inside ````text must not render a diagram: {text}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/render/render_md.rs
+++ b/crates/tui/src/render/render_md.rs
@@ -5,6 +5,10 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+use ratatui_markdown::{
+    mermaid::{render_mermaid, theme::MermaidTheme},
+    theme::{CodeColors, Generation, RichTextTheme},
+};
 use unicode_width::UnicodeWidthStr;
 
 use crate::{render::util::split_at_display_width, theme::Theme};
@@ -58,6 +62,98 @@ impl tui_markdown::StyleSheet for TuiStyleSheet {
     fn metadata_block(&self) -> Style {
         Style::new().fg(self.theme.warning)
     }
+}
+
+/// Maps the app [`Theme`] into ratatui-markdown's `RichTextTheme`.
+///
+/// Shared by the Mermaid renderer and the `/tasks-dag` popup so both use the
+/// exact same color mapping.
+#[derive(Clone, Copy)]
+pub(crate) struct TuiRichTextTheme<'a> {
+    pub theme: &'a Theme,
+}
+
+impl RichTextTheme for TuiRichTextTheme<'_> {
+    fn generation(&self) -> Generation {
+        Generation(0)
+    }
+
+    fn get_text_color(&self) -> Color {
+        self.theme.fg
+    }
+
+    fn get_muted_text_color(&self) -> Color {
+        self.theme.muted_fg()
+    }
+
+    fn get_primary_color(&self) -> Color {
+        self.theme.accent
+    }
+
+    fn get_popup_selected_background(&self) -> Color {
+        self.theme.highlight
+    }
+
+    fn get_border_color(&self) -> Color {
+        self.theme.border
+    }
+
+    fn get_focused_border_color(&self) -> Color {
+        self.theme.accent
+    }
+
+    fn get_secondary_color(&self) -> Color {
+        self.theme.success
+    }
+
+    fn get_info_color(&self) -> Color {
+        self.theme.heading
+    }
+
+    fn get_json_key_color(&self) -> Color {
+        self.theme.heading
+    }
+
+    fn get_json_string_color(&self) -> Color {
+        self.theme.success
+    }
+
+    fn get_json_number_color(&self) -> Color {
+        self.theme.accent
+    }
+
+    fn get_json_bool_color(&self) -> Color {
+        self.theme.warning
+    }
+
+    fn get_json_null_color(&self) -> Color {
+        self.theme.muted
+    }
+
+    fn get_accent_yellow(&self) -> Color {
+        self.theme.warning
+    }
+
+    fn get_code_colors(&self) -> CodeColors {
+        CodeColors::default()
+    }
+
+    fn get_mermaid_theme(&self) -> MermaidTheme {
+        MermaidTheme::for_background(self.theme.bg)
+    }
+}
+
+/// Render a Mermaid diagram through ratatui-markdown with the app theme.
+///
+/// Returns `None` when the source cannot be parsed or rendered so callers can
+/// fall back to ordinary code rendering.
+#[allow(dead_code)] // consumed by main-area markdown routing (wired in by a later task); exercised by unit tests
+pub(crate) fn render_mermaid_block(
+    source: &str,
+    theme: &Theme,
+    width: usize,
+) -> Option<Vec<Line<'static>>> {
+    render_mermaid(source, width.max(1), None, &TuiRichTextTheme { theme })
 }
 
 /// Renders Markdown text into ratatui Line list and raw text list using tui-markdown.
@@ -497,6 +593,29 @@ mod tests {
 
     fn theme() -> Theme {
         Theme::from(ThemeName::from_str("retro").unwrap())
+    }
+
+    #[test]
+    fn render_mermaid_sequence_returns_terminal_lines() {
+        let source = "sequenceDiagram\n    Alice->>Bob: Hello\n    Bob-->>Alice: Hi";
+        let lines = render_mermaid_block(source, &theme(), 80).expect("valid sequence diagram");
+        let text = lines
+            .iter()
+            .map(Line::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(text.contains("Alice"), "participant missing: {text}");
+        assert!(text.contains("Bob"), "participant missing: {text}");
+        assert!(text.contains("Hello"), "message missing: {text}");
+        assert!(
+            text.contains('─') || text.contains('>'),
+            "diagram art missing: {text}"
+        );
+        assert!(
+            !text.contains("sequenceDiagram"),
+            "raw source leaked: {text}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/render/render_md.rs
+++ b/crates/tui/src/render/render_md.rs
@@ -167,20 +167,27 @@ type SegmentRenderer = fn(&str, &Theme, Option<usize>) -> (Vec<Line<'static>>, V
 /// Route complete, top-level `mermaid` fences out of `text`.
 ///
 /// A closed ` ```mermaid ` fence is rendered by `render_mermaid_block` at
-/// `width`; every other chunk (prose, pipe tables, non-Mermaid code fences)
-/// is delegated to `render_segment`. When a Mermaid fence cannot be rendered
-/// (or is never closed) the original fence text goes through the existing
-/// code renderer instead, so no source is ever dropped. Returns styled lines
-/// plus their raw text, keeping the same shape as the existing renderers.
+/// `width` (bounded to [`DEFAULT_RENDER_WIDTH`] when no width is given);
+/// every other chunk (prose, pipe tables, non-Mermaid code fences) is
+/// delegated to `render_segment` with the caller's width passed through
+/// unchanged — `None` keeps meaning "unlimited" for table layout. When a
+/// Mermaid fence cannot be rendered (or is never closed) the original fence
+/// text goes through the existing code renderer instead, so no source is ever
+/// dropped. Returns styled lines plus their raw text, keeping the same shape
+/// as the existing renderers.
 fn route_mermaid_fences(
     text: &str,
     theme: &Theme,
-    width: usize,
+    width: Option<usize>,
     render_segment: SegmentRenderer,
 ) -> (Vec<Line<'static>>, Vec<String>) {
     let mut styled_lines = Vec::new();
     let mut raw_lines = Vec::new();
     let mut chunk = String::new();
+
+    // Mermaid layout needs a concrete width; tables/prose keep the caller's
+    // optional width untouched (None = unlimited).
+    let mermaid_width = width.unwrap_or(DEFAULT_RENDER_WIDTH).max(1);
 
     let mut lines = text.lines();
     while let Some(line) = lines.next() {
@@ -215,13 +222,13 @@ fn route_mermaid_fences(
         if !closed {
             // Unclosed fence: keep it as ordinary code content, never drop it.
             let block = format!("```mermaid\n{source}");
-            let (s, r) = render_plain_markdown(&block, theme, Some(width));
+            let (s, r) = render_plain_markdown(&block, theme, width);
             styled_lines.extend(s);
             raw_lines.extend(r);
             continue;
         }
 
-        match render_mermaid_block(&source, theme, width.max(1)) {
+        match render_mermaid_block(&source, theme, mermaid_width) {
             Some(rendered) => {
                 for line in rendered {
                     let raw = line.to_string();
@@ -232,7 +239,7 @@ fn route_mermaid_fences(
             None => {
                 // Invalid diagram: send the original fence through the code renderer.
                 let block = format!("```mermaid\n{source}```");
-                let (s, r) = render_plain_markdown(&block, theme, Some(width));
+                let (s, r) = render_plain_markdown(&block, theme, width);
                 styled_lines.extend(s);
                 raw_lines.extend(r);
             }
@@ -256,11 +263,11 @@ fn flush_segment(
     raw_lines: &mut Vec<String>,
     chunk: &mut String,
     theme: &Theme,
-    width: usize,
+    width: Option<usize>,
     render_segment: SegmentRenderer,
 ) {
     if !chunk.trim().is_empty() {
-        let (s, r) = render_segment(chunk, theme, Some(width));
+        let (s, r) = render_segment(chunk, theme, width);
         styled_lines.extend(s);
         raw_lines.extend(r);
         chunk.clear();
@@ -284,7 +291,12 @@ fn mermaid_fence_opener(line: &str) -> Option<()> {
 /// at a nominal [`DEFAULT_RENDER_WIDTH`]; all other content keeps the plain
 /// tui-markdown pipeline.
 pub(crate) fn render_markdown_tui(text: &str, theme: &Theme) -> (Vec<Line<'static>>, Vec<String>) {
-    route_mermaid_fences(text, theme, DEFAULT_RENDER_WIDTH, render_plain_markdown)
+    route_mermaid_fences(
+        text,
+        theme,
+        Some(DEFAULT_RENDER_WIDTH),
+        render_plain_markdown,
+    )
 }
 
 /// The plain tui-markdown chunk renderer (no width-aware tables).
@@ -336,8 +348,7 @@ pub(crate) fn render_markdown_with_tables(
     theme: &Theme,
     available_width: Option<usize>,
 ) -> (Vec<Line<'static>>, Vec<String>) {
-    let width = available_width.unwrap_or(DEFAULT_RENDER_WIDTH);
-    route_mermaid_fences(text, theme, width, render_prose_and_tables)
+    route_mermaid_fences(text, theme, available_width, render_prose_and_tables)
 }
 
 /// The width-aware chunk renderer (pipe tables + tui-markdown).
@@ -842,8 +853,9 @@ mod tests {
 
     #[test]
     fn render_markdown_with_tables_routes_mermaid_before_table_scan() {
-        // The diagram source contains `|`-prefixed lines that must not be
-        // mistaken for a pipe table, and prose tables around it must survive.
+        // The diagram source contains a valid `|` inside a node label that
+        // must be rendered as diagram art, never parsed as a pipe table.
+        // Prose tables around it must survive.
         let md = "\
 | A | B |
 | --- | --- |
@@ -851,7 +863,7 @@ mod tests {
 
 ```mermaid
 flowchart LR
-  A[Start] --> B[End]
+  A[Start] --> B[Step | done]
 ```
 
 Trailing prose.
@@ -862,6 +874,10 @@ Trailing prose.
         assert!(
             styled.iter().any(|l| l.to_string().contains('─')),
             "expected diagram box art: {text}"
+        );
+        assert!(
+            text.contains("Step | done"),
+            "node label with `|` must render inside the diagram: {text}"
         );
         assert!(
             text.contains("| A | B |") && text.contains("| 1 | 2 |"),
@@ -1247,6 +1263,24 @@ Plain trailing paragraph.
             raw.iter().any(|l| l.contains("Plain trailing paragraph")),
             "trailing prose missing:\n{}",
             raw.join("\n")
+        );
+    }
+
+    #[test]
+    fn render_markdown_with_tables_none_width_keeps_unlimited_table() {
+        // `None` must flow through to `format_table` unchanged (unlimited):
+        // a long cell stays on a single row instead of being wrapped at the
+        // nominal 80-column width.
+        let cell = "word ".repeat(40); // ~200 chars
+        let long_cell = cell.trim_end();
+        let md = format!("| A | B |\n| --- | --- |\n| 1 | {long_cell} |");
+        let (_styled, raw) = render_markdown_with_tables(&md, &theme(), None);
+        let text = raw.join("\n");
+
+        let full_row = format!("| 1 | {long_cell} |");
+        assert!(
+            text.lines().any(|l| l == full_row),
+            "long cell must stay on one row when width is None:\n{text}"
         );
     }
 }

--- a/crates/tui/src/render/render_md.rs
+++ b/crates/tui/src/render/render_md.rs
@@ -170,11 +170,15 @@ type SegmentRenderer = fn(&str, &Theme, Option<usize>) -> (Vec<Line<'static>>, V
 /// `width` (bounded to [`DEFAULT_RENDER_WIDTH`] when no width is given);
 /// every other chunk (prose, pipe tables, non-Mermaid code fences) is
 /// delegated to `render_segment` with the caller's width passed through
-/// unchanged — `None` keeps meaning "unlimited" for table layout. When a
-/// Mermaid fence cannot be rendered (or is never closed) the original fence
-/// text goes through the existing code renderer instead, so no source is ever
-/// dropped. Returns styled lines plus their raw text, keeping the same shape
-/// as the existing renderers.
+/// unchanged — `None` keeps meaning "unlimited" for table layout. Only
+/// *top-level* Mermaid fences are routed: while scanning, non-Mermaid fenced
+/// blocks ( ` ```rust `, ` ```text `, bare ` ``` `, …) are tracked so a
+/// literal ` ```mermaid ` line inside ordinary code is passed through
+/// unchanged until its matching closing fence — it is code content, never a
+/// diagram. When a Mermaid fence cannot be rendered (or is never closed) the
+/// original fence text goes through the existing code renderer instead, so no
+/// source is ever dropped. Returns styled lines plus their raw text, keeping
+/// the same shape as the existing renderers.
 fn route_mermaid_fences(
     text: &str,
     theme: &Theme,
@@ -190,60 +194,82 @@ fn route_mermaid_fences(
     let mermaid_width = width.unwrap_or(DEFAULT_RENDER_WIDTH).max(1);
 
     let mut lines = text.lines();
+    let mut in_non_mermaid_fence = false;
     while let Some(line) = lines.next() {
-        if mermaid_fence_opener(line).is_none() {
+        if in_non_mermaid_fence {
+            // Inside an ordinary fenced block: pass everything through until
+            // its closing fence, so a literal ```mermaid inside e.g. ```rust
+            // is never mistaken for a top-level diagram.
+            chunk.push_str(line);
+            chunk.push('\n');
+            if line.trim() == "```" {
+                in_non_mermaid_fence = false;
+            }
+            continue;
+        }
+
+        if mermaid_fence_opener(line).is_some() {
+            // Collect source lines until a trimmed closing fence.
+            let mut source = String::new();
+            let mut closed = false;
+            for src in lines.by_ref() {
+                if src.trim() == "```" {
+                    closed = true;
+                    break;
+                }
+                source.push_str(src);
+                source.push('\n');
+            }
+
+            // Flush preceding prose so the diagram keeps its position in the doc.
+            flush_segment(
+                &mut styled_lines,
+                &mut raw_lines,
+                &mut chunk,
+                theme,
+                width,
+                render_segment,
+            );
+
+            if !closed {
+                // Unclosed fence: keep it as ordinary code content, never drop it.
+                let block = format!("```mermaid\n{source}");
+                let (s, r) = render_plain_markdown(&block, theme, width);
+                styled_lines.extend(s);
+                raw_lines.extend(r);
+                continue;
+            }
+
+            match render_mermaid_block(&source, theme, mermaid_width) {
+                Some(rendered) => {
+                    for line in rendered {
+                        let raw = line.to_string();
+                        raw_lines.push(raw);
+                        styled_lines.push(line);
+                    }
+                }
+                None => {
+                    // Invalid diagram: send the original fence through the code renderer.
+                    let block = format!("```mermaid\n{source}```");
+                    let (s, r) = render_plain_markdown(&block, theme, width);
+                    styled_lines.extend(s);
+                    raw_lines.extend(r);
+                }
+            }
+            continue;
+        }
+
+        if is_fence_opener(line) {
+            // Ordinary (non-Mermaid) fence opener: track the block so any
+            // Mermaid-looking line inside it stays literal code content.
+            in_non_mermaid_fence = true;
             chunk.push_str(line);
             chunk.push('\n');
             continue;
         }
 
-        // Collect source lines until a trimmed closing fence.
-        let mut source = String::new();
-        let mut closed = false;
-        for src in lines.by_ref() {
-            if src.trim() == "```" {
-                closed = true;
-                break;
-            }
-            source.push_str(src);
-            source.push('\n');
-        }
-
-        // Flush preceding prose so the diagram keeps its position in the doc.
-        flush_segment(
-            &mut styled_lines,
-            &mut raw_lines,
-            &mut chunk,
-            theme,
-            width,
-            render_segment,
-        );
-
-        if !closed {
-            // Unclosed fence: keep it as ordinary code content, never drop it.
-            let block = format!("```mermaid\n{source}");
-            let (s, r) = render_plain_markdown(&block, theme, width);
-            styled_lines.extend(s);
-            raw_lines.extend(r);
-            continue;
-        }
-
-        match render_mermaid_block(&source, theme, mermaid_width) {
-            Some(rendered) => {
-                for line in rendered {
-                    let raw = line.to_string();
-                    raw_lines.push(raw);
-                    styled_lines.push(line);
-                }
-            }
-            None => {
-                // Invalid diagram: send the original fence through the code renderer.
-                let block = format!("```mermaid\n{source}```");
-                let (s, r) = render_plain_markdown(&block, theme, width);
-                styled_lines.extend(s);
-                raw_lines.extend(r);
-            }
-        }
+        chunk.push_str(line);
+        chunk.push('\n');
     }
 
     flush_segment(
@@ -285,6 +311,15 @@ fn mermaid_fence_opener(line: &str) -> Option<()> {
     lang.eq_ignore_ascii_case("mermaid").then_some(())
 }
 
+/// Detect any Markdown fence opener.
+///
+/// A line whose trimmed form starts with three backticks opens a fence,
+/// whether its language is `mermaid`, another language (`rust`, `text`, …),
+/// or absent (a bare ` ``` ` with no info string).
+fn is_fence_opener(line: &str) -> bool {
+    line.trim().starts_with("```")
+}
+
 /// Renders Markdown text into ratatui Line list and raw text list using tui-markdown.
 ///
 /// Complete top-level ` ```mermaid ` fences are rendered as terminal diagrams
@@ -299,8 +334,11 @@ pub(crate) fn render_markdown_tui(text: &str, theme: &Theme) -> (Vec<Line<'stati
     )
 }
 
-/// The plain tui-markdown chunk renderer (no width-aware tables).
-fn render_plain_markdown(
+/// The plain tui-markdown chunk renderer (no width-aware tables, no Mermaid
+/// routing). Fallback code-card previews go through this path directly so a
+/// reconstructed fallback fence is never re-routed through the Mermaid
+/// renderer.
+pub(crate) fn render_plain_markdown(
     text: &str,
     theme: &Theme,
     _width: Option<usize>,
@@ -849,6 +887,63 @@ mod tests {
         let text = raw.join("\n");
 
         assert!(text.contains("fn kept() {}"), "code source missing: {text}");
+    }
+
+    #[test]
+    fn render_markdown_mermaid_fence_inside_non_mermaid_fence_is_literal() {
+        // A literal ```mermaid line inside an ordinary (non-Mermaid) fenced
+        // block is code content, not a diagram: only top-level Mermaid fences
+        // may be routed. The nested fence must survive unchanged and no box-art
+        // may appear.
+        for lang in ["text", "rust"] {
+            let md = format!("```{lang}\n```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```\n");
+            let (lines, raw) = render_markdown_tui(&md, &theme());
+            let text = raw.join("\n");
+
+            assert!(
+                text.contains("sequenceDiagram") && text.contains("Alice->>Bob: Hello"),
+                "literal Mermaid fence inside ```{lang} must stay code content: {text}"
+            );
+            assert!(
+                !lines
+                    .iter()
+                    .any(|l| l.to_string().contains('─') || l.to_string().contains('│')),
+                "nested Mermaid fence must not render a diagram (```{lang}): {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_markdown_with_tables_mermaid_fence_inside_non_mermaid_fence_is_literal() {
+        // Same guarantee through the width-aware tables pipeline: the router
+        // must pass a non-Mermaid fenced block through before the table
+        // scanner (or the inner markdown pass) ever sees its lines.
+        let md = "\
+prose
+
+```text
+```mermaid
+sequenceDiagram
+  Alice->>Bob: Hello
+```
+";
+        let (lines, raw) = render_markdown_with_tables(md, &theme(), Some(40));
+        let text = raw.join("\n");
+
+        assert!(
+            text.contains("prose"),
+            "surrounding prose must survive: {text}"
+        );
+        assert!(
+            text.contains("sequenceDiagram") && text.contains("Alice->>Bob: Hello"),
+            "literal Mermaid fence inside ```text must stay code content: {text}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.to_string().contains('─') || l.to_string().contains('│')),
+            "nested Mermaid fence must not render a diagram: {text}"
+        );
     }
 
     #[test]

--- a/crates/tui/src/render/render_md.rs
+++ b/crates/tui/src/render/render_md.rs
@@ -147,7 +147,6 @@ impl RichTextTheme for TuiRichTextTheme<'_> {
 ///
 /// Returns `None` when the source cannot be parsed or rendered so callers can
 /// fall back to ordinary code rendering.
-#[allow(dead_code)] // consumed by main-area markdown routing (wired in by a later task); exercised by unit tests
 pub(crate) fn render_mermaid_block(
     source: &str,
     theme: &Theme,
@@ -156,8 +155,144 @@ pub(crate) fn render_mermaid_block(
     render_mermaid(source, width.max(1), None, &TuiRichTextTheme { theme })
 }
 
+/// Layout width used when a caller has no explicit width to pass.
+///
+/// `render_markdown_tui` has no width parameter; Mermaid fences inside it are
+/// laid out at a nominal 80 columns.
+const DEFAULT_RENDER_WIDTH: usize = 80;
+
+/// Renderer for one non-Mermaid chunk of Markdown (prose, tables, code fences).
+type SegmentRenderer = fn(&str, &Theme, Option<usize>) -> (Vec<Line<'static>>, Vec<String>);
+
+/// Route complete, top-level `mermaid` fences out of `text`.
+///
+/// A closed ` ```mermaid ` fence is rendered by `render_mermaid_block` at
+/// `width`; every other chunk (prose, pipe tables, non-Mermaid code fences)
+/// is delegated to `render_segment`. When a Mermaid fence cannot be rendered
+/// (or is never closed) the original fence text goes through the existing
+/// code renderer instead, so no source is ever dropped. Returns styled lines
+/// plus their raw text, keeping the same shape as the existing renderers.
+fn route_mermaid_fences(
+    text: &str,
+    theme: &Theme,
+    width: usize,
+    render_segment: SegmentRenderer,
+) -> (Vec<Line<'static>>, Vec<String>) {
+    let mut styled_lines = Vec::new();
+    let mut raw_lines = Vec::new();
+    let mut chunk = String::new();
+
+    let mut lines = text.lines();
+    while let Some(line) = lines.next() {
+        if mermaid_fence_opener(line).is_none() {
+            chunk.push_str(line);
+            chunk.push('\n');
+            continue;
+        }
+
+        // Collect source lines until a trimmed closing fence.
+        let mut source = String::new();
+        let mut closed = false;
+        for src in lines.by_ref() {
+            if src.trim() == "```" {
+                closed = true;
+                break;
+            }
+            source.push_str(src);
+            source.push('\n');
+        }
+
+        // Flush preceding prose so the diagram keeps its position in the doc.
+        flush_segment(
+            &mut styled_lines,
+            &mut raw_lines,
+            &mut chunk,
+            theme,
+            width,
+            render_segment,
+        );
+
+        if !closed {
+            // Unclosed fence: keep it as ordinary code content, never drop it.
+            let block = format!("```mermaid\n{source}");
+            let (s, r) = render_plain_markdown(&block, theme, Some(width));
+            styled_lines.extend(s);
+            raw_lines.extend(r);
+            continue;
+        }
+
+        match render_mermaid_block(&source, theme, width.max(1)) {
+            Some(rendered) => {
+                for line in rendered {
+                    let raw = line.to_string();
+                    raw_lines.push(raw);
+                    styled_lines.push(line);
+                }
+            }
+            None => {
+                // Invalid diagram: send the original fence through the code renderer.
+                let block = format!("```mermaid\n{source}```");
+                let (s, r) = render_plain_markdown(&block, theme, Some(width));
+                styled_lines.extend(s);
+                raw_lines.extend(r);
+            }
+        }
+    }
+
+    flush_segment(
+        &mut styled_lines,
+        &mut raw_lines,
+        &mut chunk,
+        theme,
+        width,
+        render_segment,
+    );
+    (styled_lines, raw_lines)
+}
+
+/// Render one pending non-Mermaid chunk through the segment renderer.
+fn flush_segment(
+    styled_lines: &mut Vec<Line<'static>>,
+    raw_lines: &mut Vec<String>,
+    chunk: &mut String,
+    theme: &Theme,
+    width: usize,
+    render_segment: SegmentRenderer,
+) {
+    if !chunk.trim().is_empty() {
+        let (s, r) = render_segment(chunk, theme, Some(width));
+        styled_lines.extend(s);
+        raw_lines.extend(r);
+        chunk.clear();
+    }
+}
+
+/// Detect a top-level `mermaid` fence opener.
+///
+/// A line whose trimmed form starts with three backticks opens a fence; the
+/// info string after the backticks must be `mermaid` (case-insensitive).
+fn mermaid_fence_opener(line: &str) -> Option<()> {
+    let trimmed = line.trim();
+    let info = trimmed.strip_prefix("```")?;
+    let lang = info.split_whitespace().next().unwrap_or("");
+    lang.eq_ignore_ascii_case("mermaid").then_some(())
+}
+
 /// Renders Markdown text into ratatui Line list and raw text list using tui-markdown.
+///
+/// Complete top-level ` ```mermaid ` fences are rendered as terminal diagrams
+/// at a nominal [`DEFAULT_RENDER_WIDTH`]; all other content keeps the plain
+/// tui-markdown pipeline.
 pub(crate) fn render_markdown_tui(text: &str, theme: &Theme) -> (Vec<Line<'static>>, Vec<String>) {
+    route_mermaid_fences(text, theme, DEFAULT_RENDER_WIDTH, render_plain_markdown)
+}
+
+/// The plain tui-markdown chunk renderer (no width-aware tables).
+fn render_plain_markdown(
+    text: &str,
+    theme: &Theme,
+    _width: Option<usize>,
+) -> (Vec<Line<'static>>, Vec<String>) {
     let options = tui_markdown::Options::new(TuiStyleSheet::new(*theme));
     let safe_text = escape_task_list_markers(text);
     let tui_text = tui_markdown::from_str_with_options(safe_text.as_ref(), &options);
@@ -191,9 +326,22 @@ pub(crate) fn render_markdown_tui(text: &str, theme: &Theme) -> (Vec<Line<'stati
 /// Pipe-table rows (lines starting with `|`) are extracted and rendered by
 /// `format_table` with `available_width` — long cells wrap inside the table
 /// layout and columns stay aligned. Everything else is delegated to
-/// tui-markdown. System messages like `/skills` produce plain markdown and
-/// go through this single pipeline instead of hand-building ratatui lines.
+/// tui-markdown. Complete top-level ` ```mermaid ` fences are routed to the
+/// Mermaid renderer *before* the table scanner runs, so `|` lines inside a
+/// diagram are never mistaken for table rows. System messages like `/skills`
+/// produce plain markdown and go through this single pipeline instead of
+/// hand-building ratatui lines.
 pub(crate) fn render_markdown_with_tables(
+    text: &str,
+    theme: &Theme,
+    available_width: Option<usize>,
+) -> (Vec<Line<'static>>, Vec<String>) {
+    let width = available_width.unwrap_or(DEFAULT_RENDER_WIDTH);
+    route_mermaid_fences(text, theme, width, render_prose_and_tables)
+}
+
+/// The width-aware chunk renderer (pipe tables + tui-markdown).
+fn render_prose_and_tables(
     text: &str,
     theme: &Theme,
     available_width: Option<usize>,
@@ -615,6 +763,126 @@ mod tests {
         assert!(
             !text.contains("sequenceDiagram"),
             "raw source leaked: {text}"
+        );
+    }
+
+    #[test]
+    fn render_markdown_mermaid_flowchart_uses_box_art() {
+        let md = "```mermaid\nflowchart TD\n  A[Start] --> B[End]\n```";
+        let (lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.to_string().contains('─') || line.to_string().contains('│')),
+            "expected flowchart box art: {text}"
+        );
+        assert!(!text.contains("flowchart TD"), "raw Mermaid leaked: {text}");
+    }
+
+    #[test]
+    fn render_markdown_invalid_mermaid_falls_back_to_code() {
+        let md = "```mermaid\nnot a valid diagram\n```";
+        let (_lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(
+            text.contains("not a valid diagram"),
+            "fallback lost source: {text}"
+        );
+    }
+
+    #[test]
+    fn render_markdown_mermaid_keeps_surrounding_prose() {
+        let md = "before\n\n```mermaid\nflowchart TD\n  A --> B\n```\n\nafter";
+        let (lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(lines.iter().any(|l| l.to_string().contains('─')), "{text}");
+        assert!(text.contains("before"), "leading prose missing: {text}");
+        assert!(text.contains("after"), "trailing prose missing: {text}");
+    }
+
+    #[test]
+    fn render_markdown_unclosed_mermaid_fence_keeps_source() {
+        let md = "```mermaid\nflowchart TD\n  A --> B\n";
+        let (_lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(
+            text.contains("flowchart TD") && text.contains("A --> B"),
+            "unclosed fence must keep its source: {text}"
+        );
+    }
+
+    #[test]
+    fn render_markdown_mermaid_opener_is_case_insensitive() {
+        let md = "```MERMAID\npie title T\n  \"A\" : 1\n```";
+        let (lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.to_string().contains('█') || l.to_string().contains('%')),
+            "uppercase opener should still render: {text}"
+        );
+        assert!(!text.contains("pie title T"), "raw Mermaid leaked: {text}");
+    }
+
+    #[test]
+    fn render_markdown_non_mermaid_fence_stays_code() {
+        let md = "```rust\nfn kept() {}\n```";
+        let (_lines, raw) = render_markdown_tui(md, &theme());
+        let text = raw.join("\n");
+
+        assert!(text.contains("fn kept() {}"), "code source missing: {text}");
+    }
+
+    #[test]
+    fn render_markdown_with_tables_routes_mermaid_before_table_scan() {
+        // The diagram source contains `|`-prefixed lines that must not be
+        // mistaken for a pipe table, and prose tables around it must survive.
+        let md = "\
+| A | B |
+| --- | --- |
+| 1 | 2 |
+
+```mermaid
+flowchart LR
+  A[Start] --> B[End]
+```
+
+Trailing prose.
+";
+        let (styled, raw) = render_markdown_with_tables(md, &theme(), Some(40));
+        let text = raw.join("\n");
+
+        assert!(
+            styled.iter().any(|l| l.to_string().contains('─')),
+            "expected diagram box art: {text}"
+        );
+        assert!(
+            text.contains("| A | B |") && text.contains("| 1 | 2 |"),
+            "pipe table must survive: {text}"
+        );
+        assert!(
+            text.contains("Trailing prose."),
+            "trailing prose must survive: {text}"
+        );
+        assert!(!text.contains("flowchart LR"), "raw Mermaid leaked: {text}");
+    }
+
+    #[test]
+    fn render_markdown_with_tables_invalid_mermaid_falls_back() {
+        let md = "```mermaid\nnot a valid diagram\n```";
+        let (_lines, raw) = render_markdown_with_tables(md, &theme(), Some(40));
+        let text = raw.join("\n");
+
+        assert!(
+            text.contains("not a valid diagram"),
+            "fallback lost source: {text}"
         );
     }
 

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -12,7 +12,9 @@ use tact_protocol::{
 };
 
 use crate::{
-    render::render_md::{format_table, is_horizontal_rule, render_markdown_tui, render_mermaid_block},
+    render::render_md::{
+        format_table, is_horizontal_rule, render_markdown_tui, render_mermaid_block,
+    },
     widgets::{
         state::*,
         tool_widget::{ToolPhase, ToolWidget},
@@ -574,12 +576,9 @@ impl App {
         {
             let raw = diagram.iter().map(|l| l.to_string()).collect::<Vec<_>>();
             match start_idx {
-                Some(start) => self.splice_msgs(
-                    start..stream_end,
-                    diagram,
-                    raw,
-                    RawMessageType::LLM,
-                ),
+                Some(start) => {
+                    self.splice_msgs(start..stream_end, diagram, raw, RawMessageType::LLM)
+                }
                 None => self.extend_msgs(diagram, raw, RawMessageType::LLM),
             }
             return;

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -546,7 +546,10 @@ impl App {
     /// never becomes a `CodeBlock` card. Every other block — ordinary code,
     /// invalid Mermaid, or an interrupted (unclosed) Mermaid fence — keeps
     /// the existing code-card overlay fallback (blank placeholder region +
-    /// `CodeBlock` entry) so no source is dropped. Resets
+    /// `CodeBlock` entry) so no source is dropped. An unclosed Mermaid fence
+    /// previews its raw source with a plain `text` language (the reconstructed
+    /// fence must not be re-routed through the Mermaid renderer), while the
+    /// card keeps the original `lang` metadata. Resets
     /// `code_block_is_mermaid` once the buffered block is finalized.
     pub(crate) fn finish_stream_code_block(
         &mut self,
@@ -556,6 +559,7 @@ impl App {
         stream_end: usize,
         closed: bool,
     ) {
+        let is_mermaid = self.stream.code_block_is_mermaid;
         self.stream.code_block_is_mermaid = false;
 
         if lines.is_empty() {
@@ -567,7 +571,7 @@ impl App {
 
         let source = format!("```{lang}\n{}\n```", lines.join("\n"));
         if closed
-            && lang.eq_ignore_ascii_case("mermaid")
+            && is_mermaid
             && let Some(diagram) = render_mermaid_block(
                 &lines.join("\n"),
                 &self.theme,
@@ -588,8 +592,16 @@ impl App {
         // with a sized blank region and store a CodeBlock overlay for card
         // rendering. Without a recorded placeholder range, append the rendered
         // content directly instead.
+        //
+        // An unclosed Mermaid fence must keep readable raw source in its styled
+        // preview: re-rendering the reconstructed closed fence through the
+        // Mermaid route would draw a diagram for a fence that never closed.
+        // Use a plain `text` language for that preview source only; the card
+        // keeps the original `lang`.
+        let preview_lang = if is_mermaid && !closed { "text" } else { &lang };
+        let preview_source = format!("```{preview_lang}\n{}\n```", lines.join("\n"));
         const MAX_CODE_PREVIEW: usize = 30;
-        let (styled, _) = render_markdown_tui(&source, &self.theme);
+        let (styled, _) = render_markdown_tui(&preview_source, &self.theme);
         match start_idx {
             Some(start) => {
                 let placeholder_count = styled.len().min(MAX_CODE_PREVIEW) + 2; // +2 for card border
@@ -612,7 +624,7 @@ impl App {
                 });
             }
             None => {
-                let (styled, raw) = render_markdown_tui(&source, &self.theme);
+                let (styled, raw) = render_markdown_tui(&preview_source, &self.theme);
                 self.extend_msgs(styled, raw, RawMessageType::LLM);
             }
         }
@@ -722,7 +734,13 @@ impl App {
                 self.stream.code_block = true;
                 self.stream.code_block_buffer.clear();
                 self.stream.code_block_lang = lang.clone();
-                self.stream.code_block_is_mermaid = lang.eq_ignore_ascii_case("mermaid");
+                // Match `mermaid_fence_opener`: detect Mermaid from the first
+                // whitespace-separated info token, case-insensitively, without
+                // changing the stored language metadata for ordinary code.
+                self.stream.code_block_is_mermaid = lang
+                    .split_whitespace()
+                    .next()
+                    .is_some_and(|token| token.eq_ignore_ascii_case("mermaid"));
                 self.stream.code_block_start_idx = Some(self.messages.len());
                 self.stream.code_block_line_count = 1;
 

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -539,17 +539,20 @@ impl App {
     /// `apply_stream_chunk`, or cut off by the stream ending in
     /// `flush_stream_pending`.
     ///
-    /// Valid Mermaid is spliced directly into the log as diagram lines and
-    /// never becomes a `CodeBlock` card. Every other block keeps the existing
-    /// code-card overlay fallback (blank placeholder region + `CodeBlock`
-    /// entry) so no source is dropped. Resets `code_block_is_mermaid` once
-    /// the buffered block is finalized.
+    /// `closed` reports whether a closing fence was actually seen. Valid,
+    /// *closed* Mermaid is spliced directly into the log as diagram lines and
+    /// never becomes a `CodeBlock` card. Every other block — ordinary code,
+    /// invalid Mermaid, or an interrupted (unclosed) Mermaid fence — keeps
+    /// the existing code-card overlay fallback (blank placeholder region +
+    /// `CodeBlock` entry) so no source is dropped. Resets
+    /// `code_block_is_mermaid` once the buffered block is finalized.
     pub(crate) fn finish_stream_code_block(
         &mut self,
         lang: String,
         lines: Vec<String>,
         start_idx: Option<usize>,
         stream_end: usize,
+        closed: bool,
     ) {
         self.stream.code_block_is_mermaid = false;
 
@@ -561,7 +564,8 @@ impl App {
         }
 
         let source = format!("```{lang}\n{}\n```", lines.join("\n"));
-        if lang.eq_ignore_ascii_case("mermaid")
+        if closed
+            && lang.eq_ignore_ascii_case("mermaid")
             && let Some(diagram) = render_mermaid_block(
                 &lines.join("\n"),
                 &self.theme,
@@ -642,7 +646,7 @@ impl App {
                 let stream_end = start_idx
                     .map(|s| s + self.stream.code_block_line_count)
                     .unwrap_or(0);
-                self.finish_stream_code_block(lang, lines, start_idx, stream_end);
+                self.finish_stream_code_block(lang, lines, start_idx, stream_end, true);
                 self.stream.code_block = false;
                 self.stream.code_block_line_count = 0;
             } else if self.stream.code_block {

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -593,11 +593,12 @@ impl App {
                     start
                 }
             };
-            self.mermaid_blocks.push(crate::widgets::state::MermaidBlock {
-                start_idx: start,
-                end_idx: start + row_count,
-                source,
-            });
+            self.mermaid_blocks
+                .push(crate::widgets::state::MermaidBlock {
+                    start_idx: start,
+                    end_idx: start + row_count,
+                    source,
+                });
             return;
         }
 

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -14,6 +14,7 @@ use tact_protocol::{
 use crate::{
     render::render_md::{
         format_table, is_horizontal_rule, render_markdown_tui, render_mermaid_block,
+        render_plain_markdown,
     },
     widgets::{
         state::*,
@@ -546,11 +547,12 @@ impl App {
     /// never becomes a `CodeBlock` card. Every other block — ordinary code,
     /// invalid Mermaid, or an interrupted (unclosed) Mermaid fence — keeps
     /// the existing code-card overlay fallback (blank placeholder region +
-    /// `CodeBlock` entry) so no source is dropped. An unclosed Mermaid fence
-    /// previews its raw source with a plain `text` language (the reconstructed
-    /// fence must not be re-routed through the Mermaid renderer), while the
-    /// card keeps the original `lang` metadata. Resets
-    /// `code_block_is_mermaid` once the buffered block is finalized.
+    /// `CodeBlock` entry) so no source is dropped. The fallback styled preview
+    /// is rendered through the plain (non-Mermaid) code path exactly once, so
+    /// a reconstructed fallback fence is never re-routed through the Mermaid
+    /// renderer, while the card keeps the original `lang` metadata and raw
+    /// content. Resets `code_block_is_mermaid` once the buffered block is
+    /// finalized.
     pub(crate) fn finish_stream_code_block(
         &mut self,
         lang: String,
@@ -569,7 +571,6 @@ impl App {
             return;
         }
 
-        let source = format!("```{lang}\n{}\n```", lines.join("\n"));
         if closed
             && is_mermaid
             && let Some(diagram) = render_mermaid_block(
@@ -593,15 +594,15 @@ impl App {
         // rendering. Without a recorded placeholder range, append the rendered
         // content directly instead.
         //
-        // An unclosed Mermaid fence must keep readable raw source in its styled
-        // preview: re-rendering the reconstructed closed fence through the
-        // Mermaid route would draw a diagram for a fence that never closed.
-        // Use a plain `text` language for that preview source only; the card
-        // keeps the original `lang`.
-        let preview_lang = if is_mermaid && !closed { "text" } else { &lang };
-        let preview_source = format!("```{preview_lang}\n{}\n```", lines.join("\n"));
+        // The styled preview is rendered through the plain (non-Mermaid) code
+        // path exactly once: re-routing the reconstructed fence through the
+        // Mermaid router could draw a diagram for a fence that never closed
+        // (or re-parse an invalid one), and a nested literal ```mermaid line
+        // inside the buffered source must stay code content. The card keeps
+        // the original `lang` metadata and raw `content`.
+        let preview_source = format!("```{lang}\n{}\n```", lines.join("\n"));
         const MAX_CODE_PREVIEW: usize = 30;
-        let (styled, _) = render_markdown_tui(&preview_source, &self.theme);
+        let (styled, raw) = render_plain_markdown(&preview_source, &self.theme, None);
         match start_idx {
             Some(start) => {
                 let placeholder_count = styled.len().min(MAX_CODE_PREVIEW) + 2; // +2 for card border
@@ -624,7 +625,6 @@ impl App {
                 });
             }
             None => {
-                let (styled, raw) = render_markdown_tui(&preview_source, &self.theme);
                 self.extend_msgs(styled, raw, RawMessageType::LLM);
             }
         }

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -579,13 +579,25 @@ impl App {
                 self.log_scroll.width.max(1) as usize,
             )
         {
+            let source = lines.join("\n");
             let raw = diagram.iter().map(|l| l.to_string()).collect::<Vec<_>>();
-            match start_idx {
+            let row_count = diagram.len();
+            let start = match start_idx {
                 Some(start) => {
-                    self.splice_msgs(start..stream_end, diagram, raw, RawMessageType::LLM)
+                    self.splice_msgs(start..stream_end, diagram, raw, RawMessageType::LLM);
+                    start
                 }
-                None => self.extend_msgs(diagram, raw, RawMessageType::LLM),
-            }
+                None => {
+                    let start = self.messages.len();
+                    self.extend_msgs(diagram, raw, RawMessageType::LLM);
+                    start
+                }
+            };
+            self.mermaid_blocks.push(crate::widgets::state::MermaidBlock {
+                start_idx: start,
+                end_idx: start + row_count,
+                source,
+            });
             return;
         }
 
@@ -1770,7 +1782,62 @@ mod lifecycle_tests {
             .lines()
             .find(|l| l.contains("📊 任务统计："))
             .expect("stats block missing");
-        assert_eq!(stats_line, "📊 任务统计：⏱ 00:05");
+        assert_eq!(stats_line, "📊 任务统计：⏱ 00:05  [copy]");
+    }
+
+    #[test]
+    fn copy_turn_ending_at_stats_copies_last_turn_only() {
+        let mut app = make_app();
+        app.add_user_message("first question".into());
+        app.add_system_message("first answer".into());
+        app.last_prompt_elapsed_secs = Some(1);
+        app.add_task_end_separator();
+        app.add_task_stats_block();
+
+        app.add_user_message("second question".into());
+        app.add_system_message("second answer".into());
+        app.last_prompt_elapsed_secs = Some(2);
+        app.add_task_end_separator();
+        app.add_task_stats_block();
+
+        let stats_idx = app
+            .raw_messages
+            .iter()
+            .rposition(|l| l.contains("📊 任务统计："))
+            .expect("stats");
+        app.copy_turn_ending_at_stats(stats_idx);
+
+        // Prefer clipboard_buffer when system clipboard is unavailable; otherwise
+        // just verify the extracted range would exclude the first turn.
+        let start = app
+            .raw_messages
+            .iter()
+            .position(|l| l.contains("📊 任务统计："))
+            .expect("first stats")
+            + 1;
+        let mut expected_parts = Vec::new();
+        for i in start..stats_idx {
+            let line = app.raw_messages[i].as_str();
+            if line.is_empty()
+                || crate::render::cells::separator::is_task_end_separator(line)
+                || crate::widgets::state::is_task_stats_line(line)
+            {
+                continue;
+            }
+            expected_parts.push(line);
+        }
+        let expected = expected_parts.join("\n");
+        assert!(
+            expected.contains("second question") && expected.contains("second answer"),
+            "expected second turn in {expected}"
+        );
+        assert!(
+            !expected.contains("first question") && !expected.contains("first answer"),
+            "first turn leaked into {expected}"
+        );
+        if !app.clipboard_buffer.is_empty() {
+            assert_eq!(app.clipboard_buffer, expected);
+        }
     }
 
     #[test]

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -12,7 +12,7 @@ use tact_protocol::{
 };
 
 use crate::{
-    render::render_md::{format_table, is_horizontal_rule, render_markdown_tui},
+    render::render_md::{format_table, is_horizontal_rule, render_markdown_tui, render_mermaid_block},
     widgets::{
         state::*,
         tool_widget::{ToolPhase, ToolWidget},
@@ -535,6 +535,86 @@ impl App {
         self.freeze_last_prompt_cost();
     }
 
+    /// Finalize a buffered stream code block — either closed by a fence inside
+    /// `apply_stream_chunk`, or cut off by the stream ending in
+    /// `flush_stream_pending`.
+    ///
+    /// Valid Mermaid is spliced directly into the log as diagram lines and
+    /// never becomes a `CodeBlock` card. Every other block keeps the existing
+    /// code-card overlay fallback (blank placeholder region + `CodeBlock`
+    /// entry) so no source is dropped. Resets `code_block_is_mermaid` once
+    /// the buffered block is finalized.
+    pub(crate) fn finish_stream_code_block(
+        &mut self,
+        lang: String,
+        lines: Vec<String>,
+        start_idx: Option<usize>,
+        stream_end: usize,
+    ) {
+        self.stream.code_block_is_mermaid = false;
+
+        if lines.is_empty() {
+            if let Some(start) = start_idx {
+                self.drain_msgs(start..stream_end);
+            }
+            return;
+        }
+
+        let source = format!("```{lang}\n{}\n```", lines.join("\n"));
+        if lang.eq_ignore_ascii_case("mermaid")
+            && let Some(diagram) = render_mermaid_block(
+                &lines.join("\n"),
+                &self.theme,
+                self.log_scroll.width.max(1) as usize,
+            )
+        {
+            let raw = diagram.iter().map(|l| l.to_string()).collect::<Vec<_>>();
+            match start_idx {
+                Some(start) => self.splice_msgs(
+                    start..stream_end,
+                    diagram,
+                    raw,
+                    RawMessageType::LLM,
+                ),
+                None => self.extend_msgs(diagram, raw, RawMessageType::LLM),
+            }
+            return;
+        }
+
+        // Existing code-card fallback: replace the streaming placeholder rows
+        // with a sized blank region and store a CodeBlock overlay for card
+        // rendering. Without a recorded placeholder range, append the rendered
+        // content directly instead.
+        const MAX_CODE_PREVIEW: usize = 30;
+        let (styled, _) = render_markdown_tui(&source, &self.theme);
+        match start_idx {
+            Some(start) => {
+                let placeholder_count = styled.len().min(MAX_CODE_PREVIEW) + 2; // +2 for card border
+                let placeholders: Vec<Line<'static>> =
+                    (0..placeholder_count).map(|_| Line::from("")).collect();
+                let raw_placeholders: Vec<String> =
+                    (0..placeholder_count).map(|_| String::new()).collect();
+                self.splice_msgs(
+                    start..stream_end,
+                    placeholders,
+                    raw_placeholders,
+                    RawMessageType::LLM,
+                );
+                self.code_blocks.push(CodeBlock {
+                    start_idx: start,
+                    end_idx: start + placeholder_count,
+                    lang,
+                    content: lines.join("\n"),
+                    styled,
+                });
+            }
+            None => {
+                let (styled, raw) = render_markdown_tui(&source, &self.theme);
+                self.extend_msgs(styled, raw, RawMessageType::LLM);
+            }
+        }
+    }
+
     fn apply_stream_chunk(&mut self, text: String) {
         self.ensure_gap_after_user_message();
         self.ensure_gap_after_tools();
@@ -553,44 +633,16 @@ impl App {
             let is_code_fence_close = trimmed == "```" && self.stream.code_block;
 
             if is_code_fence_close {
-                // Completed: replace streaming placeholders with a sized blank region,
-                // then store a CodeBlock overlay for card rendering.
-                const MAX_CODE_PREVIEW: usize = 30;
+                // Completed: finalize the buffered block — valid Mermaid is
+                // spliced in as diagram lines, everything else becomes a
+                // CodeBlock card (see finish_stream_code_block).
                 let lang = std::mem::take(&mut self.stream.code_block_lang);
                 let lines = std::mem::take(&mut self.stream.code_block_buffer);
-
-                if let Some(start_idx) = self.stream.code_block_start_idx.take() {
-                    let stream_end = start_idx + self.stream.code_block_line_count;
-
-                    if !lines.is_empty() {
-                        let code_text = format!("```{}\n{}\n```", lang, lines.join("\n"));
-                        let (styled, _) = render_markdown_tui(&code_text, &self.theme);
-                        let placeholder_count = styled.len().min(MAX_CODE_PREVIEW) + 2; // +2 for card border
-                        let placeholders: Vec<Line<'static>> =
-                            (0..placeholder_count).map(|_| Line::from("")).collect();
-                        let raw_placeholders: Vec<String> =
-                            (0..placeholder_count).map(|_| String::new()).collect();
-                        self.splice_msgs(
-                            start_idx..stream_end,
-                            placeholders,
-                            raw_placeholders,
-                            RawMessageType::LLM,
-                        );
-                        self.code_blocks.push(CodeBlock {
-                            start_idx,
-                            end_idx: start_idx + placeholder_count,
-                            lang,
-                            content: lines.join("\n"),
-                            styled,
-                        });
-                    } else {
-                        self.drain_msgs(start_idx..stream_end);
-                    }
-                } else if !lines.is_empty() {
-                    let code_text = format!("```{}\n{}\n```", lang, lines.join("\n"));
-                    let (styled, raw) = render_markdown_tui(&code_text, &self.theme);
-                    completed.extend(styled.into_iter().zip(raw));
-                }
+                let start_idx = self.stream.code_block_start_idx.take();
+                let stream_end = start_idx
+                    .map(|s| s + self.stream.code_block_line_count)
+                    .unwrap_or(0);
+                self.finish_stream_code_block(lang, lines, start_idx, stream_end);
                 self.stream.code_block = false;
                 self.stream.code_block_line_count = 0;
             } else if self.stream.code_block {
@@ -667,6 +719,7 @@ impl App {
                 self.stream.code_block = true;
                 self.stream.code_block_buffer.clear();
                 self.stream.code_block_lang = lang.clone();
+                self.stream.code_block_is_mermaid = lang.eq_ignore_ascii_case("mermaid");
                 self.stream.code_block_start_idx = Some(self.messages.len());
                 self.stream.code_block_line_count = 1;
 

--- a/crates/tui/src/widgets/state/app/construct.rs
+++ b/crates/tui/src/widgets/state/app/construct.rs
@@ -107,6 +107,8 @@ impl App {
             tools: ToolState::default(),
             code_blocks: Vec::new(),
             code_popup: None,
+            mermaid_blocks: Vec::new(),
+            mermaid_popup: None,
             task_dag_popup: None,
             subagent_popup: None,
             system_prompt_popup: None,

--- a/crates/tui/src/widgets/state/app/messages.rs
+++ b/crates/tui/src/widgets/state/app/messages.rs
@@ -6,12 +6,21 @@ use ratatui::{
 use tact_llm::content::{ContentBlock, Message, MessageContent, Role};
 
 use crate::{
-    render::render_md::render_markdown_tui,
+    render::{cells::separator::is_task_end_separator, render_md::render_markdown_tui},
     widgets::state::{
         log_messages::{SystemMsgStyle, classify_system_message},
         *,
     },
 };
+
+/// Prefix for the per-turn stats row appended after each task-end separator.
+pub(crate) const TASK_STATS_PREFIX: &str = "📊 任务统计：";
+/// Clickable copy affordance appended to each task-stats row.
+pub(crate) const TASK_STATS_COPY_BTN: &str = "[copy]";
+
+pub(crate) fn is_task_stats_line(raw: &str) -> bool {
+    raw.starts_with(TASK_STATS_PREFIX)
+}
 
 impl App {
     pub(crate) fn add_startup_logo(&mut self) {
@@ -198,7 +207,9 @@ impl App {
     /// Reads the already-frozen `last_prompt_elapsed_secs` and the status-bar
     /// token/model snapshots; deliberately adds no new state (YAGNI — the data
     /// is already collected by `add_task_end_separator` / `TokenUsage` /
-    /// `ModelInfo` updates).
+    /// `ModelInfo` updates). A trailing `[copy]` button copies this turn's
+    /// log text (from the previous stats row, or session start, up to but not
+    /// including this stats row).
     pub(crate) fn add_task_stats_block(&mut self) {
         let secs = self.last_prompt_elapsed_secs.unwrap_or(0).max(0);
         let mm_ss = format!("{:02}:{:02}", secs / 60, secs % 60);
@@ -225,7 +236,54 @@ impl App {
             }
             parts.push(detail);
         }
-        self.add_system_message(format!("📊 任务统计：{}", parts.join(" · ")));
+        let body = format!("{TASK_STATS_PREFIX}{}", parts.join(" · "));
+        let raw = format!("{body}  {TASK_STATS_COPY_BTN}");
+        let line = Line::from(vec![
+            Span::styled(body, Style::default().fg(self.theme.accent)),
+            Span::raw("  "),
+            Span::styled(
+                TASK_STATS_COPY_BTN.to_string(),
+                Style::default()
+                    .fg(self.theme.heading)
+                    .add_modifier(Modifier::BOLD)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+        ]);
+        self.append_msg(line, raw, RawMessageType::LLM);
+        if self.input_mode == InputMode::Insert || self.input_mode == InputMode::Normal {
+            self.log_scroll.offset = u16::MAX;
+        }
+    }
+
+    /// Copy the turn that ends at the given task-stats physical row.
+    ///
+    /// Range: after the previous stats line (or session start) .. `stats_phys`
+    /// (exclusive). Skips blank rows, task-end separators, and other stats rows.
+    pub(crate) fn copy_turn_ending_at_stats(&mut self, stats_phys: usize) {
+        let Some(raw) = self.raw_messages.get(stats_phys) else {
+            return;
+        };
+        if !is_task_stats_line(raw) {
+            return;
+        }
+        let start = (0..stats_phys)
+            .rev()
+            .find(|&i| is_task_stats_line(&self.raw_messages[i]))
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let mut parts: Vec<&str> = Vec::new();
+        for i in start..stats_phys {
+            let line = self.raw_messages[i].as_str();
+            if line.is_empty() || is_task_end_separator(line) || is_task_stats_line(line) {
+                continue;
+            }
+            parts.push(line);
+        }
+        let text = parts.join("\n");
+        if text.is_empty() {
+            return;
+        }
+        self.copy_text(&text);
     }
 
     /// Add a user input message and record it in task history.

--- a/crates/tui/src/widgets/state/app/popups.rs
+++ b/crates/tui/src/widgets/state/app/popups.rs
@@ -38,6 +38,7 @@ impl App {
         self.thinking.popup.is_some()
             || self.tools.popup.is_some()
             || self.code_popup.is_some()
+            || self.mermaid_popup.is_some()
             || self.task_dag_popup.is_some()
             || self.system_prompt_popup.is_some()
             || self.subagent_popup.is_some()
@@ -49,6 +50,8 @@ impl App {
         } else if let Some(p) = self.tools.popup.as_mut() {
             Some(&mut p.scroll)
         } else if let Some(p) = self.code_popup.as_mut() {
+            Some(&mut p.scroll)
+        } else if let Some(p) = self.mermaid_popup.as_mut() {
             Some(&mut p.scroll)
         } else if let Some(p) = self.task_dag_popup.as_mut() {
             Some(&mut p.scroll)
@@ -80,6 +83,8 @@ impl App {
             self.close_diff_popup();
         } else if self.code_popup.is_some() {
             self.close_code_popup();
+        } else if self.mermaid_popup.is_some() {
+            self.close_mermaid_popup();
         } else if self.task_dag_popup.is_some() {
             self.task_dag_popup = None;
         } else if self.system_prompt_popup.is_some() {
@@ -102,6 +107,8 @@ impl App {
             Some(self.mouse.diff_popup_area)
         } else if self.code_popup.is_some() {
             Some(self.mouse.code_popup_area)
+        } else if self.mermaid_popup.is_some() {
+            Some(self.mouse.mermaid_popup_area)
         } else if self.task_dag_popup.is_some() {
             Some(self.mouse.task_dag_popup_area)
         } else if self.subagent_popup.is_some() {
@@ -125,6 +132,8 @@ impl App {
             self.copy_diff_popup();
         } else if self.code_popup.is_some() {
             self.copy_code_popup();
+        } else if self.mermaid_popup.is_some() {
+            self.copy_mermaid_popup();
         } else if self.subagent_popup.is_some() {
             self.copy_subagent_popup();
         } else if self.task_dag_popup.is_some() {
@@ -697,6 +706,37 @@ impl App {
             return;
         };
         let text = self.code_blocks[popup.block_idx].content.clone();
+        self.copy_text(&text);
+    }
+
+    // ========== Mermaid Popup ==========
+
+    /// Open the Mermaid source popup for a rendered diagram block.
+    pub(crate) fn open_mermaid_popup(&mut self, block_idx: usize) {
+        if block_idx < self.mermaid_blocks.len() && !self.mermaid_blocks[block_idx].source.is_empty()
+        {
+            self.mermaid_popup = Some(MermaidPopup {
+                block_idx,
+                scroll: 0,
+            });
+        }
+    }
+
+    /// Close the Mermaid source popup.
+    pub(crate) fn close_mermaid_popup(&mut self) {
+        self.mermaid_popup = None;
+        self.mouse.mermaid_popup_area = Rect::default();
+    }
+
+    /// Copy the Mermaid fence body to the clipboard.
+    pub(crate) fn copy_mermaid_popup(&mut self) {
+        let Some(popup) = &self.mermaid_popup else {
+            return;
+        };
+        if popup.block_idx >= self.mermaid_blocks.len() {
+            return;
+        }
+        let text = self.mermaid_blocks[popup.block_idx].source.clone();
         self.copy_text(&text);
     }
 }

--- a/crates/tui/src/widgets/state/app/popups.rs
+++ b/crates/tui/src/widgets/state/app/popups.rs
@@ -713,7 +713,8 @@ impl App {
 
     /// Open the Mermaid source popup for a rendered diagram block.
     pub(crate) fn open_mermaid_popup(&mut self, block_idx: usize) {
-        if block_idx < self.mermaid_blocks.len() && !self.mermaid_blocks[block_idx].source.is_empty()
+        if block_idx < self.mermaid_blocks.len()
+            && !self.mermaid_blocks[block_idx].source.is_empty()
         {
             self.mermaid_popup = Some(MermaidPopup {
                 block_idx,

--- a/crates/tui/src/widgets/state/app/visibility.rs
+++ b/crates/tui/src/widgets/state/app/visibility.rs
@@ -469,6 +469,12 @@ impl App {
                         block.end_idx -= 1;
                     }
                 }
+                for block in &mut self.mermaid_blocks {
+                    if block.start_idx > idx {
+                        block.start_idx -= 1;
+                        block.end_idx -= 1;
+                    }
+                }
                 for block in &mut self.tools.blocks {
                     if block.phys_idx > idx {
                         block.phys_idx -= 1;
@@ -577,6 +583,12 @@ impl App {
             adjust(&mut active.phys_idx);
         }
         for block in &mut self.code_blocks {
+            if block.start_idx >= at {
+                block.start_idx = (block.start_idx as isize + delta).max(0) as usize;
+                block.end_idx = (block.end_idx as isize + delta).max(0) as usize;
+            }
+        }
+        for block in &mut self.mermaid_blocks {
             if block.start_idx >= at {
                 block.start_idx = (block.start_idx as isize + delta).max(0) as usize;
                 block.end_idx = (block.end_idx as isize + delta).max(0) as usize;

--- a/crates/tui/src/widgets/state/app/visibility.rs
+++ b/crates/tui/src/widgets/state/app/visibility.rs
@@ -421,8 +421,10 @@ impl App {
             // without a trailing newline — fold it in before finalizing.
             let pending = std::mem::take(&mut self.stream.buffer);
             let pending_trim = pending.trim();
-            if pending_trim == "```" {
-                // Proper close fence without `\n` — discard, do not add to content.
+            let closed = pending_trim == "```";
+            if closed {
+                // Proper close fence without `\n` — discard, do not add to
+                // content; the block is still a valid closed block.
             } else if !pending.is_empty() {
                 self.stream.code_block_buffer.push(pending);
             }
@@ -433,7 +435,7 @@ impl App {
             let stream_end = start_idx
                 .map(|s| s + self.stream.code_block_line_count)
                 .unwrap_or(0);
-            self.finish_stream_code_block(lang, code_lines, start_idx, stream_end);
+            self.finish_stream_code_block(lang, code_lines, start_idx, stream_end, closed);
             self.stream.code_block = false;
             self.stream.code_block_line_count = 0;
         }

--- a/crates/tui/src/widgets/state/app/visibility.rs
+++ b/crates/tui/src/widgets/state/app/visibility.rs
@@ -416,10 +416,9 @@ impl App {
         }
         // Flush incomplete code block (interrupted stream)
         if self.stream.code_block {
-            const MAX_CODE_PREVIEW: usize = 30;
             // Line-oriented streaming only consumes text after `\n`. A final
             // closing fence (or last content line) may still sit in `buffer`
-            // without a trailing newline — fold it in before building the card.
+            // without a trailing newline — fold it in before finalizing.
             let pending = std::mem::take(&mut self.stream.buffer);
             let pending_trim = pending.trim();
             if pending_trim == "```" {
@@ -430,38 +429,11 @@ impl App {
 
             let lang = std::mem::take(&mut self.stream.code_block_lang);
             let code_lines = std::mem::take(&mut self.stream.code_block_buffer);
-
-            if let Some(start_idx) = self.stream.code_block_start_idx.take() {
-                let stream_end = start_idx + self.stream.code_block_line_count;
-                if !code_lines.is_empty() {
-                    let code_text = format!("```{}\n{}\n```", lang, code_lines.join("\n"));
-                    let (styled, _) = render_markdown_tui(&code_text, &self.theme);
-                    let placeholder_count = styled.len().min(MAX_CODE_PREVIEW) + 2;
-                    let placeholders: Vec<Line<'static>> =
-                        (0..placeholder_count).map(|_| Line::from("")).collect();
-                    let raw_placeholders: Vec<String> =
-                        (0..placeholder_count).map(|_| String::new()).collect();
-                    self.splice_msgs(
-                        start_idx..stream_end,
-                        placeholders,
-                        raw_placeholders,
-                        RawMessageType::LLM,
-                    );
-                    self.code_blocks.push(CodeBlock {
-                        start_idx,
-                        end_idx: start_idx + placeholder_count,
-                        lang,
-                        content: code_lines.join("\n"),
-                        styled,
-                    });
-                } else {
-                    self.drain_msgs(start_idx..stream_end);
-                }
-            } else if !code_lines.is_empty() {
-                let code_text = format!("```{}\n{}\n```", lang, code_lines.join("\n"));
-                let (lines, raw_lines) = render_markdown_tui(&code_text, &self.theme);
-                self.extend_msgs(lines, raw_lines, RawMessageType::LLM);
-            }
+            let start_idx = self.stream.code_block_start_idx.take();
+            let stream_end = start_idx
+                .map(|s| s + self.stream.code_block_line_count)
+                .unwrap_or(0);
+            self.finish_stream_code_block(lang, code_lines, start_idx, stream_end);
             self.stream.code_block = false;
             self.stream.code_block_line_count = 0;
         }

--- a/crates/tui/src/widgets/state/mod.rs
+++ b/crates/tui/src/widgets/state/mod.rs
@@ -41,6 +41,7 @@ pub(crate) use slash_command::SlashCommandState;
 pub(crate) use status_bar_state::StatusBarState;
 pub(crate) use stream_state::StreamState;
 
+pub(crate) use app::messages::{TASK_STATS_COPY_BTN, is_task_stats_line};
 pub(crate) use task_dag::{DEFAULT_DAG_RENDER_WIDTH, TaskDagPopup, render_task_dag_lines};
 pub(crate) use task_panel::TaskPanelState;
 pub(crate) use thinking_state::{ActiveThinkingBlock, ThinkingBlock, ThinkingPopup, ThinkingState};
@@ -179,11 +180,33 @@ pub(crate) struct CodeBlock {
     pub styled: Vec<Line<'static>>,
 }
 
+/// A successfully rendered Mermaid diagram spliced into the log as terminal art.
+///
+/// Unlike [`CodeBlock`], there is no card chrome — `start_idx..end_idx` covers
+/// the diagram rows themselves. Double-click opens [`MermaidPopup`] so the
+/// original fence body can be copied.
+#[derive(Debug, Clone)]
+pub(crate) struct MermaidBlock {
+    /// First diagram line index in messages (inclusive).
+    pub start_idx: usize,
+    /// One-past-last diagram line index in messages.
+    pub end_idx: usize,
+    /// Fence body only (no ```mermaid / closing ```).
+    pub source: String,
+}
+
 /// Code block popup state (similar to ThinkingPopup / DiffPopup).
 #[derive(Debug, Clone)]
 pub(crate) struct CodePopup {
     pub block_idx: usize,
     pub lang: String,
+    pub scroll: u16,
+}
+
+/// Mermaid source popup (double-click a rendered diagram in the log).
+#[derive(Debug, Clone)]
+pub(crate) struct MermaidPopup {
+    pub block_idx: usize,
     pub scroll: u16,
 }
 
@@ -292,6 +315,10 @@ pub struct App {
     pub(crate) code_blocks: Vec<CodeBlock>,
     /// Code block popup preview (fullscreen independent scroll viewer).
     pub(crate) code_popup: Option<CodePopup>,
+    /// Successfully rendered Mermaid diagrams (source retained for copy popup).
+    pub(crate) mermaid_blocks: Vec<MermaidBlock>,
+    /// Mermaid source popup (double-click a rendered diagram).
+    pub(crate) mermaid_popup: Option<MermaidPopup>,
     /// `/tasks-dag` Mermaid→Unicode dependency graph popup.
     pub(crate) task_dag_popup: Option<TaskDagPopup>,
     /// Subagent live-output / markdown summary popup.

--- a/crates/tui/src/widgets/state/mouse_state.rs
+++ b/crates/tui/src/widgets/state/mouse_state.rs
@@ -137,6 +137,8 @@ pub(crate) struct MouseState {
     pub(crate) popup_text_drag_origin: Option<PopupTextHit>,
     /// code block popup area (used to determine if click is inside the popup).
     pub(crate) code_popup_area: Rect,
+    /// Mermaid source popup area.
+    pub(crate) mermaid_popup_area: Rect,
     /// `/tasks-dag` popup area.
     pub(crate) task_dag_popup_area: Rect,
     /// Double/triple click detection: time and position of the last left click.
@@ -150,6 +152,8 @@ pub(crate) struct MouseState {
     pub(crate) last_click_tool: Option<usize>,
     /// Index of the code block hit by the last click (used for double-click popup open).
     pub(crate) last_click_code: Option<usize>,
+    /// Index of the Mermaid block hit by the last click (used for double-click popup open).
+    pub(crate) last_click_mermaid: Option<usize>,
 }
 
 impl MouseState {

--- a/crates/tui/src/widgets/state/stream_state.rs
+++ b/crates/tui/src/widgets/state/stream_state.rs
@@ -9,4 +9,9 @@ pub(crate) struct StreamState {
     pub(crate) code_block_lang: String,
     pub(crate) code_block_start_idx: Option<usize>,
     pub(crate) code_block_line_count: usize,
+    /// Whether the buffered fence opened with a `mermaid` language tag.
+    ///
+    /// Set when the opening fence is seen, reset whenever the buffered block
+    /// is finalized (valid diagram spliced in, or code-card fallback).
+    pub(crate) code_block_is_mermaid: bool,
 }

--- a/crates/tui/src/widgets/state/task_dag.rs
+++ b/crates/tui/src/widgets/state/task_dag.rs
@@ -1,14 +1,10 @@
 //! Task dependency DAG → Mermaid → ratatui-markdown rendering.
 
-use ratatui::{style::Color, text::Line};
-use ratatui_markdown::{
-    markdown::MarkdownRenderer,
-    mermaid::theme::MermaidTheme,
-    theme::{CodeColors, Generation, RichTextTheme},
-};
+use ratatui::text::Line;
+use ratatui_markdown::markdown::MarkdownRenderer;
 use tact_protocol::{TaskSnapshot, TaskStatusSnapshot};
 
-use crate::theme::Theme;
+use crate::{render::render_md::TuiRichTextTheme, theme::Theme};
 
 /// Width used to pre-render the DAG before the popup's actual width is known
 /// (the popup re-renders at its real width on the first frame).
@@ -80,82 +76,6 @@ fn tasks_to_markdown(tasks: &[TaskSnapshot], source: &str) -> String {
     out
 }
 
-/// Maps the app [`Theme`] into ratatui-markdown's `RichTextTheme`.
-#[derive(Clone, Copy)]
-pub(crate) struct DagTheme<'a> {
-    pub theme: &'a Theme,
-}
-
-impl RichTextTheme for DagTheme<'_> {
-    fn generation(&self) -> Generation {
-        Generation(0)
-    }
-
-    fn get_text_color(&self) -> Color {
-        self.theme.fg
-    }
-
-    fn get_muted_text_color(&self) -> Color {
-        self.theme.muted_fg()
-    }
-
-    fn get_primary_color(&self) -> Color {
-        self.theme.accent
-    }
-
-    fn get_popup_selected_background(&self) -> Color {
-        self.theme.highlight
-    }
-
-    fn get_border_color(&self) -> Color {
-        self.theme.border
-    }
-
-    fn get_focused_border_color(&self) -> Color {
-        self.theme.accent
-    }
-
-    fn get_secondary_color(&self) -> Color {
-        self.theme.success
-    }
-
-    fn get_info_color(&self) -> Color {
-        self.theme.heading
-    }
-
-    fn get_json_key_color(&self) -> Color {
-        self.theme.heading
-    }
-
-    fn get_json_string_color(&self) -> Color {
-        self.theme.success
-    }
-
-    fn get_json_number_color(&self) -> Color {
-        self.theme.accent
-    }
-
-    fn get_json_bool_color(&self) -> Color {
-        self.theme.warning
-    }
-
-    fn get_json_null_color(&self) -> Color {
-        self.theme.muted
-    }
-
-    fn get_accent_yellow(&self) -> Color {
-        self.theme.warning
-    }
-
-    fn get_code_colors(&self) -> CodeColors {
-        CodeColors::default()
-    }
-
-    fn get_mermaid_theme(&self) -> MermaidTheme {
-        MermaidTheme::for_background(self.theme.bg)
-    }
-}
-
 /// Render the task DAG (mermaid diagram + legend) via ratatui-markdown.
 pub(crate) fn render_task_dag_lines(
     tasks: &[TaskSnapshot],
@@ -175,7 +95,7 @@ pub(crate) fn render_task_dag_lines(
     let md = tasks_to_markdown(tasks, &source);
     let renderer = MarkdownRenderer::new(width);
     let blocks = renderer.parse(&md);
-    let lines = renderer.render(&blocks, &DagTheme { theme });
+    let lines = renderer.render(&blocks, &TuiRichTextTheme { theme });
     (source, lines)
 }
 

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -16,6 +16,9 @@ tact implements **three-tier progressive compaction**:
 > endpoint, replacing the opaque protocol baseline (never the logical context).
 > Endpoints without native compaction are unsupported — no local-summary
 > fallback. See [book/05_chapter_compact.md](../book/05_chapter_compact.md).
+> The Responses wire baseline is retained as raw JSON. Known items are
+> normalized for Tact content, while unknown input/output items are preserved
+> and replayed on the next request instead of being silently dropped.
 
 ```mermaid
 flowchart TB

--- a/docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md
+++ b/docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md
@@ -1,0 +1,438 @@
+# Mermaid Main-Area Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render supported Mermaid fenced blocks as themed terminal diagrams in the TUI main area while preserving existing Markdown, code-card, scrolling, and fallback behavior.
+
+**Architecture:** Keep `tui-markdown` as the normal Markdown renderer. Add a narrow Mermaid renderer in `render_md.rs` that extracts complete top-level `mermaid` fences, calls the already-enabled `ratatui-markdown::mermaid::render_mermaid`, and falls back to the existing renderer when parsing fails. Reuse the width-aware `MarkdownCell` path for content that must re-layout and add a Mermaid flag to the streaming fence state so valid completed diagrams do not become `CodeBlock` overlays.
+
+**Tech Stack:** Rust, ratatui `Line`, existing `tui-markdown`, existing `ratatui-markdown` Mermaid feature, TUI unit/render-gap tests.
+
+## Global Constraints
+
+- Do not add a dependency or a new Mermaid parser.
+- Supported diagram types are limited to those implemented by the pinned `ratatui-markdown` revision.
+- Ordinary Markdown, tables, headings, and non-Mermaid code cards must retain their current output and behavior.
+- Invalid or unsupported Mermaid must remain readable through the existing code rendering path.
+- Run Cargo commands serially; unset `http_proxy`, `https_proxy`, and `all_proxy` for tests.
+- Follow TDD: each production change is preceded by a focused failing test.
+- Update `book/23_chapter_tui.md`, `book/23_chapter_tui_zh.md`, `book/26_chapter_issue.md`, and `book/26_chapter_issue_zh.md` in the same change because the main-area rendering contract is user-visible.
+
+---
+
+## File Map
+
+- Modify `crates/tui/src/render/render_md.rs`: shared `RichTextTheme` adapter, Mermaid block renderer, and Markdown/fence routing tests.
+- Modify `crates/tui/src/widgets/state/task_dag.rs`: reuse the shared theme adapter without changing DAG output.
+- Modify `crates/tui/src/render/cells/markdown.rs`: ensure the width-aware whole-Markdown cell uses the Mermaid-aware router and add cell rendering tests.
+- Modify `crates/tui/src/widgets/state/stream_state.rs`: record whether the currently buffered fence is Mermaid.
+- Modify `crates/tui/src/widgets/state/app/agent.rs`: route streaming Mermaid completion to diagram lines or code fallback.
+- Modify `crates/tui/src/widgets/state/app/visibility.rs`: route incomplete-stream flush through the same Mermaid/code finalization behavior.
+- Modify `crates/tui/src/render/render_gap_tests.rs`: main-area streamed Mermaid and fallback regressions.
+- Modify `book/23_chapter_tui.md` and `book/23_chapter_tui_zh.md`: describe Mermaid fenced-block behavior and fallback.
+- Modify `book/26_chapter_issue.md` and `book/26_chapter_issue_zh.md`: add the newest user-visible behavior entry.
+- Create `docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md`: this plan.
+
+---
+
+### Task 1: Add the shared Mermaid theme adapter and renderer
+
+**Files:**
+- Modify: `crates/tui/src/render/render_md.rs`
+- Modify: `crates/tui/src/widgets/state/task_dag.rs`
+
+**Interfaces:**
+- Produce `pub(crate) fn render_mermaid_block(source: &str, theme: &Theme, width: usize) -> Option<Vec<Line<'static>>>`.
+- Produce a shared `RichTextTheme` implementation in `render_md.rs` that maps the existing `Theme` fields to the colors required by `ratatui-markdown`.
+- Consume the existing `ratatui_markdown::mermaid::render_mermaid` API.
+
+- [ ] **Step 1: Write the failing unit test for a sequence diagram.**
+
+Add a test beside the existing `render_markdown_*` tests:
+
+```rust
+#[test]
+fn render_mermaid_sequence_returns_terminal_lines() {
+    let source = "sequenceDiagram\n    Alice->>Bob: Hello\n    Bob-->>Alice: Hi";
+    let lines = render_mermaid_block(source, &theme(), 80).expect("valid sequence diagram");
+    let text = lines.iter().map(Line::to_string).collect::<Vec<_>>().join("\n");
+
+    assert!(text.contains("Alice"), "participant missing: {text}");
+    assert!(text.contains("Bob"), "participant missing: {text}");
+    assert!(text.contains("Hello"), "message missing: {text}");
+    assert!(text.contains('─') || text.contains('>'), "diagram art missing: {text}");
+    assert!(!text.contains("sequenceDiagram"), "raw source leaked: {text}");
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails for the missing helper.**
+
+Run:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_md::tests::render_mermaid_sequence_returns_terminal_lines -- --exact
+```
+
+Expected: compilation failure because `render_mermaid_block` does not exist.
+
+- [ ] **Step 3: Implement the smallest shared adapter and helper.**
+
+Move/generalize the color mapping currently implemented by `DagTheme` into `render_md.rs`. The helper should follow this shape:
+
+```rust
+pub(crate) fn render_mermaid_block(
+    source: &str,
+    theme: &Theme,
+    width: usize,
+) -> Option<Vec<Line<'static>>> {
+    ratatui_markdown::mermaid::render_mermaid(
+        source,
+        width.max(1),
+        None,
+        &TuiRichTextTheme { theme },
+    )
+}
+```
+
+Keep the adapter `Copy`/borrowed, map `get_mermaid_theme()` with `MermaidTheme::for_background(theme.bg)`, and preserve the existing `DagTheme` color choices exactly. Change `task_dag.rs` to import the shared adapter and use it when calling `MarkdownRenderer::render`; do not change `tasks_to_mermaid`, popup width handling, source-copy behavior, or tests.
+
+- [ ] **Step 4: Run the focused test and existing DAG tests.**
+
+Run serially:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_md::tests::render_mermaid_sequence_returns_terminal_lines -- --exact
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib widgets::state::task_dag::tests
+```
+
+Expected: the sequence test and all task-DAG tests pass.
+
+- [ ] **Step 5: Commit the shared helper.**
+
+```bash
+git add crates/tui/src/render/render_md.rs crates/tui/src/widgets/state/task_dag.rs
+git commit -m "feat(tui): add shared Mermaid renderer"
+```
+
+---
+
+### Task 2: Route complete Mermaid fences through Markdown rendering
+
+**Files:**
+- Modify: `crates/tui/src/render/render_md.rs`
+- Modify: `crates/tui/src/render/cells/markdown.rs`
+
+**Interfaces:**
+- Keep `render_markdown_tui` and `render_markdown_with_tables` call sites source-compatible.
+- Add an internal fence router that accepts `(text, theme, width)` and returns `(Vec<Line<'static>>, Vec<String>)`.
+- The router must delegate non-Mermaid content to the existing `tui-markdown`/table logic and invoke `render_mermaid_block` only for a closed, top-level `mermaid` fence.
+
+- [ ] **Step 1: Write failing tests for flowchart, fallback, and width-aware cell routing.**
+
+Add tests in `render_md.rs`:
+
+```rust
+#[test]
+fn render_markdown_mermaid_flowchart_uses_box_art() {
+    let md = "```mermaid\nflowchart TD\n  A[Start] --> B[End]\n```";
+    let (lines, raw) = render_markdown_tui(md, &theme());
+    let text = raw.join("\n");
+
+    assert!(lines.iter().any(|line| line.to_string().contains('─') || line.to_string().contains('│')),
+        "expected flowchart box art: {text}");
+    assert!(!text.contains("flowchart TD"), "raw Mermaid leaked: {text}");
+}
+
+#[test]
+fn render_markdown_invalid_mermaid_falls_back_to_code() {
+    let md = "```mermaid\nnot a valid diagram\n```";
+    let (_lines, raw) = render_markdown_tui(md, &theme());
+    let text = raw.join("\n");
+
+    assert!(text.contains("not a valid diagram"), "fallback lost source: {text}");
+}
+```
+
+Add a `MarkdownCell` test in `cells/markdown.rs`:
+
+```rust
+#[test]
+fn markdown_cell_renders_mermaid_at_the_requested_width() {
+    let cell = MarkdownCell::new(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```",
+        &dark(),
+    );
+    let text = render_text(&cell, 60);
+
+    assert!(text.contains("Alice") && text.contains("Bob"), "diagram missing: {text}");
+    assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
+}
+```
+
+- [ ] **Step 2: Run the new focused tests and verify they fail.**
+
+Run serially:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_md::tests::render_markdown_mermaid_flowchart_uses_box_art -- --exact
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_md::tests::render_markdown_invalid_mermaid_falls_back_to_code -- --exact
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::cells::markdown::tests::markdown_cell_renders_mermaid_at_the_requested_width -- --exact
+```
+
+Expected: tests fail because the current `tui-markdown` path emits the Mermaid source as code.
+
+- [ ] **Step 3: Add a narrow top-level fence extractor.**
+
+Implement a line-oriented helper in `render_md.rs` that:
+
+- treats a line whose trimmed form starts with ````` as a fence opener;
+- recognizes `mermaid` case-insensitively after the opening fence;
+- collects source lines until a trimmed closing line equal to `````;
+- flushes preceding/following prose to the existing renderer;
+- calls `render_mermaid_block` with `width.max(1)`;
+- if rendering returns `None`, sends the original opening fence, source, and closing fence through the existing code renderer;
+- leaves non-Mermaid fences untouched for the existing parser;
+- treats an unclosed Mermaid fence as ordinary Markdown/code content rather than dropping it.
+
+Keep the existing `render_markdown_tui` output unchanged when no Mermaid fence is present. Make `render_markdown_with_tables` invoke the Mermaid extractor before its pipe-table scanner so `|` lines inside a diagram are not mistaken for a table. Use the existing `format_table` implementation for prose/table segments.
+
+- [ ] **Step 4: Wire `MarkdownCell` to the same width-aware router.**
+
+Replace the cell's current call to `render_markdown_with_tables` only as needed so the cell passes its content width into the Mermaid route. Preserve `wrap_line` and the existing width cache; Mermaid output should be regenerated when `MarkdownCell::height`/`render_partial` is called at a new width.
+
+- [ ] **Step 5: Run the focused and adjacent Markdown tests.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_md::tests
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::cells::markdown::tests
+```
+
+Expected: all existing Markdown/table/cell tests and the new Mermaid tests pass.
+
+- [ ] **Step 6: Commit Markdown routing.**
+
+```bash
+git add crates/tui/src/render/render_md.rs crates/tui/src/render/cells/markdown.rs
+git commit -m "feat(tui): render Mermaid fences in Markdown"
+```
+
+---
+
+### Task 3: Route streamed Mermaid blocks without creating code-card overlays
+
+**Files:**
+- Modify: `crates/tui/src/widgets/state/stream_state.rs`
+- Modify: `crates/tui/src/widgets/state/app/agent.rs`
+- Modify: `crates/tui/src/widgets/state/app/visibility.rs`
+- Modify: `crates/tui/src/render/render_gap_tests.rs`
+
+**Interfaces:**
+- Add `StreamState::code_block_is_mermaid: bool`, defaulting to `false`.
+- Reuse `render_mermaid_block` and the existing message splice/placeholder APIs.
+- Valid completed Mermaid becomes ordinary log content or a width-aware Markdown cell, but never adds an entry to `app.code_blocks`.
+- Invalid Mermaid and ordinary fences retain the existing `CodeBlock` fallback.
+
+- [ ] **Step 1: Write the failing main-area regression tests.**
+
+Add to `render_gap_tests.rs`:
+
+```rust
+#[test]
+fn log_renders_streamed_mermaid_without_code_card() {
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nsequenceDiagram\n  Alice->>Bob: Hello\n```\n".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert!(app.code_blocks.is_empty(), "valid Mermaid must not become a code card");
+    assert!(text.contains("Alice") && text.contains("Bob"), "diagram missing: {text}");
+    assert!(!text.contains("sequenceDiagram"), "raw Mermaid leaked: {text}");
+}
+
+#[test]
+fn log_falls_back_to_code_card_for_invalid_streamed_mermaid() {
+    let mut app = make_app();
+    app.handle_agent_update(AgentUpdate::StreamChunk(
+        "```mermaid\nnot valid Mermaid\n```\n".into(),
+    ));
+    app.handle_agent_update(AgentUpdate::TaskComplete("done".into()));
+
+    let text = render_main_area_text(&mut app, 100, 30);
+
+    assert_eq!(app.code_blocks.len(), 1, "invalid Mermaid should use code fallback");
+    assert!(text.contains("not valid Mermaid"), "fallback lost source: {text}");
+}
+```
+
+Add a test for a closing Mermaid fence without a trailing newline alongside `flush_consumes_closing_fence_without_trailing_newline`; it must assert a valid diagram and `app.code_blocks.is_empty()`.
+
+- [ ] **Step 2: Run the focused tests and verify they fail.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_gap_tests::log_renders_streamed_mermaid_without_code_card -- --exact
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_gap_tests::log_falls_back_to_code_card_for_invalid_streamed_mermaid -- --exact
+```
+
+Expected: the first test fails because the current path creates a `CodeBlock`; the second may pass only for source retention, but must be kept as a regression for the shared fallback path.
+
+- [ ] **Step 3: Mark Mermaid when opening a stream fence.**
+
+When `apply_stream_chunk` extracts the language, assign:
+
+```rust
+self.stream.code_block_is_mermaid = lang.eq_ignore_ascii_case("mermaid");
+```
+
+Keep buffering lines exactly as today. The preview may retain the existing streaming code styling, but do not create a `CodeBlock` object for a valid completed Mermaid block.
+
+- [ ] **Step 4: Centralize close/finalize behavior.**
+
+Extract the close logic currently duplicated between `apply_stream_chunk` and `flush_stream_pending` into one helper with this behavior:
+
+```rust
+fn finish_stream_code_block(&mut self, lang: String, lines: Vec<String>, start: usize, end: usize) {
+    let source = format!("```{lang}\n{}\n```", lines.join("\n"));
+    if lang.eq_ignore_ascii_case("mermaid")
+        && let Some(diagram) = render_mermaid_block(
+            &lines.join("\n"),
+            &self.theme,
+            self.log_scroll.width.max(1) as usize,
+        )
+    {
+        let raw = diagram.iter().map(Line::to_string).collect::<Vec<_>>();
+        self.splice_msgs(start..end, diagram, raw, RawMessageType::LLM);
+        return;
+    }
+
+    const MAX_CODE_PREVIEW: usize = 30;
+    let (styled, _) = render_markdown_tui(&source, &self.theme);
+    let placeholder_count = styled.len().min(MAX_CODE_PREVIEW) + 2;
+    let placeholders: Vec<Line<'static>> =
+        (0..placeholder_count).map(|_| Line::from("")).collect();
+    let raw_placeholders: Vec<String> =
+        (0..placeholder_count).map(|_| String::new()).collect();
+    self.splice_msgs(
+        start..end,
+        placeholders,
+        raw_placeholders,
+        RawMessageType::LLM,
+    );
+    self.code_blocks.push(CodeBlock {
+        start_idx: start,
+        end_idx: start + placeholder_count,
+        lang,
+        content: lines.join("\n"),
+        styled,
+    });
+}
+```
+
+The actual implementation should use the existing `code_block_start_idx`, `code_block_line_count`, `splice_msgs`, and `CodeBlock` fields rather than introducing a second overlay type. Reset `code_block_is_mermaid` whenever the buffered block is finalized.
+
+- [ ] **Step 5: Make incomplete flush use the same helper.**
+
+In `flush_stream_pending`, preserve the current handling of a final pending ` ``` ` without newline, collect any remaining content, and call the same finalization helper. If the stream ends with an unclosed Mermaid fence, the helper receives no closing fence and must take the fallback code-card branch; it must not discard buffered source.
+
+- [ ] **Step 6: Run streaming and existing code-card tests.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib render::render_gap_tests
+# Run only after the previous command exits:
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib widgets::state::app::agent::lifecycle_tests
+```
+
+Expected: Mermaid stream tests pass, existing Rust/text code-card tests remain green, and no test reports leaked closing fences.
+
+- [ ] **Step 7: Commit streaming support.**
+
+```bash
+git add crates/tui/src/widgets/state/stream_state.rs crates/tui/src/widgets/state/app/agent.rs crates/tui/src/widgets/state/app/visibility.rs crates/tui/src/render/render_gap_tests.rs
+git commit -m "feat(tui): render streamed Mermaid diagrams"
+```
+
+---
+
+### Task 4: Synchronize documentation and verify the complete TUI suite
+
+**Files:**
+- Modify: `book/23_chapter_tui.md`
+- Modify: `book/23_chapter_tui_zh.md`
+- Modify: `book/26_chapter_issue.md`
+- Modify: `book/26_chapter_issue_zh.md`
+
+**Interfaces:**
+- Documentation must describe the shipped main-area behavior, not the old “all explicit fences become code cards” rule.
+- English and Chinese Ch 23 sections must remain structurally aligned.
+- Ch 26 gets one newest-first entry with date, type, symptom, decision, post-change behavior, and pointers to the spec/plan/code/tests.
+
+- [ ] **Step 1: Write the documentation assertions as a checklist before editing.**
+
+The updated Ch 23 Markdown section must state all of these facts:
+
+```text
+- A complete ```mermaid fenced block is rendered as a terminal diagram in the main log.
+- Supported types follow the pinned ratatui-markdown Mermaid renderer.
+- Streaming buffers the block until closure and does not create a code card when rendering succeeds.
+- Invalid/unsupported Mermaid falls back to the normal code block/card.
+- Ordinary explicit-language fences retain code-card behavior.
+- Width changes and viewport scrolling use the existing log layout/cache behavior.
+```
+
+- [ ] **Step 2: Edit the paired English/Chinese Ch 23 sections.**
+
+Replace only the stale fenced-content paragraph and add a short Mermaid bullet/subsection in both files. Keep heading hierarchy and section numbering identical; translate content rather than changing structure.
+
+- [ ] **Step 3: Add the newest Ch 26 issue entry in both languages.**
+
+Use date `2026-08-08`, type `optimization` or `bugfix` according to the final implementation classification, and point to:
+
+```text
+crates/tui/src/render/render_md.rs
+crates/tui/src/widgets/state/app/agent.rs
+crates/tui/src/widgets/state/app/visibility.rs
+docs/superpowers/specs/2026-08-08-mermaid-main-rendering-design.md
+docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md
+```
+
+Describe the before/after observable behavior and the code-fallback invariant in both languages.
+
+- [ ] **Step 4: Run documentation consistency checks.**
+
+```bash
+git diff --check
+rg -n "Mermaid|mermaid|时序图|代码卡片|code card" book/23_chapter_tui.md book/23_chapter_tui_zh.md book/26_chapter_issue.md book/26_chapter_issue_zh.md
+```
+
+Expected: both language files mention the same behavior and no whitespace errors are reported.
+
+- [ ] **Step 5: Run the complete TUI verification suite.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tui --lib
+```
+
+Expected: all tests pass, including the baseline 505 tests plus the new regressions.
+
+- [ ] **Step 6: Inspect the final diff and commit documentation.**
+
+```bash
+git diff --stat HEAD~3..HEAD
+git status --short --branch
+git diff --check
+git add book/23_chapter_tui.md book/23_chapter_tui_zh.md book/26_chapter_issue.md book/26_chapter_issue_zh.md
+git commit -m "docs: document main-area Mermaid rendering"
+```
+
+Expected: the worktree is clean and only the planned Mermaid code/tests/docs are changed.
+
+---
+
+## Plan Self-Review
+
+- **Spec coverage:** shared renderer and adapter are covered by Task 1; normal Markdown routing, fallback, and width-aware cell behavior by Task 2; streaming, incomplete flush, and code-card compatibility by Task 3; bilingual docs and issue log by Task 4.
+- **Placeholder scan:** no `TBD`, `TODO`, ellipsis, or unspecified implementation step remains.
+- **Type consistency:** `render_mermaid_block` returns `Option<Vec<Line<'static>>>`; all tasks use that signature. Stream finalization consumes `String`, `Vec<String>`, and index bounds already represented by `StreamState`; raw lines are derived with `Line::to_string`.
+- **Scope check:** all changes belong to one TUI rendering subsystem plus its required bilingual docs; no independent subsystem needs a separate spec.

--- a/docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md
+++ b/docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md
@@ -1,0 +1,603 @@
+# OpenAI Responses Compatibility Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the typed-core/raw-JSON Responses foundation that preserves unknown protocol data, exposes explicit Responses request options, and keeps the existing OpenAI text/reasoning/function/compaction paths working without forking `async-openai` prematurely.
+
+**Architecture:** Keep `async-openai 0.41.1` for transport and known Responses types. Add a Tact-owned raw wire boundary before typed deserialization, a Tact-owned `ResponsesRequestOptions` extension for fields not present in the shared Chat/Anthropic request model, and a versioned state representation that round-trips unknown input/output items. Do not add an SDK fork unless a fixture demonstrates that the current `byot`/raw boundary cannot implement a required behavior; if that happens, isolate the fork to the Responses dependency and keep Tact-specific state/TUI/permission logic outside it.
+
+**Tech Stack:** Rust 2024, `async-openai-responses 0.41.1` with `responses` and `byot`, `serde_json::Value`, Tokio, WireMock, SQLite/sqlx, existing Tact `LlmClient` and provider-state APIs.
+
+## Global Constraints
+
+- Preserve the existing `async-openai 0.20` Chat Completions dependency; do not replace both protocol versions with one unverified fork.
+- Unknown Responses events that do not affect protocol state must not abort a normal response.
+- Unknown output/input items must be retained as raw JSON and round-trip through provider state.
+- Compaction items remain opaque protocol state and never become `ContentBlock` values.
+- Hosted provider-executed tools never enter the local Tact tool dispatcher.
+- No API key, encrypted reasoning content, or complete sensitive input may appear in diagnostics.
+- Async tests waiting on channels must use bounded timeouts; no unbounded `recv().await`.
+- Never run multiple Cargo commands concurrently; clear `http_proxy`, `https_proxy`, and `all_proxy` for local WireMock tests.
+- Do not add a dependency when `serde_json`, the existing SDK, or existing Tact infrastructure is sufficient.
+- Update `book/05_chapter_compact.md` and `book/05_chapter_compact_zh.md` when compaction behavior changes; update both issue-log languages for shipped user-visible behavior.
+
+---
+
+## File Map
+
+- Create: `crates/tact_llm/src/openai/responses/wire.rs` — raw event/response envelope parsing and known/unknown item partitioning.
+- Create: `crates/tact_llm/src/openai/responses/request_options.rs` — Responses-only request options and JSON patch serialization; re-export `ResponsesRequestOptions` from `openai::responses`.
+- Modify: `crates/tact_llm/src/openai/responses/mod.rs` — use raw wire parsing for streaming and non-streaming responses.
+- Modify: `crates/tact_llm/src/openai/responses/convert.rs` — serialize `ResponsesRequestOptions` and preserve raw baseline items.
+- Modify: `crates/tact_llm/src/openai/responses/normalize.rs` — normalize known items while retaining raw output order.
+- Modify: `crates/tact_llm/src/openai/responses/stream.rs` — envelope-first event state machine with raw unknown-item retention.
+- Modify: `crates/tact_llm/src/types.rs` — carry optional Responses-only request options without changing non-Responses wire behavior.
+- Modify: `crates/tact_llm/src/provider_state.rs` — versioned raw item/state schema and migration checks.
+- Modify: `crates/tact_llm/src/error.rs` — contextual wire errors that do not include sensitive payloads.
+- Modify: `crates/tact_llm/src/openai/responses/*.rs` tests — fixtures and round-trip tests.
+- Modify: `crates/tact/src/agent/mod.rs` — preserve existing state/compaction behavior while consuming the extended state update.
+- Modify: `crates/tact/src/store/session_store/sqlite.rs` — verify existing JSON persistence accepts the extended state without leaking payloads.
+- Modify: `config.example.toml` — document only options that are actually exposed by Tact after implementation.
+- Modify: `docs/compaction.md`, `book/05_chapter_compact.md`, `book/05_chapter_compact_zh.md` — update raw-state/native-compaction behavior if the wire baseline contract changes.
+- Modify: `book/26_chapter_issue.md`, `book/26_chapter_issue_zh.md` — add a newest-first user-visible behavior entry if the shipped behavior changes.
+
+## Interfaces Produced by This Plan
+
+The implementation must expose these crate-internal interfaces; names may only change with an equivalent type/signature and corresponding plan update:
+
+```rust
+// crates/tact_llm/src/openai/responses/wire.rs
+pub(crate) struct RawResponseEnvelope {
+    pub(crate) value: serde_json::Value,
+    pub(crate) typed: async_openai_responses::types::responses::Response,
+    pub(crate) output_items: Vec<serde_json::Value>,
+    pub(crate) unknown_output_items: Vec<serde_json::Value>,
+}
+
+pub(crate) fn parse_response_envelope(
+    value: serde_json::Value,
+) -> Result<RawResponseEnvelope, crate::LlmError>;
+
+pub(crate) fn raw_output_items(value: &serde_json::Value)
+    -> Result<Vec<serde_json::Value>, crate::LlmError>;
+```
+
+```rust
+// crates/tact_llm/src/openai/responses/request_options.rs
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ResponsesRequestOptions {
+    pub parallel_tool_calls: Option<bool>,
+    pub truncation: Option<String>,
+    pub metadata: Option<serde_json::Map<String, serde_json::Value>>,
+    pub user: Option<String>,
+    pub prompt_cache_key: Option<String>,
+    pub text: Option<serde_json::Value>,
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ResponsesRequestOptions {
+    pub(crate) fn apply_to(
+        &self,
+        body: &mut serde_json::Value,
+    ) -> Result<(), crate::LlmError>;
+}
+```
+
+```rust
+// crates/tact_llm/src/types.rs
+impl CreateMessageParams {
+    pub fn with_responses_options(
+        self,
+        options: crate::openai::responses::ResponsesRequestOptions,
+    ) -> Self;
+}
+```
+
+The field is `None` by default, skipped by non-Responses adapters, and never serialized into Chat Completions or Anthropic requests.
+
+---
+
+### Task 1: Add the Responses-only request options boundary
+
+**Files:**
+- Create: `crates/tact_llm/src/openai/responses/request_options.rs`
+- Modify: `crates/tact_llm/src/openai/responses/mod.rs`
+- Modify: `crates/tact_llm/src/types.rs`
+- Modify: `crates/tact_llm/src/convert.rs`
+- Test: `crates/tact_llm/src/openai/responses/request_options.rs` (`#[cfg(test)]`)
+- Test: `crates/tact_llm/src/openai/responses/convert.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: existing `CreateMessageParams` and Responses JSON body builder.
+- Produces: `ResponsesRequestOptions` and `CreateMessageParams::with_responses_options` used by the Responses adapter only.
+
+- [ ] **Step 1: Write the failing serialization tests.**
+
+```rust
+#[test]
+fn responses_options_patch_only_populates_responses_fields() {
+    let options = ResponsesRequestOptions {
+        parallel_tool_calls: Some(false),
+        truncation: Some("auto".into()),
+        metadata: Some(serde_json::Map::from_iter([(
+            "ticket".into(),
+            serde_json::json!("r-1"),
+        )])),
+        user: Some("user-1".into()),
+        prompt_cache_key: Some("cache-1".into()),
+        text: Some(serde_json::json!({"format": {"type": "text"}})),
+        extra: Default::default(),
+    };
+    let mut body = serde_json::json!({"model": "gpt-5", "input": []});
+    options.apply_to(&mut body).unwrap();
+    assert_eq!(body["parallel_tool_calls"], false);
+    assert_eq!(body["truncation"], "auto");
+    assert_eq!(body["metadata"]["ticket"], "r-1");
+    assert_eq!(body["user"], "user-1");
+    assert_eq!(body["prompt_cache_key"], "cache-1");
+    assert_eq!(body["text"]["format"]["type"], "text");
+}
+
+#[test]
+fn responses_options_rejects_non_object_metadata() {
+    let options = ResponsesRequestOptions {
+        metadata: None,
+        extra: serde_json::Map::from_iter([("text".into(), serde_json::json!("bad"))]),
+        ..Default::default()
+    };
+    let mut body = serde_json::json!({});
+    let error = options.apply_to(&mut body).unwrap_err().to_string();
+    assert!(error.contains("Responses request option 'text'"));
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails because the type and method do not exist.**
+
+Run:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm responses_options_patch_only_populates_responses_fields --lib
+```
+
+Expected: compile failure naming the missing `ResponsesRequestOptions` or `apply_to` implementation.
+
+- [ ] **Step 3: Implement the options type and JSON patch.**
+
+Use `serde_json::Value` only for fields whose shape is intentionally extensible (`text` and `extra`). Reject non-object request bodies and conflicting `extra` keys with an `LlmError::Unsupported` message naming the field. Apply explicit typed fields first, then reject `extra` collisions instead of silently overwriting known fields.
+
+- [ ] **Step 4: Add the optional field and builder to `CreateMessageParams`.**
+
+Declare `mod request_options; pub use request_options::ResponsesRequestOptions;` in `crates/tact_llm/src/openai/responses/mod.rs`. The field must be skipped by serde and default to `None`:
+
+```rust
+#[serde(skip)]
+pub responses_options: Option<crate::openai::responses::ResponsesRequestOptions>,
+```
+
+Add `with_responses_options`, and update `Default` construction only as needed by the compiler. Chat/Anthropic conversion tests must prove the field does not appear on their wire bodies.
+
+- [ ] **Step 5: Apply options from `convert::create_response`.**
+
+After the existing typed request is serialized and before state input replacement, call `options.apply_to(&mut body)` when `request.responses_options` is `Some(_)`. Existing context-management patching remains separate and wins only for its own `context_management` key.
+
+- [ ] **Step 6: Run the focused tests and the existing Responses conversion tests.**
+
+Run:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses::convert --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm responses_options --lib
+```
+
+Expected: all focused tests pass, including existing request/compaction tests.
+
+- [ ] **Step 7: Commit the task.**
+
+```bash
+git add crates/tact_llm/src/types.rs crates/tact_llm/src/convert.rs crates/tact_llm/src/openai/responses/mod.rs crates/tact_llm/src/openai/responses/request_options.rs
+git commit -m "feat: add Responses request options boundary"
+```
+
+---
+
+### Task 2: Introduce envelope-first raw response parsing
+
+**Files:**
+- Create: `crates/tact_llm/src/openai/responses/wire.rs`
+- Modify: `crates/tact_llm/src/openai/responses/mod.rs`
+- Modify: `crates/tact_llm/src/openai/responses/normalize.rs`
+- Modify: `crates/tact_llm/src/openai/responses/stream.rs`
+- Test: `crates/tact_llm/src/openai/responses/wire.rs` (`#[cfg(test)]`)
+- Test: `crates/tact_llm/src/openai/responses/normalize.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: raw JSON returned by `create_byot`, `create_stream_byot`, and terminal SSE events.
+- Produces: `RawResponseEnvelope`, raw output item order, known typed `Response`, and non-fatal unknown-event handling.
+
+- [ ] **Step 1: Add a fixture with an unknown output item and a valid message.**
+
+Create a test-local JSON value:
+
+```rust
+fn response_with_unknown_output_item() -> serde_json::Value {
+    serde_json::json!({
+        "id": "resp_unknown_item",
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {"type": "future_item", "id": "future-1", "payload": {"x": 1}},
+            {"type": "message", "id": "msg-1", "status": "completed", "role": "assistant",
+             "content": [{"type": "output_text", "text": "hello", "annotations": []}]}
+        ],
+        "usage": {"input_tokens": 1, "input_tokens_details": {"cached_tokens": 0},
+                  "output_tokens": 1, "output_tokens_details": {"reasoning_tokens": 0},
+                  "total_tokens": 2}
+    })
+}
+```
+
+- [ ] **Step 2: Run the test against the current typed boundary and verify the expected failure.**
+
+Add a test calling `parse_response_envelope(response_with_unknown_output_item())` and assert that it returns two raw output items and one unknown item. Run:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses::wire --lib
+```
+
+Expected: compile failure until the new module/function exists; after temporarily wiring only typed deserialization, the fixture must fail with the SDK unknown-variant error. The final implementation must remove that failure.
+
+- [ ] **Step 3: Implement raw output extraction before typed parsing.**
+
+`raw_output_items` must require an object response and array `output`, clone each item as `Value`, and return contextual errors for missing/wrong-shaped fields. `parse_response_envelope` must:
+
+1. extract raw output items;
+2. classify each item by its string `type`;
+3. deserialize the complete response through the SDK only when all items are known;
+4. otherwise deserialize a typed response with unknown items removed/replaced only for normalization, while retaining the original raw sequence in `RawResponseEnvelope`;
+5. never expose unknown payloads in an error string.
+
+The typed surrogate must preserve response status, usage, ids, and all known output items in original order.
+
+- [ ] **Step 4: Route non-streaming Responses through the envelope parser.**
+
+In `OpenAiResponsesAdapter::create_message`, request `Value`, call `parse_response_envelope`, normalize the typed surrogate, and pass the raw output sequence to `NormalizedResponse` for state update. Do not deserialize `Value` directly into `Response` before the raw parser.
+
+- [ ] **Step 5: Add unknown event envelope handling for streams.**
+
+`parse_stream_event` must inspect `type` before typed deserialization. Existing known events continue through `ResponseStreamEvent`; an unknown event becomes `Ok(None)` unless it is an output-item lifecycle event with a missing/invalid item object, which returns a contextual protocol error. Keep the raw event only for diagnostics bounded to event type, not payload.
+
+- [ ] **Step 6: Run the wire, normalize, and stream test groups.**
+
+Run:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses::wire --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses::normalize --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses::stream --lib
+```
+
+Expected: unknown output item is retained, ordinary text remains visible, unknown harmless events do not abort, and existing compaction sequence tests remain green.
+
+- [ ] **Step 7: Commit the task.**
+
+```bash
+git add crates/tact_llm/src/openai/responses/wire.rs crates/tact_llm/src/openai/responses/mod.rs crates/tact_llm/src/openai/responses/normalize.rs crates/tact_llm/src/openai/responses/stream.rs
+git commit -m "feat: preserve unknown Responses wire items"
+```
+
+---
+
+### Task 3: Make provider state round-trip raw Responses items
+
+**Files:**
+- Modify: `crates/tact_llm/src/provider_state.rs`
+- Modify: `crates/tact_llm/src/openai/responses/normalize.rs`
+- Modify: `crates/tact_llm/src/openai/responses/convert.rs`
+- Modify: `crates/tact/src/store/session_store/sqlite.rs`
+- Test: `crates/tact_llm/src/provider_state.rs` (`#[cfg(test)]`)
+- Test: `crates/tact/src/store/session_store/sqlite.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `RawResponseEnvelope.output_items` from Task 2.
+- Produces: versioned `ResponsesConversationState` that preserves unknown baseline/output JSON and validates context hashes.
+
+- [ ] **Step 1: Write the failing state round-trip test.**
+
+Extend the existing state fixture with an unknown item and assert its exact JSON survives serialize/deserialize and `create_response`:
+
+```rust
+#[test]
+fn state_with_unknown_items_round_trips_exact_json() {
+    let unknown = serde_json::json!({
+        "type": "future_item", "id": "future-1", "payload": {"nested": [1, 2, 3]}
+    });
+    let state = state_with_input_items(vec![unknown.clone()]);
+    let encoded = serde_json::to_string(&ProviderConversationState::OpenAiResponses(state)).unwrap();
+    let decoded: ProviderConversationState = serde_json::from_str(&encoded).unwrap();
+    let ProviderConversationState::OpenAiResponses(decoded) = decoded else { panic!("wrong state variant") };
+    assert_eq!(decoded.input_items[0], unknown);
+}
+```
+
+- [ ] **Step 2: Run the focused state tests and confirm the new fixture fails or exposes the missing state field.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm provider_state::tests::state_with_unknown_items_round_trips_exact_json --lib
+```
+
+Expected: failure until the state fixture/helper and baseline handling are updated.
+
+- [ ] **Step 3: Keep state schema version 1 backward-compatible and add raw item validation.**
+
+Do not change existing persisted field names unless required. Ensure `input_items: Vec<Value>` remains the canonical raw baseline. Add a state validation helper that rejects non-object input items and preserves unknown fields. If a schema change is unavoidable, add an explicit version 2 enum and a migration test from the current version 1 JSON; do not silently reinterpret old state.
+
+- [ ] **Step 4: Pass raw terminal output into `ProviderStateUpdate`.**
+
+Update `NormalizedResponse` so state creation receives the exact ordered raw output items. Known items remain normalized for Tact blocks; unknown items remain only in protocol state. The logical message count/hash rules remain unchanged.
+
+- [ ] **Step 5: Verify SQLite persistence and sensitive-data redaction.**
+
+Add an SQLite test that persists/loads a state containing a marker in an unknown item, confirms the state JSON contains it when loaded by the owning session, and confirms the corrupt-state error path reports only structural metadata and not the marker. Use existing session-store helpers rather than adding a new persistence layer.
+
+- [ ] **Step 6: Run state and SQLite tests.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm provider_state --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact store::session_store::sqlite --lib
+```
+
+Expected: all existing state/SQLite tests plus the new exact round-trip and redaction tests pass.
+
+- [ ] **Step 7: Commit the task.**
+
+```bash
+git add crates/tact_llm/src/provider_state.rs crates/tact_llm/src/openai/responses/normalize.rs crates/tact_llm/src/openai/responses/convert.rs crates/tact/src/store/session_store/sqlite.rs
+git commit -m "feat: round-trip raw Responses state items"
+```
+
+---
+
+### Task 4: Add Responses capability metadata without enabling unverified providers
+
+**Files:**
+- Create: `crates/tact_llm/src/openai/responses/capabilities.rs`
+- Modify: `crates/tact_llm/src/provider.rs`
+- Modify: `crates/tact_llm/src/types.rs`
+- Modify: `crates/tact/src/config/types.rs`
+- Modify: `crates/tact/src/config/resolve.rs`
+- Test: `crates/tact_llm/src/openai/responses/capabilities.rs` (`#[cfg(test)]`)
+- Test: `crates/tact/src/config/resolve.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: provider kind, protocol, base URL, and current Responses adapter construction.
+- Produces: stable `ResponsesCapabilities` metadata for routing and configuration validation.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResponsesToolKind {
+    WebSearch,
+    FileSearch,
+    CodeInterpreter,
+    ImageGeneration,
+    Computer,
+    LocalShell,
+    Shell,
+    Custom,
+    Namespace,
+    ApplyPatch,
+    ToolSearch,
+    RemoteMcp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponsesCapabilities {
+    pub responses: bool,
+    pub streaming: bool,
+    pub compact: bool,
+    pub hosted_tools: std::collections::BTreeSet<ResponsesToolKind>,
+}
+```
+
+- [ ] **Step 1: Write capability and config rejection tests.**
+
+Assert that official OpenAI Responses defaults to `responses = true`, `streaming = true`, `compact = true`, while custom providers default to only the capabilities explicitly configured. Assert that DeepSeek and Kimi remain rejected by current config resolution until their endpoint validation is separately approved.
+
+- [ ] **Step 2: Run the tests and verify missing capability APIs fail.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm responses_capabilities --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact config::resolve::tests::reject_deepseek_responses_protocol --lib
+```
+
+Expected: the new capability test fails to compile before implementation; the existing DeepSeek rejection remains green.
+
+- [ ] **Step 3: Implement capability defaults and provider exposure.**
+
+OpenAI official provider gets the capabilities already implemented by this foundation. Custom providers must not silently claim Hosted Tool support. Keep `build_openai_responses` usable for custom endpoints, but use capabilities to gate requests that require unsupported features. Do not remove DeepSeek/Kimi config rejection in this task.
+
+- [ ] **Step 4: Keep capability configuration out of TOML in this foundation.**
+
+Expose static capability metadata from `ProviderInfo`: official OpenAI enables only capabilities implemented by this repository, while custom providers expose core Responses streaming but no Hosted Tool capability. Do not infer capabilities from model names or base URL substrings. A later Hosted Tools plan may add an explicit TOML allow-list after its request and execution semantics are implemented.
+
+- [ ] **Step 5: Run capability and config tests.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm provider::tests --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact config::resolve --lib
+```
+
+Expected: all provider construction and existing rejection tests pass, with new capability assertions green.
+
+- [ ] **Step 6: Commit the task.**
+
+```bash
+git add crates/tact_llm/src/openai/responses/capabilities.rs crates/tact_llm/src/provider.rs crates/tact_llm/src/types.rs crates/tact/src/config/types.rs crates/tact/src/config/resolve.rs
+git commit -m "feat: describe Responses provider capabilities"
+```
+
+---
+
+### Task 5: Add wire fixtures and end-to-end regression coverage
+
+**Files:**
+- Create: `crates/tact_llm/src/openai/responses/fixtures/unknown_output_item.json`
+- Create: `crates/tact_llm/src/openai/responses/fixtures/unknown_event_stream.jsonl`
+- Modify: `crates/tact_llm/src/openai/responses/mod.rs`
+- Modify: `crates/tact/src/agent/mod.rs`
+- Modify: `crates/tact/src/store/session_store/sqlite.rs`
+- Test: existing Responses unit and WireMock test modules in the files above
+
+**Interfaces:**
+- Consumes: Tasks 1–4 request options, raw envelope parser, raw state, and capability metadata.
+- Produces: regression coverage proving existing behavior and new compatibility behavior coexist.
+
+- [ ] **Step 1: Add fixtures for ordinary response, unknown item, unknown event, function call, and compaction.**
+
+Use stable JSON fixtures with no real encrypted payloads or secrets. Keep unknown payloads short and deterministic. The stream fixture must contain terminal event, output item added/done, one harmless unknown event, and a valid visible text delta.
+
+- [ ] **Step 2: Add failing end-to-end tests.**
+
+Cover these exact behaviors:
+
+```rust
+#[tokio::test]
+async fn responses_unknown_item_survives_next_request() {
+    let server = wiremock::MockServer::start().await;
+    // Register two `/responses` mocks, run two adapter turns, then assert
+    // the second request contains the first turn's unknown raw item.
+    let requests = record_requests(&server).await;
+    assert_eq!(requests[1]["input"][0]["type"], "future_item");
+}
+
+#[tokio::test]
+async fn responses_unknown_stream_event_does_not_abort_text() {
+    let server = wiremock::MockServer::start().await;
+    // Serve `unknown_event_stream.jsonl` as SSE and assert the final block is
+    // `ContentBlock::Text { text: "hello" }`.
+    let response = stream_one_turn(&server).await;
+    assert_eq!(response.blocks, vec![ContentBlock::Text { text: "hello".into() }]);
+}
+
+#[tokio::test]
+async fn responses_request_options_are_sent_without_affecting_chat_requests() {
+    let server = wiremock::MockServer::start().await;
+    let request = request_with_responses_options(&server).await;
+    assert_eq!(request["parallel_tool_calls"], false);
+    assert!(request.get("reasoning_effort").is_none());
+}
+```
+
+Define test helpers in the same test module before using them: `record_requests(&MockServer) -> Vec<serde_json::Value>` parses `server.received_requests()` bodies; `stream_one_turn(&MockServer) -> LlmResponse` constructs the existing `OpenAiResponsesAdapter`, calls `stream_message`, and returns the response; `request_with_responses_options(&MockServer) -> serde_json::Value` constructs a request with `ResponsesRequestOptions`, runs `create_message`, and parses the captured body. Each async channel receive inside these helpers must use `tokio::time::timeout(Duration::from_secs(2), ...)`.
+
+- [ ] **Step 3: Run the new tests before implementation wiring is complete.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses --lib
+```
+
+Expected: the new assertions fail until all previous tasks are integrated; existing tests identify any regression.
+
+- [ ] **Step 4: Wire the full adapter and agent loop.**
+
+Ensure `Agent::ensure_session`, ordinary stream calls, automatic compaction, explicit compaction, and SQLite replacement all use the new state update without changing the existing atomic persistence order.
+
+- [ ] **Step 5: Run the complete focused matrix.**
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact agent::tests::responses --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact store::session_store::sqlite --lib
+```
+
+Expected: all focused tests pass, including existing compaction/state tests and the new raw compatibility cases.
+
+- [ ] **Step 6: Commit the task.**
+
+```bash
+git add crates/tact_llm/src/openai/responses/fixtures crates/tact_llm/src/openai/responses crates/tact/src/agent/mod.rs crates/tact/src/store/session_store/sqlite.rs
+git commit -m "test: cover Responses raw compatibility round trips"
+```
+
+---
+
+### Task 6: Document the extension boundary and fork decision gate
+
+**Files:**
+- Modify: `config.example.toml`
+- Modify: `docs/compaction.md`
+- Modify: `book/05_chapter_compact.md`
+- Modify: `book/05_chapter_compact_zh.md`
+- Modify: `book/26_chapter_issue.md`
+- Modify: `book/26_chapter_issue_zh.md`
+- Modify: `docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`
+
+**Interfaces:**
+- Consumes: behavior delivered by Tasks 1–5.
+- Produces: user-facing configuration and architecture documentation matching the implementation.
+
+- [ ] **Step 1: Write documentation assertions/checklist before editing.**
+
+The docs must explicitly state:
+
+- Responses-specific options are not sent by Chat Completions or Anthropic adapters.
+- Unknown protocol items are retained as raw JSON when state integrity is known.
+- Native Responses compaction remains distinct from local summary compaction.
+- Custom providers must not claim Hosted Tool support without capability declaration.
+- SDK fork is not used unless a reproducible fixture demonstrates that the current `byot`/raw boundary cannot implement the required behavior.
+
+- [ ] **Step 2: Update the config example and compaction docs.**
+
+Only document fields that are implemented and tested. Keep English and Chinese compaction chapters structurally aligned.
+
+- [ ] **Step 3: Add the issue-log entry if behavior is user-visible.**
+
+Use the newest-first format with date, type, motivation, decision, observable behavior, and code/spec/chapter pointers. Do not replace existing subsystem chapters.
+
+- [ ] **Step 4: Run documentation and formatting checks.**
+
+```bash
+cargo fmt --check
+git diff --check
+```
+
+Expected: format and diff checks pass.
+
+- [ ] **Step 5: Commit the task.**
+
+```bash
+git add config.example.toml docs/compaction.md book/05_chapter_compact.md book/05_chapter_compact_zh.md book/26_chapter_issue.md book/26_chapter_issue_zh.md docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
+git commit -m "docs: document Responses compatibility foundation"
+```
+
+---
+
+## SDK Fork Decision Gate
+
+After Tasks 1–5, fork `async-openai` only if at least one of these tests is impossible with the current dependency and raw boundary:
+
+1. A required official request type cannot be emitted without changing SDK transport or builder behavior.
+2. A required known response/event cannot be parsed into a typed surrogate while preserving the terminal response contract.
+3. SDK transport cannot expose the response bytes needed for state-safe raw round-trip.
+4. A required official endpoint cannot be reached through the current client configuration without a general-purpose transport fix.
+
+If none applies, keep the crates.io dependency and continue with Hosted Tool-specific plans. If one applies, create a separate fork integration task that:
+
+- pins a commit in `Cargo.toml` under the `async-openai-responses` package alias;
+- keeps `async-openai 0.20` unchanged;
+- adds only provider-agnostic SDK types/transport behavior;
+- adds an upstream-compatible fixture for the blocker;
+- leaves Tact state, permissions, tool execution, and TUI logic in this repository.
+
+## Verification Gate
+
+Before declaring this foundation complete, run these commands serially from the worktree:
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test --workspace --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm openai::responses --lib
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact agent::tests::responses --lib
+cargo fmt --check
+env -u http_proxy -u https_proxy -u all_proxy cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+The baseline recorded before implementation was 1246 passed, 0 failed, and 1 ignored; the final report must provide fresh command output rather than relying on that baseline.

--- a/docs/superpowers/specs/2026-08-08-mermaid-main-rendering-design.md
+++ b/docs/superpowers/specs/2026-08-08-mermaid-main-rendering-design.md
@@ -1,0 +1,101 @@
+# Mermaid Main-Area Rendering Design
+
+- **Date:** 2026-08-08
+- **Branch:** `wt/feat-mermaid-main-rendering`
+- **Status:** Approved for planning
+
+## Goal
+
+Render Mermaid fenced blocks in the TUI main log area as terminal diagrams instead of treating them as ordinary code cards. Preserve the existing Markdown and code-block behavior everywhere else.
+
+## Scope
+
+### In scope
+
+- Recognize complete fenced blocks whose language is `mermaid` in the main-area Markdown paths.
+- Reuse the workspace's existing `ratatui-markdown` Mermaid renderer.
+- Support every diagram type implemented by that dependency, including `flowchart`/`graph`, `sequenceDiagram`, `pie`, `gantt`, `stateDiagram`, `classDiagram`, `quadrantChart`, and `block`.
+- Use the application theme and the available log width.
+- Make streaming output, persisted history, and whole-Markdown cells use the same Mermaid behavior.
+- Fall back to the existing code rendering when Mermaid parsing fails or a diagram is unsupported.
+- Keep `/tasks-dag` behavior working while sharing the theme adapter where practical.
+
+### Out of scope
+
+- Adding a new Mermaid parser or dependency.
+- Implementing Mermaid types not supported by the pinned `ratatui-markdown` revision.
+- Changing ordinary Markdown, tables, headings, or non-Mermaid code-card styling.
+- Rendering Mermaid images or adding terminal image support.
+- Interactive diagram navigation beyond the existing log scrolling and clipping.
+
+## Current Context
+
+The main area currently uses `tui-markdown` through `render_markdown_tui`. During streaming, every explicit fenced language is promoted to a `CodeBlock` overlay when the fence closes. The repository already enables `ratatui-markdown`'s `markdown` and `mermaid` features for the `/tasks-dag` popup, which directly uses `MarkdownRenderer` and an application-theme adapter.
+
+## Design
+
+### 1. Shared Mermaid rendering helper
+
+Add a small helper in the TUI rendering layer that:
+
+1. Accepts Mermaid source, theme, and maximum width.
+2. Adapts the application `Theme` to `ratatui_markdown::theme::RichTextTheme`.
+3. Calls `ratatui_markdown::mermaid::render_mermaid`.
+4. Returns rendered `Line`s only when parsing/rendering succeeds.
+
+Generalize or relocate the existing `/tasks-dag` theme adapter instead of creating a second color mapping. The helper must not panic on malformed or unsupported input.
+
+### 2. Markdown block routing
+
+Extend the existing Markdown rendering pipeline to identify top-level fenced blocks with a case-insensitive `mermaid` language tag. Flush surrounding prose/table content through the current renderer, render valid Mermaid blocks with the shared helper, and preserve all other fences through the existing `tui-markdown` path.
+
+The routed Mermaid block is rendered as terminal `Line`s. Its visible/raw representation should remain aligned so log height, scrolling, and selection do not lose or duplicate rows. If the helper returns no diagram, the original fenced source goes through the ordinary code path.
+
+### 3. Streaming behavior
+
+Keep buffering a Mermaid fence until its closing fence, but mark that buffered block as Mermaid so the stream does not create the ordinary code-card header/overlay. On close:
+
+- valid Mermaid: replace the buffered placeholder rows with the rendered diagram lines;
+- invalid Mermaid: use the existing code-card path and retain the source;
+- ordinary language fence: retain current behavior unchanged.
+
+The stream's existing incomplete-fence behavior remains safe: if a response ends before the closing fence, its content is displayed as ordinary buffered code/text rather than being silently discarded.
+
+### 4. Width and theme behavior
+
+Use the actual main-area content width whenever it is available. Mermaid layout is width-dependent, so rendered lines must be regenerated when the width or theme cache changes, following the existing log visual-cache invalidation model. Avoid adding a second long-lived cache unless the current Markdown cell/cache boundary requires it.
+
+The viewport continues to clip tall diagrams through `LogColumnRenderer`; no separate Mermaid scrolling state is needed.
+
+### 5. `/tasks-dag` compatibility
+
+Keep task DAG source generation, popup scrolling, width-aware rerendering, and copy behavior unchanged. Only replace its local theme adapter with the shared adapter if that reduces duplication without changing output.
+
+## Error Handling and Fallbacks
+
+- Empty or malformed Mermaid source: ordinary code rendering.
+- Unknown diagram keyword: ordinary code rendering if the dependency returns no rendered lines.
+- Renderer output wider/taller than the viewport: normal width layout and viewport clipping.
+- No new user-facing error message; preserving source is more useful than adding log noise.
+
+## Tests
+
+Add focused tests before implementation code:
+
+1. A `sequenceDiagram` Markdown block renders lifelines/arrows and not raw `sequenceDiagram` source.
+2. A `flowchart` Markdown block renders terminal box/edge characters.
+3. Invalid Mermaid falls back to code text/card.
+4. A streamed valid Mermaid block closes into diagram rows without a normal code-card overlay.
+5. A normal language fence (for example `rust`) remains a code card.
+6. Existing history/whole-Markdown-cell rendering uses the same Mermaid route.
+7. Existing `/tasks-dag` rendering tests remain green.
+
+Run the focused TUI tests first, then the complete `cargo test -p tui --lib` command with proxy variables unset.
+
+## Acceptance Criteria
+
+- Main-area ` ```mermaid ` blocks display terminal diagrams for all types supported by the pinned renderer.
+- `sequenceDiagram` is visibly rendered in the main area, including participant/lifeline and message arrows.
+- Invalid Mermaid never disappears and remains readable as code.
+- Existing Markdown, ordinary code blocks, scrolling, width changes, themes, and task DAG popup behavior remain intact.
+- No new dependency is added.

--- a/docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
+++ b/docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
@@ -1,0 +1,252 @@
+# OpenAI Responses 完整适配设计
+
+## 目标
+
+在 Tact 现有 Responses adapter 基础上，尽可能完整覆盖当前 OpenAI Responses API，同时为未来新增的 SSE 事件、output item、tool 字段和响应元数据提供前向兼容能力。
+
+目标不是把任意 OpenAI-compatible 服务都宣称为完整兼容，而是让 OpenAI 官方 Responses endpoint 的核心能力、Hosted Tools、状态持久化和压缩链路具备清晰的能力边界与可验证行为。
+
+## 设计选择
+
+采用“强类型核心 + 原始 JSON 扩展层”：
+
+- 已知且参与 Tact 控制流的 Responses 对象使用 `async-openai-responses` 类型和 Rust 枚举。
+- 未知但属于协议状态的 item 使用原始 JSON 保留，并在下一次请求中原样透传。
+- 未知且不影响状态的 SSE 事件记录诊断信息后忽略，不阻断普通响应。
+- Hosted Tools 转换为 Tact 内部的 hosted-tool 生命周期表示，不伪装成本地 function tool。
+- 依赖 crate 尚未覆盖的已知字段通过 JSON request patch 补齐，而不为每个字段创建重复的本地类型。
+
+该方案避免完全绑定第三方 crate 的版本更新，也避免由 Tact 自己重写整个 Responses 类型系统。
+
+## 当前代码边界
+
+主要实现位于：
+
+- `crates/tact_llm/src/openai/responses/mod.rs`：Responses client、普通请求、流式请求和 native compact。
+- `crates/tact_llm/src/openai/responses/convert.rs`：Tact 消息到 Responses input 的转换。
+- `crates/tact_llm/src/openai/responses/normalize.rs`：terminal response 到 Tact 内容和 provider state 的转换。
+- `crates/tact_llm/src/openai/responses/stream.rs`：SSE 事件状态机。
+- `crates/tact_llm/src/openai/responses/history.rs`：reasoning 历史和 function-call item id 状态。
+- `crates/tact_llm/src/provider_state.rs`：Responses provider state 的版本化持久化模型。
+- `crates/tact/src/agent/mod.rs`：Responses state 恢复、自动压缩和 native compact 路由。
+- `crates/tact/src/store/session_store/sqlite.rs`：Responses state 和调用记录持久化。
+- `crates/tact/src/config/resolve.rs`、`crates/tact_llm/src/provider.rs`：provider/protocol 能力入口。
+
+## 功能范围
+
+### 1. 请求能力
+
+Responses request builder 需要覆盖 Tact 当前请求模型可以表达的字段：
+
+- `model`；
+- `input`，包括 message、image、reasoning、function call 和 function call output；
+- `instructions`；
+- `tools`、`tool_choice`、`parallel_tool_calls`；
+- `reasoning`、`reasoning.effort`、`reasoning.summary` 和 encrypted reasoning include；
+- `text` response format 相关字段；
+- `temperature`、`top_p`、`max_output_tokens`；
+- `truncation`；
+- `metadata`、`user`、`prompt_cache_key`；
+- `store` 与状态复用策略；
+- `context_management` 和 native compaction threshold。
+
+Tact 不应把 Responses 专有字段错误地映射为 Chat Completions 字段；无法表达的字段必须在配置或请求边界给出明确错误。
+
+### 2. 输入和输出转换
+
+已知核心对象使用强类型转换：
+
+- 文本 message 和多段 message content；
+- 图片输入；
+- reasoning summary、encrypted reasoning content 和历史关联信息；
+- refusal；
+- function call 与 function call output；
+- output message、annotations 和可见文本；
+- response status、incomplete details、usage 和 stop reason。
+
+协议状态与用户可见内容必须分离：
+
+- compaction item 不得变成普通 `ContentBlock`；
+- hosted tool call 不得变成本地 `ToolUse`；
+- 未知 item 必须保留 raw JSON；
+- 无法安全转换的已知 item 不得静默丢弃。
+
+### 3. 流式事件
+
+流式状态机覆盖核心生命周期：
+
+- response created / in-progress / completed / incomplete / failed；
+- output item added / done；
+- output text delta / done；
+- reasoning summary delta / done；
+- reasoning text delta / done；
+- refusal delta；
+- function call arguments delta / done；
+- hosted tool added / done；
+- error。
+
+处理规则：
+
+- 已知且影响输出或状态的事件必须严格校验顺序和完整性。
+- 未知且不影响状态的事件记录诊断信息后继续。
+- 未知 output item 必须进入 terminal output/state 的 raw item 序列。
+- 已声明但未完成的 compaction item 必须失败，不能使用可见文本恢复绕过它。
+- 重复的 added/done 事件应幂等处理，不能重复追加 assistant tool item。
+- 流结束时没有 terminal event 必须返回协议错误。
+
+### 4. Hosted Tools
+
+Hosted Tools 与本地 function tools 使用不同的数据流：
+
+- 本地 function tool：Tact 调度并执行，使用现有 `ToolUse` / `ToolResult` 流程。
+- Hosted Tool：OpenAI 执行，Tact 只记录、展示和保存其生命周期，不进入本地 tool dispatcher。
+
+分阶段支持：
+
+1. `web_search`：请求声明、output item 生命周期、查询、来源和失败信息。
+2. `file_search`：请求声明、搜索结果、引用和详情展示。
+3. `computer` / `computer_use_preview`：先完成协议解析和明确的 capability gate；只有建立权限确认、截图/坐标输入和动作安全边界后，才允许执行。
+
+Hosted Tool 的未知字段和原始 action/result 必须保存在 raw JSON 中。TUI 应复用统一 ToolWidget/Step 生命周期，而不是为每种 hosted tool 建立独立渲染分支。
+
+### 5. Provider state 和 session 恢复
+
+Responses state 继续使用版本化模型：
+
+- 保存 provider、base URL、model、input baseline、compaction id；
+- 保存 logical message count 和 context hash；
+- 保存未知 input/output item 的 raw JSON；
+- state schema 变更必须增加版本和迁移路径；
+- provider/base URL 不匹配时拒绝复用；
+- model 变化允许继续尝试，但 provider 可以在请求时拒绝不兼容的 opaque state；
+- state 和逻辑消息必须原子持久化，不能只更新其中一侧。
+
+未知 item 必须满足 state round-trip：读取旧 session 后再次生成请求时，未知 item 的协议语义不能丢失或被转换成文本。
+
+### 6. Compaction 和恢复
+
+- OpenAI Responses 使用 `/responses/compact`，不退回本地 summary。
+- 普通 Responses 请求可发送 `context_management` compact threshold。
+- native compact 的输入必须是当前 protocol baseline 加上尚未覆盖的 logical message suffix。
+- compact 返回的 resource 必须包含且只包含一个有效 compaction item。
+- compact 成功后先持久化 usage、state 和逻辑上下文，再提交 runtime counters。
+- 传输错误有限重试；协议错误不重试。
+- provider 不支持 compact 时必须通过 capability/configuration 明确失败，而不是在运行中表现为普通 summary compact。
+
+### 7. Provider capability
+
+Responses 能力不再只由 `protocol = "responses"` 一个布尔值隐含表达。需要逐步显式表示至少这些 capability：
+
+- `responses`；
+- `responses_streaming`；
+- `responses_compact`；
+- `responses_hosted_web_search`；
+- `responses_hosted_file_search`；
+- `responses_computer`。
+
+OpenAI 官方 provider 默认开启其已实现能力。自定义 OpenAI-compatible provider 必须通过配置或能力探测声明支持范围。DeepSeek/Kimi 只有在 endpoint 真实通过对应 wire/fixture/live 验证后才能解除当前配置阻断。
+
+## 错误处理和安全边界
+
+- 解析错误必须包含 event/item 类型和必要上下文，但不能打印 API key、encrypted content 或完整敏感输入。
+- 未知事件不能被当作成功状态。
+- 未知 item 可以保留，但如果无法判断它是否影响 state baseline 完整性，必须停止提交新 state。
+- Hosted Tool 的 provider 执行结果不能触发本地命令执行。
+- `computer` 相关动作在没有明确权限和确认协议前只能报告“不支持执行”，不能猜测执行。
+- 所有 async channel 等待必须有超时；测试不得使用无界 `recv().await`。
+
+## 测试策略
+
+### 单元测试
+
+覆盖：
+
+- request builder 的每个关键字段和 JSON patch；
+- message/image/reasoning/tool 转换；
+- stop reason 和 incomplete reason；
+- 未知 item raw JSON 保留；
+- 未知 event 忽略或拒绝规则；
+- 重复/缺失 output item 事件；
+- compaction item 校验；
+- provider state hash、版本和 round-trip。
+
+### WireMock 集成测试
+
+覆盖：
+
+- 普通 `/responses` streaming；
+- function call 多轮往返；
+- hosted tool lifecycle；
+- `/responses/compact` 成功、malformed resource、传输重试和持久化失败；
+- session restore 后的 baseline 复用；
+- model change 后 state 绑定行为。
+
+测试执行时必须清除代理环境，避免本地 WireMock 请求被代理：
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm responses
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact agent::tests::responses
+```
+
+### Fixture/live 验证
+
+- 使用官方 Responses SSE/JSON fixture 作为稳定回归集。
+- 对 OpenAI 官方 endpoint 增加显式 `#[ignore]` live tests，覆盖 text、reasoning、function tool、web search、compact。
+- live tests 不作为普通 CI 的唯一正确性依据。
+
+## 文档同步
+
+行为变化必须同步：
+
+- `config.example.toml`；
+- `docs/compaction.md`；
+- `book/05_chapter_compact.md`；
+- `book/05_chapter_compact_zh.md`；
+- `book/26_chapter_issue.md`；
+- `book/26_chapter_issue_zh.md`；
+- Responses/API 相关章节和配置说明。
+
+双语章节需保持相同章节结构、表格和流程图语义。
+
+## 分阶段交付
+
+### 阶段 1：协议基础和 raw 扩展层
+
+建立 typed core/raw extension 边界，补齐 request builder、未知事件/item 保存和 state round-trip。完成后不新增 hosted tool，但现有 text/reasoning/function/compact 行为不能回归。
+
+### 阶段 2：核心 Responses 完整化
+
+补齐输入/输出 content 类型、reasoning、refusal、annotations、usage、incomplete/failed/cancelled、function call streaming 和错误恢复。
+
+### 阶段 3：Hosted Tools
+
+先实现 web search，再实现 file search；统一 Step/ToolWidget 生命周期。computer tool 只在权限和执行模型设计完成后开放。
+
+### 阶段 4：能力声明和 provider 解锁
+
+增加 capability 表达，修正 OpenAI/custom provider 路由，并针对 DeepSeek/Kimi 分别进行 endpoint 验证；未验证通过的 provider 保持配置阻断。
+
+### 阶段 5：文档、live 验证和发布验收
+
+完成 fixture/live matrix、双语文档、issue log、migration 说明和完整串行验证。
+
+## 非目标
+
+- 不把所有 provider 的专有协议统一成一个无损的万能抽象。
+- 不在没有权限模型的情况下执行 computer action。
+- 不为每个未知 OpenAI 字段创建本地强类型。
+- 不用本地 summary 静默替代官方 Responses native compact。
+- 不承诺所有第三方 OpenAI-compatible endpoint 支持官方全部 Hosted Tools。
+
+## 完成标准
+
+只有同时满足以下条件，才称为“核心 Responses 完整”：
+
+1. OpenAI 官方核心 request/response/stream fixture 全部通过。
+2. 未知事件不破坏普通响应，未知 item 可 state round-trip。
+3. function tool 多轮、reasoning、图片、refusal、usage 和失败恢复有测试。
+4. native compact、session restore 和 SQLite 原子持久化有测试。
+5. web_search 和 file_search 的 hosted 生命周期与 TUI 展示有测试。
+6. provider capability 与配置错误信息准确，不支持能力不会静默降级。
+7. 双语文档和配置示例与实际行为一致。
+8. `cargo fmt --check`、目标 crate 测试和 workspace clippy 串行通过。

--- a/docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
+++ b/docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
@@ -36,7 +36,7 @@
 
 ### 1. 请求能力
 
-Responses request builder 需要覆盖 Tact 当前请求模型可以表达的字段：
+Responses request builder 需要覆盖 Tact 运行时拥有或明确暴露的 Responses-specific 请求字段：
 
 - `model`；
 - `input`，包括 message、image、reasoning、function call 和 function call output；
@@ -50,7 +50,7 @@ Responses request builder 需要覆盖 Tact 当前请求模型可以表达的字
 - `store` 与状态复用策略；
 - `context_management` 和 native compaction threshold。
 
-Tact 不应把 Responses 专有字段错误地映射为 Chat Completions 字段；无法表达的字段必须在配置或请求边界给出明确错误。
+当前 `CreateMessageParams` 主要是 Anthropic/Chat Completions 形状，因此不能假设它已经能表达这些字段。实现需要增加一个明确的 `ResponsesRequestOptions` 请求扩展（或等价的 typed/raw boundary），由 Responses adapter 消费；非 Responses adapter 必须忽略或拒绝该扩展，不能把 Responses 字段误映射到 Chat Completions。无法表达的字段必须在配置或请求边界给出明确错误。
 
 ### 2. 输入和输出转换
 
@@ -64,7 +64,7 @@ Tact 不应把 Responses 专有字段错误地映射为 Chat Completions 字段�
 - output message、annotations 和可见文本；
 - response status、incomplete details、usage 和 stop reason。
 
-协议状态与用户可见内容必须分离：
+协议状态与用户可见内容必须分离。由于 typed `Response` 在遇到未知 output item 时可能在反序列化阶段直接失败，raw envelope 解析必须先于 typed normalization：先按 `type` 解析事件/响应外壳，再将已知 item 交给强类型转换，未知 item 保留为原始 JSON。terminal output 的顺序和 state update 必须基于这组 raw item 保持。
 
 - compaction item 不得变成普通 `ContentBlock`；
 - hosted tool call 不得变成本地 `ToolUse`；
@@ -101,11 +101,14 @@ Hosted Tools 与本地 function tools 使用不同的数据流：
 - 本地 function tool：Tact 调度并执行，使用现有 `ToolUse` / `ToolResult` 流程。
 - Hosted Tool：OpenAI 执行，Tact 只记录、展示和保存其生命周期，不进入本地 tool dispatcher。
 
-分阶段支持：
+分阶段支持，并为每个官方 tool family 建立 capability matrix：
 
 1. `web_search`：请求声明、output item 生命周期、查询、来源和失败信息。
 2. `file_search`：请求声明、搜索结果、引用和详情展示。
-3. `computer` / `computer_use_preview`：先完成协议解析和明确的 capability gate；只有建立权限确认、截图/坐标输入和动作安全边界后，才允许执行。
+3. `code_interpreter`、`image_generation`、`local_shell`、shell、`custom`、namespace、apply_patch、tool search 和 remote MCP 相关 item：先完成 raw/typed 协议解析和 capability gate，再分别决定是否能映射到 Tact 的执行与展示模型；web search 的 preview/versioned tool names 也必须纳入同一矩阵。
+4. `computer` / `computer_use_preview`：先完成协议解析和明确的 capability gate；只有建立权限确认、截图/坐标输入和动作安全边界后，才允许执行。
+
+每个 tool family 必须明确标注为“已支持执行”“仅 provider 执行并展示”“仅解析并拒绝执行”或“未实现且显式报错”，不能以一个笼统的 `hosted_tools` 布尔值代替。
 
 Hosted Tool 的未知字段和原始 action/result 必须保存在 raw JSON 中。TUI 应复用统一 ToolWidget/Step 生命周期，而不是为每种 hosted tool 建立独立渲染分支。
 
@@ -246,7 +249,7 @@ env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact agent::tests::r
 2. 未知事件不破坏普通响应，未知 item 可 state round-trip。
 3. function tool 多轮、reasoning、图片、refusal、usage 和失败恢复有测试。
 4. native compact、session restore 和 SQLite 原子持久化有测试。
-5. web_search 和 file_search 的 hosted 生命周期与 TUI 展示有测试。
+5. 每个官方 Responses tool family 都有 capability matrix；已支持的 family 有请求、流式、失败和 TUI 测试，未支持的 family 有明确 gate/错误测试。
 6. provider capability 与配置错误信息准确，不支持能力不会静默降级。
 7. 双语文档和配置示例与实际行为一致。
 8. `cargo fmt --check`、目标 crate 测试和 workspace clippy 串行通过。

--- a/docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
+++ b/docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md
@@ -1,0 +1,255 @@
+# OpenAI Responses 完整适配设计
+
+## 目标
+
+在 Tact 现有 Responses adapter 基础上，尽可能完整覆盖当前 OpenAI Responses API，同时为未来新增的 SSE 事件、output item、tool 字段和响应元数据提供前向兼容能力。
+
+目标不是把任意 OpenAI-compatible 服务都宣称为完整兼容，而是让 OpenAI 官方 Responses endpoint 的核心能力、Hosted Tools、状态持久化和压缩链路具备清晰的能力边界与可验证行为。
+
+## 设计选择
+
+采用“强类型核心 + 原始 JSON 扩展层”：
+
+- 已知且参与 Tact 控制流的 Responses 对象使用 `async-openai-responses` 类型和 Rust 枚举。
+- 未知但属于协议状态的 item 使用原始 JSON 保留，并在下一次请求中原样透传。
+- 未知且不影响状态的 SSE 事件记录诊断信息后忽略，不阻断普通响应。
+- Hosted Tools 转换为 Tact 内部的 hosted-tool 生命周期表示，不伪装成本地 function tool。
+- 依赖 crate 尚未覆盖的已知字段通过 JSON request patch 补齐，而不为每个字段创建重复的本地类型。
+
+该方案避免完全绑定第三方 crate 的版本更新，也避免由 Tact 自己重写整个 Responses 类型系统。
+
+## 当前代码边界
+
+主要实现位于：
+
+- `crates/tact_llm/src/openai/responses/mod.rs`：Responses client、普通请求、流式请求和 native compact。
+- `crates/tact_llm/src/openai/responses/convert.rs`：Tact 消息到 Responses input 的转换。
+- `crates/tact_llm/src/openai/responses/normalize.rs`：terminal response 到 Tact 内容和 provider state 的转换。
+- `crates/tact_llm/src/openai/responses/stream.rs`：SSE 事件状态机。
+- `crates/tact_llm/src/openai/responses/history.rs`：reasoning 历史和 function-call item id 状态。
+- `crates/tact_llm/src/provider_state.rs`：Responses provider state 的版本化持久化模型。
+- `crates/tact/src/agent/mod.rs`：Responses state 恢复、自动压缩和 native compact 路由。
+- `crates/tact/src/store/session_store/sqlite.rs`：Responses state 和调用记录持久化。
+- `crates/tact/src/config/resolve.rs`、`crates/tact_llm/src/provider.rs`：provider/protocol 能力入口。
+
+## 功能范围
+
+### 1. 请求能力
+
+Responses request builder 需要覆盖 Tact 运行时拥有或明确暴露的 Responses-specific 请求字段：
+
+- `model`；
+- `input`，包括 message、image、reasoning、function call 和 function call output；
+- `instructions`；
+- `tools`、`tool_choice`、`parallel_tool_calls`；
+- `reasoning`、`reasoning.effort`、`reasoning.summary` 和 encrypted reasoning include；
+- `text` response format 相关字段；
+- `temperature`、`top_p`、`max_output_tokens`；
+- `truncation`；
+- `metadata`、`user`、`prompt_cache_key`；
+- `store` 与状态复用策略；
+- `context_management` 和 native compaction threshold。
+
+当前 `CreateMessageParams` 主要是 Anthropic/Chat Completions 形状，因此不能假设它已经能表达这些字段。实现需要增加一个明确的 `ResponsesRequestOptions` 请求扩展（或等价的 typed/raw boundary），由 Responses adapter 消费；非 Responses adapter 必须忽略或拒绝该扩展，不能把 Responses 字段误映射到 Chat Completions。无法表达的字段必须在配置或请求边界给出明确错误。
+
+### 2. 输入和输出转换
+
+已知核心对象使用强类型转换：
+
+- 文本 message 和多段 message content；
+- 图片输入；
+- reasoning summary、encrypted reasoning content 和历史关联信息；
+- refusal；
+- function call 与 function call output；
+- output message、annotations 和可见文本；
+- response status、incomplete details、usage 和 stop reason。
+
+协议状态与用户可见内容必须分离。由于 typed `Response` 在遇到未知 output item 时可能在反序列化阶段直接失败，raw envelope 解析必须先于 typed normalization：先按 `type` 解析事件/响应外壳，再将已知 item 交给强类型转换，未知 item 保留为原始 JSON。terminal output 的顺序和 state update 必须基于这组 raw item 保持。
+
+- compaction item 不得变成普通 `ContentBlock`；
+- hosted tool call 不得变成本地 `ToolUse`；
+- 未知 item 必须保留 raw JSON；
+- 无法安全转换的已知 item 不得静默丢弃。
+
+### 3. 流式事件
+
+流式状态机覆盖核心生命周期：
+
+- response created / in-progress / completed / incomplete / failed；
+- output item added / done；
+- output text delta / done；
+- reasoning summary delta / done；
+- reasoning text delta / done；
+- refusal delta；
+- function call arguments delta / done；
+- hosted tool added / done；
+- error。
+
+处理规则：
+
+- 已知且影响输出或状态的事件必须严格校验顺序和完整性。
+- 未知且不影响状态的事件记录诊断信息后继续。
+- 未知 output item 必须进入 terminal output/state 的 raw item 序列。
+- 已声明但未完成的 compaction item 必须失败，不能使用可见文本恢复绕过它。
+- 重复的 added/done 事件应幂等处理，不能重复追加 assistant tool item。
+- 流结束时没有 terminal event 必须返回协议错误。
+
+### 4. Hosted Tools
+
+Hosted Tools 与本地 function tools 使用不同的数据流：
+
+- 本地 function tool：Tact 调度并执行，使用现有 `ToolUse` / `ToolResult` 流程。
+- Hosted Tool：OpenAI 执行，Tact 只记录、展示和保存其生命周期，不进入本地 tool dispatcher。
+
+分阶段支持，并为每个官方 tool family 建立 capability matrix：
+
+1. `web_search`：请求声明、output item 生命周期、查询、来源和失败信息。
+2. `file_search`：请求声明、搜索结果、引用和详情展示。
+3. `code_interpreter`、`image_generation`、`local_shell`、shell、`custom`、namespace、apply_patch、tool search 和 remote MCP 相关 item：先完成 raw/typed 协议解析和 capability gate，再分别决定是否能映射到 Tact 的执行与展示模型；web search 的 preview/versioned tool names 也必须纳入同一矩阵。
+4. `computer` / `computer_use_preview`：先完成协议解析和明确的 capability gate；只有建立权限确认、截图/坐标输入和动作安全边界后，才允许执行。
+
+每个 tool family 必须明确标注为“已支持执行”“仅 provider 执行并展示”“仅解析并拒绝执行”或“未实现且显式报错”，不能以一个笼统的 `hosted_tools` 布尔值代替。
+
+Hosted Tool 的未知字段和原始 action/result 必须保存在 raw JSON 中。TUI 应复用统一 ToolWidget/Step 生命周期，而不是为每种 hosted tool 建立独立渲染分支。
+
+### 5. Provider state 和 session 恢复
+
+Responses state 继续使用版本化模型：
+
+- 保存 provider、base URL、model、input baseline、compaction id；
+- 保存 logical message count 和 context hash；
+- 保存未知 input/output item 的 raw JSON；
+- state schema 变更必须增加版本和迁移路径；
+- provider/base URL 不匹配时拒绝复用；
+- model 变化允许继续尝试，但 provider 可以在请求时拒绝不兼容的 opaque state；
+- state 和逻辑消息必须原子持久化，不能只更新其中一侧。
+
+未知 item 必须满足 state round-trip：读取旧 session 后再次生成请求时，未知 item 的协议语义不能丢失或被转换成文本。
+
+### 6. Compaction 和恢复
+
+- OpenAI Responses 使用 `/responses/compact`，不退回本地 summary。
+- 普通 Responses 请求可发送 `context_management` compact threshold。
+- native compact 的输入必须是当前 protocol baseline 加上尚未覆盖的 logical message suffix。
+- compact 返回的 resource 必须包含且只包含一个有效 compaction item。
+- compact 成功后先持久化 usage、state 和逻辑上下文，再提交 runtime counters。
+- 传输错误有限重试；协议错误不重试。
+- provider 不支持 compact 时必须通过 capability/configuration 明确失败，而不是在运行中表现为普通 summary compact。
+
+### 7. Provider capability
+
+Responses 能力不再只由 `protocol = "responses"` 一个布尔值隐含表达。需要逐步显式表示至少这些 capability：
+
+- `responses`；
+- `responses_streaming`；
+- `responses_compact`；
+- `responses_hosted_web_search`；
+- `responses_hosted_file_search`；
+- `responses_computer`。
+
+OpenAI 官方 provider 默认开启其已实现能力。自定义 OpenAI-compatible provider 必须通过配置或能力探测声明支持范围。DeepSeek/Kimi 只有在 endpoint 真实通过对应 wire/fixture/live 验证后才能解除当前配置阻断。
+
+## 错误处理和安全边界
+
+- 解析错误必须包含 event/item 类型和必要上下文，但不能打印 API key、encrypted content 或完整敏感输入。
+- 未知事件不能被当作成功状态。
+- 未知 item 可以保留，但如果无法判断它是否影响 state baseline 完整性，必须停止提交新 state。
+- Hosted Tool 的 provider 执行结果不能触发本地命令执行。
+- `computer` 相关动作在没有明确权限和确认协议前只能报告“不支持执行”，不能猜测执行。
+- 所有 async channel 等待必须有超时；测试不得使用无界 `recv().await`。
+
+## 测试策略
+
+### 单元测试
+
+覆盖：
+
+- request builder 的每个关键字段和 JSON patch；
+- message/image/reasoning/tool 转换；
+- stop reason 和 incomplete reason；
+- 未知 item raw JSON 保留；
+- 未知 event 忽略或拒绝规则；
+- 重复/缺失 output item 事件；
+- compaction item 校验；
+- provider state hash、版本和 round-trip。
+
+### WireMock 集成测试
+
+覆盖：
+
+- 普通 `/responses` streaming；
+- function call 多轮往返；
+- hosted tool lifecycle；
+- `/responses/compact` 成功、malformed resource、传输重试和持久化失败；
+- session restore 后的 baseline 复用；
+- model change 后 state 绑定行为。
+
+测试执行时必须清除代理环境，避免本地 WireMock 请求被代理：
+
+```bash
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact_llm responses
+env -u http_proxy -u https_proxy -u all_proxy cargo test -p tact agent::tests::responses
+```
+
+### Fixture/live 验证
+
+- 使用官方 Responses SSE/JSON fixture 作为稳定回归集。
+- 对 OpenAI 官方 endpoint 增加显式 `#[ignore]` live tests，覆盖 text、reasoning、function tool、web search、compact。
+- live tests 不作为普通 CI 的唯一正确性依据。
+
+## 文档同步
+
+行为变化必须同步：
+
+- `config.example.toml`；
+- `docs/compaction.md`；
+- `book/05_chapter_compact.md`；
+- `book/05_chapter_compact_zh.md`；
+- `book/26_chapter_issue.md`；
+- `book/26_chapter_issue_zh.md`；
+- Responses/API 相关章节和配置说明。
+
+双语章节需保持相同章节结构、表格和流程图语义。
+
+## 分阶段交付
+
+### 阶段 1：协议基础和 raw 扩展层
+
+建立 typed core/raw extension 边界，补齐 request builder、未知事件/item 保存和 state round-trip。完成后不新增 hosted tool，但现有 text/reasoning/function/compact 行为不能回归。
+
+### 阶段 2：核心 Responses 完整化
+
+补齐输入/输出 content 类型、reasoning、refusal、annotations、usage、incomplete/failed/cancelled、function call streaming 和错误恢复。
+
+### 阶段 3：Hosted Tools
+
+先实现 web search，再实现 file search；统一 Step/ToolWidget 生命周期。computer tool 只在权限和执行模型设计完成后开放。
+
+### 阶段 4：能力声明和 provider 解锁
+
+增加 capability 表达，修正 OpenAI/custom provider 路由，并针对 DeepSeek/Kimi 分别进行 endpoint 验证；未验证通过的 provider 保持配置阻断。
+
+### 阶段 5：文档、live 验证和发布验收
+
+完成 fixture/live matrix、双语文档、issue log、migration 说明和完整串行验证。
+
+## 非目标
+
+- 不把所有 provider 的专有协议统一成一个无损的万能抽象。
+- 不在没有权限模型的情况下执行 computer action。
+- 不为每个未知 OpenAI 字段创建本地强类型。
+- 不用本地 summary 静默替代官方 Responses native compact。
+- 不承诺所有第三方 OpenAI-compatible endpoint 支持官方全部 Hosted Tools。
+
+## 完成标准
+
+只有同时满足以下条件，才称为“核心 Responses 完整”：
+
+1. OpenAI 官方核心 request/response/stream fixture 全部通过。
+2. 未知事件不破坏普通响应，未知 item 可 state round-trip。
+3. function tool 多轮、reasoning、图片、refusal、usage 和失败恢复有测试。
+4. native compact、session restore 和 SQLite 原子持久化有测试。
+5. 每个官方 Responses tool family 都有 capability matrix；已支持的 family 有请求、流式、失败和 TUI 测试，未支持的 family 有明确 gate/错误测试。
+6. provider capability 与配置错误信息准确，不支持能力不会静默降级。
+7. 双语文档和配置示例与实际行为一致。
+8. `cargo fmt --check`、目标 crate 测试和 workspace clippy 串行通过。


### PR DESCRIPTION
## Summary

Two feature lines plus supporting hardening, 30 commits ahead of `main`.

### 1. Mermaid diagrams in the TUI main area
- Render complete top-level `mermaid` fenced blocks as themed terminal diagrams in the main render path, with fallback to the existing code-card renderer for unclosed/streamed/invalid fences.
- New local sequence-diagram renderer (`render/mermaid_sequence.rs`) that correctly handles CJK labels, `+`/`-` activation shorthand, self-loops, and label placement; other diagram types go through `ratatui-markdown`.
- Streamed Mermaid fences track fence marker/run length so valid completed diagrams don't become code overlays.
- Double-click a rendered diagram opens a popup with the raw Mermaid source (copy affordances).

### 2. Complete OpenAI Responses support
- Tact-owned raw JSON wire boundary before typed deserialization (`responses/wire.rs`) preserving unknown protocol data.
- Explicit `ResponsesRequestOptions` for fields not present in the shared Chat/Anthropic request model.
- Tolerant handling of unknown event stream lines and unknown output items (fixtures included).
- Responses capabilities model and state model updates.

### 3. Supporting changes
- Allow custom OpenAI-compatible provider names in config; subagent provider used in model picker.
- Thinking effort and budget are mutually exclusive in config/status bar; all Luna reasoning effort tiers exposed.
- Account polling additions in `tact_llm` / `tact-ui`; recovery backoff/retry messages surface underlying errors.
- Bilingual book chapters (`05`, `06`, `21`, `22`, `23`, `26`) and design/plan docs updated in the same change.

## Tests
- `cargo test -p tui` — 536 passed.
- `cargo fmt --check` and `cargo clippy -p tui --lib` clean.

## Docs
- `docs/superpowers/plans/2026-08-08-mermaid-main-rendering.md`
- `docs/superpowers/plans/2026-08-08-responses-compatibility-foundation.md`
- `docs/superpowers/specs/2026-08-08-mermaid-main-rendering-design.md`
- `docs/superpowers/specs/2026-08-08-openai-responses-complete-design.md`
