### PR TITLE
fix: plugin install, task-stats i18n, TUI fixes; bump to v1.1.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "tact-ui"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "tact_llm"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -5215,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "tool_refactor_macros"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.19"
+version = "1.1.20"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/language-Rust-orange?style=flat-square&logo=rust" alt="Rust" />
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License" />
-  <img src="https://img.shields.io/badge/version-1.0.10-blue?style=flat-square" alt="Version" />
+  <img src="https://img.shields.io/badge/version-1.1.20-blue?style=flat-square" alt="Version" />
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20WSL-lightgrey?style=flat-square" alt="Platform" />
 </p>
 
@@ -120,8 +120,8 @@ cargo install --path crates/tact-ui   # or: cargo install -p tact-ui from the re
 **Binary releases:** push a version tag to publish pre-built binaries for Linux (x86_64 / ARM64), macOS (x86_64 / ARM64), and Windows (x86_64):
 
 ```bash
-git tag v1.0.10
-git push origin v1.0.10
+git tag v1.1.20
+git push origin v1.1.20
 ```
 
 GitHub Actions (`.github/workflows/release.yml`) uploads `tact-ui-v<version>-<target-triple>.tar.gz` / `.zip` plus `SHA256SUMS`.

--- a/book/23_chapter_tui.md
+++ b/book/23_chapter_tui.md
@@ -75,7 +75,7 @@ pub enum UserCommand {
 
 | Command | Source | Handler in `tui.rs` |
 |---------|--------|---------------------|
-| **`SubmitTask`** | Enter in insert mode, slash commands, `@` file picker submit | Reset `tool_use_counter`, clear `cancel_flag`, `build_user_message`, `agent_loop`; emit `TaskComplete` only if loop succeeds and was not cancelled |
+| **`SubmitTask`** | Enter in insert mode, slash commands, `@` file picker submit — **while `Planning`/`Executing` the Enter instead queues the message** (Codex-style "submit after the current task", see §6.6) | Reset `tool_use_counter`, clear `cancel_flag`, `build_user_message`, `agent_loop`; emit `TaskComplete` only if loop succeeds and was not cancelled |
 | **`Cancel`** | `/cancel`, or Normal-mode `c` while `Planning` / `Executing` | Set `cancel_flag`; loop exits at next check; next `SubmitTask` clears the flag ([Ch 18](./18_chapter_agent_loop.md)) |
 | **`Compact`** | `/compact` (idle only) | `agent.compact_history(None)` → native `/responses/compact` for Responses providers, local summarizer otherwise ([Ch 5](./05_chapter_compact.md)) |
 | **`QueryBalance`** | `/balance` (DeepSeek/Kimi only) | `account::query_once()` → `AccountUpdate` channel ([Ch 25](./25_chapter_protocol.md)) |
@@ -245,7 +245,7 @@ Vertical constraints in `lib.rs`:
 
 - Top bar: fixed 1 row.
 - Main area: `Constraint::Min(3)`.
-- Input height: `min(display rows, 3) + 2` for border — display rows count soft-wrapped rows, not just explicit `\n` splits (long lines wrap inside the box).
+- Input height: `min(display rows, 3) + 2` for border — display rows count soft-wrapped rows, not just explicit `\n` splits (long lines wrap inside the box). While queued messages are pending, add `pending_display_lines()` (hint row + one row per queued message, capped at 4) on top.
 - Bottom height: always 2 rows (account balance/quota appends to row 1, not a third row).
 
 Popups are drawn **after** the base layout so they paint on top. Most use `Clear` first (no drop shadow — avoids dark bands on some terminals).
@@ -337,6 +337,8 @@ pub(crate) trait Renderable {
 - Row 2: model name, `max_out_token` (the effective text-output budget: `max_tokens` minus the reasoning share for effort-semantic models — e.g. `max_out_token 73K` at `high` effort on a 128K envelope — while budget-semantic models keep the full `max_tokens` since their thinking envelope is separate), `think high`/`思考 high` (effort) or `think 32K`/`思考 32K` (budget; the two are mutually exclusive — a stale budget is never shown next to an effort), `ctx` meter with `■`/`·` fill, `∑ₜₒₖ` last-call total, `▣ cache%`/`缓存%`. Segments joined with two spaces. Narrow terminals drop cache → uptime → path → ∑ → ctx first.
 
 **Input** (`render_input_box`): rounded border in `Insert` mode; up to 3 content rows; long lines soft-wrap at character boundaries (`wrap_line`, CJK double-width aware — `Paragraph` stays unwrapped and draws exactly those rows) and the caret/scroll follow the wrapped rows (`caret_in_wrapped`); CJK-aware cursor width; approval banner when `WaitingForUser`. Palette mode uses `render_command_line`. When `[voice].enabled = true`, a **centered** title-bar button (separate `Block` title from the left input label, so the top border stays visible between them) records microphone audio (macOS permission required), sends WAV to the configured transcription service, and inserts the returned text at the cursor (`Esc` cancels). Optional `[voice].voice_keybind` toggles the same control from the keyboard; only an exact match is consumed. See [Ch 21](./21_chapter_config.md) and `crates/tact/src/voice/`.
+
+**Queued messages while busy** (Codex-style "submit after the current task", since 2026-08-16): pressing Enter while the agent is `Planning`/`Executing` no longer flashes a "busy" message — the text is queued in `App.pending_messages` (input is cleared, the hint "Message will be submitted after the current task (esc to interrupt and send immediately)" plus one `↳ message` row per queued message render **above** the input box). The queue is flushed automatically when the agent reaches `Idle`/`Done` (`handlers::skills::flush_pending_when_idle`, called from the main loop after the `agent_rx` drain): every queued message is dispatched as its own `SubmitTask`, in order — the command driver (`tact-ui/src/driver.rs`) already serializes in-flight `SubmitTask`s, so each queued message becomes the next user turn. **Esc is untouched** — it always exits insert mode, queue intact (it never interrupts a running task). There is **no "send now" action**: queued messages are purely automatic — they are submitted when the current task finishes. The **only** way to drop queued messages is the clickable **`[Cancel]` button** on the pending block's hint row (mouse; hidden on narrow terminals): it clears the queue without touching the running task. `/cancel` (and Normal-mode `c`) is unrelated to the queue — it only cancels the in-flight task (Idle/Done → noop flash), exactly as before this feature; a task ended by `/cancel` still flushes the queue like any other task end. Char-limit validation runs at queue time, so oversized messages are rejected before they are queued. Pending state lives in `widgets/state/app/pending.rs`; the pending block paints its own background (no shadow residue, see Ch 26 2026-08-16 entry).
 
 ### 6.7 Markdown
 

--- a/book/23_chapter_tui_zh.md
+++ b/book/23_chapter_tui_zh.md
@@ -76,7 +76,7 @@ pub enum UserCommand {
 
 | 命令 | 来源 | `tui.rs` 中 handler |
 |------|------|---------------------|
-| **`SubmitTask`** | Insert 模式 Enter、slash 命令、`@` 文件选择器提交 | 重置 `tool_use_counter`、清除 `cancel_flag`、`build_user_message`、`agent_loop`；仅 loop 成功且未取消时发出 `TaskComplete` |
+| **`SubmitTask`** | Insert 模式 Enter、slash 命令、`@` 文件选择器提交 —— **Planning/Executing 期间 Enter 改为排队**（Codex 风格"当前任务结束后提交"，见 §6.6） | 重置 `tool_use_counter`、清除 `cancel_flag`、`build_user_message`、`agent_loop`；仅 loop 成功且未取消时发出 `TaskComplete` |
 | **`Cancel`** | `/cancel`，或 Planning/Executing 时 Normal 模式 `c` | 设置 `cancel_flag`；循环在下次检查时退出；下次 `SubmitTask` 清除 flag（[Ch 18](./18_chapter_agent_loop.md)） |
 | **`Compact`** | `/compact`（仅 idle 时） | `agent.compact_history(None)` → Responses provider 走原生 `/responses/compact`，其余 provider 走本地摘要（[Ch 5](./05_chapter_compact_zh.md)） |
 | **`QueryBalance`** | `/balance`（仅 DeepSeek/Kimi） | `account::query_once()` → `AccountUpdate` channel（[Ch 25](./25_chapter_protocol_zh.md)） |
@@ -242,7 +242,7 @@ flowchart TB
 
 - 顶栏：固定 1 行。
 - 主区域：`Constraint::Min(3)`。
-- 输入高度：`min(显示行, 3) + 2`（含 border）——显示行按软换行后的行数计，不只统计显式 `\n`（长行在框内折行）。
+- 输入高度：`min(显示行, 3) + 2`（含 border）——显示行按软换行后的行数计，不只统计显式 `\n`（长行在框内折行）。有待提交的排队消息时，再叠加 `pending_display_lines()`（提示行 + 每条排队消息一行，上限 4 行）。
 - 底栏高度：始终 2 行（账户余额/配额追加到第 2 行，非第三行）。
 
 Popups 在基础布局**之后**绘制以置顶。多数先用 `Clear`（无 drop shadow — 避免部分终端暗带）。
@@ -334,6 +334,8 @@ scroll 后 cell 仅部分可见时 `LogColumnRenderer` 调用 `render_partial` �
 - 第 2 行：模型名、`max_out_token`（真正留给输出的额度：effort 语义模型从 `max_tokens` 中扣除 reasoning 份额——如 128K 信封 + `high` effort 显示 `max_out_token 73K`；budget 语义模型的 thinking 走独立信封，因此仍显示完整 `max_tokens`）、`think high`/`思考 high`（effort）或 `think 32K`/`思考 32K`（预算；两者互斥——effort 存在时绝不显示残留的旧预算）、带 `■`/`·` 填充的 `ctx` 进度、`∑ₜₒₖ` 上次调用合计、`▣ 缓存%`/`cache%`。段落用两个空格连接。窄终端优先丢弃：缓存 → 运行 → 路径 → ∑ → ctx。
 
 **输入**（`render_input_box`）：`Insert` 模式圆角 border；最多 3 行内容；长行按字符边界软换行（`wrap_line`，CJK 双宽感知——`Paragraph` 保持不换行、逐行绘制这些切分），光标与滚动跟随折行行（`caret_in_wrapped`）；CJK 感知光标宽度；`WaitingForUser` 时批准横幅。Palette 模式用 `render_command_line`。当 `[voice].enabled = true` 时，标题栏**居中**按钮（与左侧 Input 标题拆成两个 `Block` title，中间顶边保持可见）可录制麦克风（macOS 需授权），将 WAV 发往配置的转写服务，并把文本插入光标处（`Esc` 可取消）。可选 `[voice].voice_keybind` 用键盘切换同一控件；仅精确匹配时消费按键。见 [第 21 章](./21_chapter_config_zh.md) 与 `crates/tact/src/voice/`。
+
+**忙时排队消息**（Codex 风格"当前任务结束后提交"，2026-08-16 起）：agent 处于 `Planning`/`Executing` 时按 Enter 不再弹"busy"提示——文本进入 `App.pending_messages` 队列（输入框清空，提示"消息将在当前任务结束后自动提交（按 esc 立即中断并发送）"及每条排队消息一行 `↳ 消息` **渲染在输入框上方**）。队列在 agent 进入 `Idle`/`Done` 时自动提交（`handlers::skills::flush_pending_when_idle`，主循环在 `agent_rx` 排空后调用）：每条排队消息按序各自派发为一个 `SubmitTask`——命令驱动（`tact-ui/src/driver.rs`）本就会串行处理在途的 `SubmitTask`，因此每条排队消息都成为下一个用户回合。**Esc 保持原语义不变**——始终退出插入模式、队列保留（绝不中断运行中的任务）。**没有"立即发送"操作**：排队消息纯自动——当前任务结束后自动提交。丢弃排队消息的**唯一**途径是 pending 提示行上的可点击 **`[Cancel]` 按钮**（鼠标；窄终端隐藏）：只清空队列、不影响运行中的任务。`/cancel`（及 Normal 模式 `c`）与队列无关——只取消在途任务（Idle/Done 时 noop 提示），与功能引入前完全一致；被 `/cancel` 结束的任务同样会触发排队消息的自动提交（与任务自然结束相同）。字符长度校验在入队时执行，超长消息不会进入队列。排队状态位于 `widgets/state/app/pending.rs`；排队块自行绘制背景（无残影，见 Ch 26 2026-08-16 条目）。
 
 ### 6.7 Markdown
 

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,23 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-16 — `/stats` responds immediately via a shared stats snapshot (no longer awaits the running task)
+
+| Field | Value |
+|-------|-------|
+| **Type** | optimization |
+| **Related** | Ch 25; `crates/tact/src/stats.rs`, `crates/tact/src/agent/mod.rs`, `crates/tact/src/agent/tool_dispatch.rs`, `crates/tact/src/hook/rtk_filter.rs`, `crates/tact-ui/src/driver.rs` |
+
+**Symptom / motivation:** `UserCommand::QueryStats` fell into the command driver's `other =>` branch, which awaits the in-flight `SubmitTask` handle before touching the `Agent` (the Agent is exclusively owned by the running task). During a long task, `/stats` appeared to do nothing until the task finished — sometimes minutes.
+
+**Decision:** Make the stats shared instead of Agent-exclusive: `AgentRuntime.stats` is now `Arc<RwLock<SessionStats>>` (std lock; all update sites use `write().unwrap()`, rtk atomic counters unchanged). The command loop clones the Arc before entering the receive loop, `QueryStats` became its own match arm that reads `stats.read().unwrap().summary()` and emits `SessionStats` via the pre-cloned `ui_tx` — no `Agent` access, no await. `headless.rs` / `interactive.rs` end-of-run summaries read through the same lock.
+
+**Behavior after:** `/stats` answers instantly even mid-run, showing a snapshot of all stats recorded so far (in-flight LLM call is not counted yet — same as before, stats are only written after each call). The Agent itself is untouched; other commands (`/compact`, `/model`, `/background`, …) still serialize behind the running task.
+
+**Pointers:** `crates/tact-ui/src/driver.rs` (`run_command_loop_with_account` QueryStats arm + `stats` clone), `crates/tact/src/stats.rs`, stats update sites in `agent/mod.rs` (main loop + compaction), `agent/tool_dispatch.rs` (tool counters), `hook/rtk_filter.rs` (`record_rtk`); test `query_stats_responds_immediately_while_task_runs` (blocked responder + AssertionStats arrives before release).
+
+---
+
 ## 1. 2026-08-16 — Codex-style queued messages while the agent is busy (submit after the current task)
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,57 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-16 — Task-stats line is localized and drops the wide 📊 icon
+
+| Field | Value |
+|-------|-------|
+| **Type** | bugfix |
+| **Related** | Ch 23; `crates/tui/src/i18n.rs`, `crates/tui/src/widgets/state/app/messages.rs`, `crates/tui/src/handlers/mouse.rs` |
+
+**Symptom / motivation:** The per-turn stats row was hardcoded as `📊 任务统计：…` (`TASK_STATS_PREFIX` in `messages.rs`), so it stayed Chinese even in English UI mode, and the wide `📊` emoji rendered too large in the log. The `[copy]` affordance was also a hardcoded English string.
+
+**Decision:** The prefix and copy button moved into the i18n `Messages` table: EN `Task stats:` / `[copy]`, ZH `任务统计：` / `[复制]`, with no emoji icons — the wide `📊` prefix and the `🧠` before the model name were both removed. The copy affordance renders **before** the stats body; only clicks inside the button glyphs trigger the copy (the rest of the row text-selects normally). `add_task_stats_block` reads them via `self.msgs()`; `is_task_stats_line` now recognizes every supported language's prefix with an optional leading button **plus** the legacy `📊 任务统计：` rows (so `[copy]` keeps working on sessions persisted before this change); the mouse handler finds the localized button's byte range via `find_task_stats_copy_button`.
+
+**Behavior after:** The stats row renders as `[copy]  Task stats:⏱ mm:ss · model · N tokens …` in English and `[复制]  任务统计：⏱ mm:ss · model · N tokens …` in Chinese, with no wide emoji prefix or model icon. Old sessions' stats rows remain copyable.
+
+**Pointers:** `crates/tui/src/i18n.rs` (`task_stats_prefix`, `task_stats_copy_btn`), `crates/tui/src/widgets/state/app/messages.rs` (`is_task_stats_line`, `find_task_stats_copy_button`, `add_task_stats_block`), `crates/tui/src/handlers/mouse.rs`; tests `task_stats_block_localizes_prefix_and_copy_button`, `task_stats_line_detection_covers_all_languages_and_legacy_rows`.
+
+---
+
+## 1. 2026-08-16 — `install.sh` no longer errors on `tmp: unbound variable` or leaks the clone dir
+
+| Field | Value |
+|-------|-------|
+| **Type** | bugfix |
+| **Related** | `scripts/install.sh` |
+
+**Symptom / motivation:** Under `set -u`, the installer printed `bash: line 351: tmp: unbound variable` after a successful release install. `try_install_release` set `trap 'rm -rf "$tmp"' RETURN` on a `local tmp`; the RETURN trap is inherited and fires again when the caller `main` returns, where `tmp` is out of scope, so the unguarded `$tmp` expansion aborted with `nounset`. Separately, `main` declared `work` as a `local` and cleaned it with an `EXIT` trap; that trap fires at script exit after `main`'s locals are gone, so `${work:-}` always saw an empty value and the `git clone` directory leaked on the from-source / non-repo path.
+
+**Decision:** (1) The release tmpdir trap is now `trap '[[ -n "${tmp:-}" ]] && rm -rf "$tmp"' RETURN` — the guard makes the inherited caller-context firing a no-op while still cleaning up on `try_install_release`'s own return. (2) `work` is no longer `local`; it is a global initialized to `""` so the existing `EXIT` trap actually removes the clone directory at script exit (including the `die` / `exit 1` paths).
+
+**Behavior after:** `curl … | bash` (and `./scripts/install.sh`) finishes with `Done. Run: tact-ui --help`, exit 0, no `unbound variable` error, and both the release tmpdir and the cloned repository directory are removed.
+
+**Pointers:** `scripts/install.sh` (`try_install_release`, `main`).
+
+---
+
+## 1. 2026-08-16 — `plugin install` no longer panics and parses the official `url` plugin sources
+
+| Field | Value |
+|-------|-------|
+| **Type** | bugfix |
+| **Related** | Ch 02; `crates/tact-ui/src/main.rs`, `crates/tact/src/plugin/marketplace.rs` |
+
+**Symptom / motivation:** `tact-ui plugin install <plugin>@claude-plugins-official` failed in two ways. First, the main entrypoint's early self-upgrade check used `args.command.take()`, which consumed *any* non-`Upgrade` command and left `args.command = None`; `Plugin` (and `Headless`) then fell through to `run_interactive`, and because `plugin` commands resolve config without an LLM provider (`install_without_llm`), the interactive path panicked at `get_provider()` with "LLM provider not initialized". Second, the official `anthropics/claude-plugins-official` catalog uses a `"source": "url"` object form (150 of its 286 plugins: `url` + `sha`, some with `path`) that `PluginSource::from_catalog_value` did not understand, so the whole catalog failed to parse with "invalid marketplace source: url".
+
+**Decision:** (1) The upgrade early-return now checks with `matches!(args.command, Some(CliCommand::Upgrade { .. }))` and only `take()`s inside the matched branch, so non-upgrade commands survive to the later dispatch. (2) `from_catalog_value` treats both `git-subdir` and `url` as Git repository sources (clone `url`, optional `path`, pinned revision), preferring the `sha` pin and falling back to `ref`.
+
+**Behavior after:** `plugin install` (and `headless`) dispatch correctly; `plugin install frontend-design@claude-plugins-official` clones the official marketplace, parses all 286 entries, and installs `frontend-design` (1 skill) at its pinned revision. Plugin commands never require an LLM provider.
+
+**Pointers:** `crates/tact-ui/src/main.rs` (upgrade early-return), `crates/tact/src/plugin/marketplace.rs` (`RawPluginSource::Object.sha`, `PluginSource::from_catalog_value`); tests `parses_url_plugin_source`, `parses_url_plugin_source_with_subdirectory`, `git_source_falls_back_to_named_ref_without_a_sha`; spec `docs/superpowers/specs/2026-07-20-plugin-install-design.md`.
+
+---
+
 ## 1. 2026-08-16 — Overlay list popups stay inside the main area
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,23 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-16 — Prose/list lines with inline code no longer paint a full code-block background
+
+| Field | Value |
+|-------|-------|
+| **Type** | bugfix |
+| **Related** | Ch 23; `crates/tui/src/render/log_style.rs` |
+
+**Symptom / motivation:** `restyle_log_line_with_skills` treated ANY line whose spans contained `theme.code_block_bg()` as a fenced-code line and repainted the WHOLE line with the code background. A common Markdown list item like `- run `cargo build`` therefore rendered as a full-width highlight block; when the item wrapped, `wrap_line` re-sliced the background onto every continuation row, leaving shadow-like bands that lingered between frames (the recurring "shadow" class of bugs).
+
+**Decision:** Only lines where EVERY span carries the code background (i.e. genuine fenced-code lines emitted by `flush_code_block`) are restyled as code. Mixed prose/list lines keep their styling; the inline-code span retains its narrow background patch (the text/fg special rendering stays).
+
+**Behavior after:** List items and paragraphs containing inline code no longer render as full-width code blocks, so wrapped rows no longer show a shadow band. Fenced code blocks still get the theme code background (and the light-theme fg fix via `restyle_code_line`).
+
+**Pointers:** `crates/tui/src/render/log_style.rs` (`restyle_log_line_with_skills`, `restyle_code_line`); test `inline_code_line_keeps_narrow_patch_not_full_block_bg`; Ch 23 render pipeline.
+
+---
+
 ## 1. 2026-08-16 — Task-stats line is localized and drops the wide 📊 icon
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,40 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-16 — Codex-style queued messages while the agent is busy (submit after the current task)
+
+| Field | Value |
+|-------|-------|
+| **Type** | feature |
+| **Related** | Ch 23; `crates/tui/src/handlers/insert.rs`, `crates/tui/src/handlers/skills.rs`, `crates/tui/src/widgets/state/app/pending.rs`, `crates/tui/src/render/input.rs`, `crates/tui/src/lib.rs` |
+
+**Symptom / motivation:** While the agent was `Planning`/`Executing`, pressing Enter flashed a "⏳ Still processing previous prompt" message and dropped the typed text — a message typed during a long tool run was lost. Codex CLI instead queues it: "Messages to be submitted after next tool call (press esc to interrupt and send immediately)".
+
+**Decision:** Replace the busy-reject with a Codex-style queue. `App.pending_messages` holds `PendingMessage { display, agent_task }`; Enter during `Planning`/`Executing` clears the input and queues (char-limit validation runs at queue time). The main loop calls `handlers::skills::flush_pending_when_idle` after draining `agent_rx`: once status reaches `Idle`/`Done`, every queued message is dispatched as its own `SubmitTask` in order — the tact-ui command driver already serializes in-flight `SubmitTask`s, so each becomes the next user turn. Submission is **fully automatic** — no "send now" path exists (the `[Send now]` button and Normal-mode `s` were removed at the user's request 2026-08-16: "send now 去掉吧，自动处理即可"). The **only** way to drop queued messages is the `[Cancel]` button on the pending block (`pending_cancel_btn_area` hit test in the mouse handler) — it clears the queue without touching the running task. `/cancel` and Normal-mode `c` are **unrelated to the queue**: they cancel only the in-flight task, exactly as before (user decision: "/cancel 也不用处理 prompt 队列"). Esc is untouched (always exits insert mode — a stray Esc never interrupts a task). The hint + `↳ message` rows render above the input box (`render_pending_block` in `render/input.rs`, button hidden on narrow terminals); the layout adds `pending_display_lines()` (hint + per-message row, capped at 4) to the input height. `submit_user_task` was split into `task_within_limits` / `dispatch_user_task` so queueing and flushing share dispatch. `/compact` keeps the old busy flash (`input_busy_msg`).
+
+**Behavior after:** Messages typed while the agent is busy are queued, shown above the input box with the Codex-style hint, and auto-submitted when the current task finishes (including when the task was ended by `/cancel`); the `[Cancel]` button drops the queue only. Multiple queued messages submit sequentially as separate turns. Oversized messages are rejected at queue time. Busy-submission is never lost.
+
+**Pointers:** `handlers/insert.rs` (`handle_enter_submit`, Esc arm), `handlers/skills.rs` (`submit_user_task`, `flush_pending_when_idle`, `interrupt_and_submit_pending`), `widgets/state/app/pending.rs`, `render/input.rs` (`render_pending_block`, `truncate_to_width`); tests `submit_queued_while_agent_busy`, `esc_with_pending_interrupts_and_submits_immediately`, `flush_pending_when_idle_submits_all_queued_in_order`, `input_box_renders_pending_block_above_input`; Ch 23 §6.6.
+
+---
+
+## 1. 2026-08-16 — Inline code uses accent text instead of a background patch
+
+| Field | Value |
+|-------|-------|
+| **Type** | bugfix |
+| **Related** | Ch 23; `crates/tui/src/render/pulldown.rs`, `crates/tui/src/render/log_style.rs` |
+
+**Symptom / motivation:** The earlier fix stopped prose lines containing inline code from being repainted as full-width code blocks, but the inline-code span still carried a narrow `code_block_bg` patch. That rectangular background remained visually heavy in ordinary prose and lists, especially after wrapping.
+
+**Decision:** Render inline code with `theme.accent` as its foreground and no background. The log restyle pass applies the same rule to legacy inline-code spans, while genuine fenced-code lines continue to use `code_block_bg` and `code_block_fg`.
+
+**Behavior after:** Inline code is distinguished by accent-colored text without a rectangular background patch. Fenced code blocks retain their themed background and foreground, so code-block boundaries remain visible.
+
+**Pointers:** `crates/tui/src/render/pulldown.rs` (`push_inline_code`), `crates/tui/src/render/log_style.rs` (`restyle_log_line_with_skills`); tests `inline_code_uses_accent_without_background` in both modules; Ch 23.
+
+---
+
 ## 1. 2026-08-16 — Prose/list lines with inline code no longer paint a full code-block background
 
 | Field | Value |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,23 @@
 
 ---
 
+## 1. 2026-08-16 — 含行内代码的正文/列表行不再整行绘制代码背景块
+
+| 字段 | 内容 |
+|-------|-------|
+| **类型** | bugfix |
+| **相关** | Ch 23；`crates/tui/src/render/log_style.rs` |
+
+**现象 / 动机：** `restyle_log_line_with_skills` 只要某行的 span 里出现 `theme.code_block_bg()` 就把整行当作围栏代码行，重绘成整行代码背景。像 `- run `cargo build`` 这种常见列表项因此渲染成一整块高亮背景；当条目换行时，`wrap_line` 会把背景重新切片到每一续行，帧间残留成阴影状色带（反复出现的 "shadow" 类问题）。
+
+**决策：** 只有**每个** span 都带代码背景的行（即 `flush_code_block` 产生的真正围栏代码行）才按代码块重绘。混合正文/列表行保留原样式；行内代码 span 保留其窄背景补丁（文字/前景特殊渲染仍在）。
+
+**变更后行为：** 含行内代码的列表项与段落不再渲染成整行代码块，换行续行不再出现阴影色带。围栏代码块仍带主题代码背景（浅色主题下仍通过 `restyle_code_line` 修正前景色）。
+
+**指针：** `crates/tui/src/render/log_style.rs`（`restyle_log_line_with_skills`、`restyle_code_line`）；测试 `inline_code_line_keeps_narrow_patch_not_full_block_bg`；Ch 23 渲染管线。
+
+---
+
 ## 1. 2026-08-16 — 任务统计行支持多语言，并去掉过宽的 📊 图标
 
 | 字段 | 内容 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,40 @@
 
 ---
 
+## 1. 2026-08-16 — Codex 风格排队消息：agent 忙时提交"当前任务结束后自动提交"
+
+| Field | Value |
+|-------|-------|
+| **Type** | feature |
+| **Related** | Ch 23; `crates/tui/src/handlers/insert.rs`、`crates/tui/src/handlers/skills.rs`、`crates/tui/src/widgets/state/app/pending.rs`、`crates/tui/src/render/input.rs`、`crates/tui/src/lib.rs` |
+
+**Symptom / motivation:** agent 处于 `Planning`/`Executing` 时按 Enter 只会闪现"⏳ 上一个任务还在处理中"并丢弃输入——工具运行期间打的消息全丢了。Codex CLI 的做法是排队："Messages to be submitted after next tool call (press esc to interrupt and send immediately)"。
+
+**Decision:** 用 Codex 风格队列取代忙时拒绝。`App.pending_messages` 存放 `PendingMessage { display, agent_task }`；`Planning`/`Executing` 时按 Enter 清空输入并入队（字符长度校验在入队时执行）。主循环在排空 `agent_rx` 后调用 `handlers::skills::flush_pending_when_idle`：状态进入 `Idle`/`Done` 后，按序把每条排队消息各自派发为一个 `SubmitTask`——tact-ui 命令驱动本就会串行处理在途 `SubmitTask`，因此每条都成为下一个用户回合。提交**纯自动**——不存在"立即发送"路径（`[Send now]` 按钮与 Normal 模式 `s` 键按用户要求移除："send now 去掉吧，自动处理即可"）。丢弃排队消息的**唯一**途径是 pending 块的 `[Cancel]` 按钮（`pending_cancel_btn_area` 命中测试在 mouse handler）——只清空队列、不影响运行中的任务。`/cancel` 与 Normal 模式 `c` 与队列**无关**：只取消在途任务，与功能引入前一致（用户决定："/cancel 也不用处理 prompt 队列"）。Esc 保持原语义（始终退出插入模式——误触不会中断任务）。提示行与 `↳ 消息` 行渲染在输入框上方（`render/input.rs` 的 `render_pending_block`，窄终端隐藏按钮）；布局把 `pending_display_lines()`（提示 + 每条一行，上限 4 行）计入输入高度。`submit_user_task` 拆成 `task_within_limits` / `dispatch_user_task`，使排队与自动提交共用派发。`/compact` 仍保留旧的忙时闪现（`input_busy_msg`）。
+
+**Behavior after:** 忙时输入的消息被排队，显示在输入框上方并带 Codex 风格提示，当前任务结束后自动提交（包括被 `/cancel` 结束的任务）；`[Cancel]` 按钮只丢弃队列。多条排队消息按顺序各自成为独立回合。超长消息在入队时即被拒绝。忙时提交不再丢失。
+
+**Pointers:** `handlers/insert.rs`（`handle_enter_submit`、Esc 分支）、`handlers/skills.rs`（`submit_user_task`、`flush_pending_when_idle`、`interrupt_and_submit_pending`）、`widgets/state/app/pending.rs`、`render/input.rs`（`render_pending_block`、`truncate_to_width`）；测试 `submit_queued_while_agent_busy`、`esc_with_pending_interrupts_and_submits_immediately`、`flush_pending_when_idle_submits_all_queued_in_order`、`input_box_renders_pending_block_above_input`；Ch 23 §6.6。
+
+---
+
+## 1. 2026-08-16 — 行内代码改用强调色文字，不再绘制背景补丁
+
+| 字段 | 内容 |
+|-------|-------|
+| **类型** | bugfix |
+| **相关** | Ch 23；`crates/tui/src/render/pulldown.rs`、`crates/tui/src/render/log_style.rs` |
+
+**现象 / 动机：** 上一个修复已经阻止含行内代码的正文行被重绘成整行代码块，但行内代码 span 自身仍携带窄的 `code_block_bg` 背景补丁。这个矩形背景在普通正文和列表中仍然显得过重，换行后尤其明显。
+
+**决策：** 行内代码使用 `theme.accent` 作为前景色，不再绘制背景。日志重绘阶段对旧的行内代码背景 span 应用相同规则；真正的围栏代码行继续使用 `code_block_bg` 与 `code_block_fg`。
+
+**变更后行为：** 行内代码通过强调色文字区分，不再出现矩形背景补丁。围栏代码块仍保留主题背景和前景色，因此代码块边界仍然清晰。
+
+**指针：** `crates/tui/src/render/pulldown.rs`（`push_inline_code`）、`crates/tui/src/render/log_style.rs`（`restyle_log_line_with_skills`）；两个模块中的 `inline_code_uses_accent_without_background` 测试；Ch 23。
+
+---
+
 ## 1. 2026-08-16 — 含行内代码的正文/列表行不再整行绘制代码背景块
 
 | 字段 | 内容 |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,23 @@
 
 ---
 
+## 1. 2026-08-16 — `/stats` 通过共享 stats 快照立即响应（不再等待运行中的任务）
+
+| Field | Value |
+|-------|-------|
+| **Type** | optimization |
+| **Related** | Ch 25; `crates/tact/src/stats.rs`、`crates/tact/src/agent/mod.rs`、`crates/tact/src/agent/tool_dispatch.rs`、`crates/tact/src/hook/rtk_filter.rs`、`crates/tact-ui/src/driver.rs` |
+
+**Symptom / motivation:** `UserCommand::QueryStats` 落在命令驱动的 `other =>` 分支，该分支会先 await 在途的 `SubmitTask` handle 才能访问 `Agent`（运行中的任务独占 Agent 所有权）。长任务期间 `/stats` 看起来毫无响应，直到任务结束——有时要等好几分钟。
+
+**Decision:** 让 stats 不再归 Agent 独占：`AgentRuntime.stats` 改为 `Arc<RwLock<SessionStats>>`（std 锁；所有更新点用 `write().unwrap()`，rtk 原子计数器保持不变）。命令循环进入 receive 循环前 clone Arc，`QueryStats` 提升为独立 match 分支：直接 `stats.read().unwrap().summary()` 并通过预 clone 的 `ui_tx` 发出 `SessionStats`——不访问 `Agent`、不 await。`headless.rs` / `interactive.rs` 的结束摘要也通过同一把锁读取。
+
+**Behavior after:** `/stats` 在任务运行中也立即响应，显示截至当前已记录的全部统计快照（进行中的 LLM 调用尚未计入——与之前一致，stats 只在每次调用后写入）。Agent 本身不受影响；其他命令（`/compact`、`/model`、`/background` 等）仍与运行中的任务串行。
+
+**Pointers:** `crates/tact-ui/src/driver.rs`（`run_command_loop_with_account` 的 QueryStats 分支 + `stats` clone）、`crates/tact/src/stats.rs`、`agent/mod.rs` 的 stats 更新点（主循环 + 压缩）、`agent/tool_dispatch.rs`（工具计数）、`hook/rtk_filter.rs`（`record_rtk`）；测试 `query_stats_responds_immediately_while_task_runs`（阻塞 responder，释放前断言收到 SessionStats）。
+
+---
+
 ## 1. 2026-08-16 — Codex 风格排队消息：agent 忙时提交"当前任务结束后自动提交"
 
 | Field | Value |

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,57 @@
 
 ---
 
+## 1. 2026-08-16 — 任务统计行支持多语言，并去掉过宽的 📊 图标
+
+| 字段 | 内容 |
+|-------|-------|
+| **类型** | bugfix |
+| **相关** | Ch 23；`crates/tui/src/i18n.rs`、`crates/tui/src/widgets/state/app/messages.rs`、`crates/tui/src/handlers/mouse.rs` |
+
+**现象 / 动机：** 每轮结束的统计行被硬编码为 `📊 任务统计：…`（`messages.rs` 中的 `TASK_STATS_PREFIX`），即使 UI 切到英文模式仍是中文，且过宽的 `📊` emoji 在日志里显得太大。`[copy]` 按钮同样是一段硬编码英文。
+
+**决策：** 前缀与复制按钮移入 i18n `Messages` 表：EN `Task stats:` / `[copy]`，ZH `任务统计：` / `[复制]`，不再带 emoji 图标——过宽的 `📊` 前缀与 model 前的 `🧠` 都被移除。复制按钮渲染在**统计正文之前**，只有点击按钮字形本身才触发复制（其余位置正常做文本选择）。`add_task_stats_block` 通过 `self.msgs()` 读取；`is_task_stats_line` 现在识别所有支持语言的前缀（可带前置按钮），**并兼容旧的 `📊 任务统计：` 行**（保证旧会话里 `[copy]` 仍然可用）；鼠标处理器通过 `find_task_stats_copy_button` 定位本地化按钮的字节区间。
+
+**变更后行为：** 统计行在英文下渲染为 `[copy]  Task stats:⏱ mm:ss · model · N tokens …`，中文下为 `[复制]  任务统计：⏱ mm:ss · model · N tokens …`，前缀与 model 前都不再有宽 emoji。旧会话的统计行仍可复制。
+
+**指针：** `crates/tui/src/i18n.rs`（`task_stats_prefix`、`task_stats_copy_btn`）、`crates/tui/src/widgets/state/app/messages.rs`（`is_task_stats_line`、`find_task_stats_copy_button`、`add_task_stats_block`）、`crates/tui/src/handlers/mouse.rs`；测试 `task_stats_block_localizes_prefix_and_copy_button`、`task_stats_line_detection_covers_all_languages_and_legacy_rows`。
+
+---
+
+## 1. 2026-08-16 — `install.sh` 不再报 `tmp: unbound variable`，也不再泄漏克隆目录
+
+| 字段 | 内容 |
+|-------|-------|
+| **类型** | bugfix |
+| **相关** | `scripts/install.sh` |
+
+**现象 / 动机：** 在 `set -u` 下，成功安装 release 后安装器打印 `bash: line 351: tmp: unbound variable`。`try_install_release` 对 `local tmp` 设置了 `trap 'rm -rf "$tmp"' RETURN`；RETURN trap 会被继承，并在调用者 `main` 返回时再次触发，此时 `tmp` 已越界，未加保护的 `$tmp` 展开因 `nounset` 中断。另外，`main` 把 `work` 声明为 `local` 并用 `EXIT` trap 清理；该 trap 在脚本退出时触发，此时 `main` 的局部变量已销毁，`${work:-}` 恒为空，导致 `git clone` 目录在源码构建 / 非仓库目录路径下泄漏。
+
+**决策：** (1) release 临时目录 trap 改为 `trap '[[ -n "${tmp:-}" ]] && rm -rf "$tmp"' RETURN` —— 加保护后，继承到调用者上下文的那次触发成为 no-op，同时在 `try_install_release` 自身返回时仍能正确清理。(2) `work` 不再是 `local`，改为初始化为 `""` 的全局变量，使已有的 `EXIT` trap 能在脚本退出时真正删除克隆目录（包括 `die` / `exit 1` 路径）。
+
+**变更后行为：** `curl … | bash`（以及 `./scripts/install.sh`）以 `Done. Run: tact-ui --help`、退出码 0 收尾，无 `unbound variable` 报错，release 临时目录与克隆仓库目录均被删除。
+
+**指针：** `scripts/install.sh`（`try_install_release`、`main`）。
+
+---
+
+## 1. 2026-08-16 — `plugin install` 不再 panic，并支持官方 `url` 类型的插件源
+
+| 字段 | 内容 |
+|-------|-------|
+| **类型** | bugfix |
+| **相关** | Ch 02；`crates/tact-ui/src/main.rs`、`crates/tact/src/plugin/marketplace.rs` |
+
+**现象 / 动机：** `tact-ui plugin install <plugin>@claude-plugins-official` 以两种方式失败。其一，主入口的自更新提前返回用了 `args.command.take()`，它会把*任何*非 `Upgrade` 的命令消费掉并置 `args.command = None`；于是 `Plugin`（以及 `Headless`）落到 `run_interactive`，而 `plugin` 命令解析配置时不会初始化 LLM provider（`install_without_llm`），交互路径因此在 `get_provider()` panic：`LLM provider not initialized`。其二，官方 `anthropics/claude-plugins-official` 目录使用了 `"source": "url"` 对象形式（286 个插件中的 150 个：`url` + `sha`，部分带 `path`），而 `PluginSource::from_catalog_value` 无法识别，导致整个目录解析失败，报 `invalid marketplace source: url`。
+
+**决策：** (1) 自更新提前返回改为先 `matches!(args.command, Some(CliCommand::Upgrade { .. }))` 判断，仅在命中分支内 `take()`，非 upgrade 命令得以进入后续分发。(2) `from_catalog_value` 将 `git-subdir` 与 `url` 统一视为 Git 仓库源（克隆 `url`、可选 `path`、锁定修订），优先使用 `sha` 锁定，回退到 `ref`。
+
+**变更后行为：** `plugin install`（以及 `headless`）正确分发；`plugin install frontend-design@claude-plugins-official` 会克隆官方目录、解析全部 286 条并安装 `frontend-design`（1 个 skill），锁定到其固定修订。插件命令从不依赖 LLM provider。
+
+**指针：** `crates/tact-ui/src/main.rs`（自更新提前返回）、`crates/tact/src/plugin/marketplace.rs`（`RawPluginSource::Object.sha`、`PluginSource::from_catalog_value`）；测试 `parses_url_plugin_source`、`parses_url_plugin_source_with_subdirectory`、`git_source_falls_back_to_named_ref_without_a_sha`；spec `docs/superpowers/specs/2026-07-20-plugin-install-design.md`。
+
+---
+
 ## 1. 2026-08-16 — 覆盖式列表弹窗限定在主区域内
 
 | 字段 | 内容 |

--- a/crates/tact-ui/src/driver.rs
+++ b/crates/tact-ui/src/driver.rs
@@ -39,6 +39,9 @@ pub async fn run_command_loop_with_account(
     let image_work_dir = image_work_dir.as_ref().to_path_buf();
     let cancel_flag = agent.runtime.cancel_flag.clone();
     let ui_tx = agent.runtime.ui_tx.clone();
+    // Shared stats snapshot: QueryStats can read it without awaiting the
+    // in-flight task (the Agent itself is exclusively owned by that task).
+    let stats = agent.runtime.stats.clone();
 
     let mut agent = Some(agent);
     let mut active: Option<JoinHandle<Agent>> = None;
@@ -51,6 +54,15 @@ pub async fn run_command_loop_with_account(
                 cancel_flag.store(true, Ordering::Relaxed);
                 if let Some(tx) = &ui_tx {
                     let _ = tx.send(AgentUpdate::Info("Cancelling...".into()));
+                }
+            }
+            UserCommand::QueryStats => {
+                // Immediate snapshot: does NOT wait for the running task —
+                // stats live in an Arc<RwLock<SessionStats>> shared with the
+                // agent, so /stats responds instantly even mid-run.
+                let stats_text = stats.read().expect("session stats lock poisoned").summary();
+                if let Some(tx) = &ui_tx {
+                    let _ = tx.send(AgentUpdate::SessionStats(stats_text));
                 }
             }
             UserCommand::SubmitTask(task) => {
@@ -178,8 +190,8 @@ async fn handle_user_command_with_account(
             }
         }
         UserCommand::QueryStats => {
-            let stats_text = agent.runtime.stats.summary();
-            agent.emit_update(AgentUpdate::SessionStats(stats_text));
+            // Handled at the loop level (immediate shared-stats snapshot);
+            // reaching this arm means the caller bypassed the command loop.
         }
         UserCommand::QueryBackground(task_id) => {
             match agent
@@ -415,5 +427,64 @@ mod tests {
             }
         }
         assert!(saw_error, "QueryBackground with unknown id must emit Error");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn query_stats_responds_immediately_while_task_runs() {
+        use std::time::Duration;
+
+        install_test_config();
+        let (agent_tx, mut agent_rx) = tokio::sync::mpsc::unbounded_channel();
+        // The responder spins on an AtomicBool until the test releases it — a
+        // deterministic "long running LLM call". A serialized QueryStats
+        // (awaiting the task) would hang until the release fires.
+        let release = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let release_rx = release.clone();
+        let mock = MockClient::with_responder(move |_request, _| {
+            while !release_rx.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok((vec![text_block("done")], Some(StopReason::EndTurn), None))
+        });
+        let (agent, work_dir) = build_test_agent(mock, Some(agent_tx));
+        let (user_cmd_tx, user_cmd_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let loop_handle = tokio::spawn(super::run_command_loop(agent, user_cmd_rx, work_dir));
+
+        // Start a task that is now stuck in the responder, then ask for stats.
+        user_cmd_tx
+            .send(UserCommand::SubmitTask("long task".into()))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let start = std::time::Instant::now();
+        user_cmd_tx.send(UserCommand::QueryStats).unwrap();
+
+        // The stats snapshot must arrive while the task is still blocked.
+        let mut saw_stats = false;
+        loop {
+            match tokio::time::timeout(Duration::from_millis(300), agent_rx.recv()).await {
+                Ok(Some(AgentUpdate::SessionStats(_))) => {
+                    saw_stats = true;
+                    break;
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) | Err(_) => break,
+            }
+        }
+        assert!(
+            saw_stats,
+            "expected SessionStats while the task is still running"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(450),
+            "QueryStats must NOT await the in-flight task"
+        );
+
+        // Release the blocked task and let the loop drain.
+        release.store(true, std::sync::atomic::Ordering::Relaxed);
+        drop(user_cmd_tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), loop_handle)
+            .await
+            .expect("command loop must finish");
     }
 }

--- a/crates/tact-ui/src/driver.rs
+++ b/crates/tact-ui/src/driver.rs
@@ -142,7 +142,8 @@ async fn handle_user_command_with_account(
                 }
                 Ok(()) => {
                     // Cancelled: clear TUI busy state (Planning/Executing) so
-                    // the next prompt is not blocked behind input_busy_msg.
+                    // queued (pending) messages are flushed rather than waiting
+                    // on a stale busy state.
                     agent.emit_update(AgentUpdate::TaskCancelled);
                 }
                 Err(e) => {

--- a/crates/tact-ui/src/headless.rs
+++ b/crates/tact-ui/src/headless.rs
@@ -142,7 +142,15 @@ async fn run_headless_locked(
     agent.agent_loop(Some(prompt_message)).await?;
 
     eprintln!("[session id: {session_id}]");
-    eprintln!("{}", agent.runtime.stats.summary());
+    eprintln!(
+        "{}",
+        agent
+            .runtime
+            .stats
+            .read()
+            .expect("session stats lock poisoned")
+            .summary()
+    );
 
     if let Some(final_content) = agent.runtime.context.last() {
         let text = extract_text(&final_content.content);

--- a/crates/tact-ui/src/interactive.rs
+++ b/crates/tact-ui/src/interactive.rs
@@ -255,7 +255,15 @@ async fn run_interactive_locked(
         eprintln!("[session id: {sid}]");
     }
 
-    eprintln!("{}", agent.runtime.stats.summary());
+    eprintln!(
+        "{}",
+        agent
+            .runtime
+            .stats
+            .read()
+            .expect("session stats lock poisoned")
+            .summary()
+    );
 
     Ok(())
 }

--- a/crates/tact-ui/src/main.rs
+++ b/crates/tact-ui/src/main.rs
@@ -17,7 +17,10 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Self-upgrade does not need a session store or provider config.
-    if let Some(CliCommand::Upgrade { repo, yes, check }) = args.command.take() {
+    if matches!(args.command, Some(CliCommand::Upgrade { .. })) {
+        let Some(CliCommand::Upgrade { repo, yes, check }) = args.command.take() else {
+            unreachable!("upgrade command was just matched");
+        };
         return tact::upgrade::run_upgrade(tact::upgrade::UpgradeOptions { repo, yes, check })
             .await;
     }

--- a/crates/tact/src/agent/mod.rs
+++ b/crates/tact/src/agent/mod.rs
@@ -3,7 +3,10 @@
 mod tool_dispatch;
 pub(crate) mod tool_schedule;
 
-use std::path::Path;
+use std::{
+    path::Path,
+    sync::{Arc, RwLock},
+};
 
 use anyhow::{Context, Result};
 use chrono::Utc;
@@ -91,7 +94,7 @@ pub struct AgentRuntime {
     pub compact_state: CompactState,
     pub recovery_state: RecoveryState,
     pub permission_manager: PermissionManager,
-    pub stats: SessionStats,
+    pub stats: Arc<RwLock<SessionStats>>,
     pub ui_tx: Option<tokio::sync::mpsc::UnboundedSender<AgentUpdate>>,
     pub cancel_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub session_store: Option<DynSessionStore>,
@@ -186,7 +189,7 @@ impl Agent {
                 compact_state: CompactState::default(),
                 recovery_state: RecoveryState::default(),
                 permission_manager,
-                stats: SessionStats::default(),
+                stats: Arc::new(RwLock::new(SessionStats::default())),
                 ui_tx: None,
                 cancel_flag,
                 session_store: None,
@@ -722,11 +725,18 @@ impl Agent {
             }));
 
             // ── Stats: before LLM call ──
-            self.runtime.stats.prompt_count += 1;
             let prompt_chars = serde_json::to_string(&request)
                 .map(|s| s.chars().count() as u64)
                 .unwrap_or(0);
-            self.runtime.stats.total_prompt_chars += prompt_chars;
+            {
+                let mut stats = self
+                    .runtime
+                    .stats
+                    .write()
+                    .expect("session stats lock poisoned");
+                stats.prompt_count += 1;
+                stats.total_prompt_chars += prompt_chars;
+            }
             let llm_call_start = std::time::Instant::now();
 
             let (content, stop_reason, token_usage, request_body, state_update) = match self
@@ -778,23 +788,31 @@ impl Agent {
             };
 
             // ── Stats: after LLM call ──
-            self.runtime
-                .stats
-                .llm_call_durations
-                .push(llm_call_start.elapsed());
             let response_chars = serde_json::to_string(&content)
                 .map(|s| s.chars().count() as u64)
                 .unwrap_or(0);
-            self.runtime.stats.total_response_chars += response_chars;
-            for block in &content {
-                if let ContentBlock::Thinking { thinking, .. } = block {
-                    self.runtime.stats.thinking_blocks += 1;
-                    self.runtime.stats.total_thinking_chars += thinking.chars().count() as u64;
+            {
+                let mut stats = self
+                    .runtime
+                    .stats
+                    .write()
+                    .expect("session stats lock poisoned");
+                stats.llm_call_durations.push(llm_call_start.elapsed());
+                stats.total_response_chars += response_chars;
+                for block in &content {
+                    if let ContentBlock::Thinking { thinking, .. } = block {
+                        stats.thinking_blocks += 1;
+                        stats.total_thinking_chars += thinking.chars().count() as u64;
+                    }
                 }
             }
 
             if let Some(ref usage) = token_usage {
-                self.runtime.stats.record_token_usage(usage);
+                self.runtime
+                    .stats
+                    .write()
+                    .expect("session stats lock poisoned")
+                    .record_token_usage(usage);
                 self.runtime.last_token_total = usage.total;
             }
             self.runtime.llm_call_last_message_id = self.runtime.last_message_db_id;
@@ -1100,7 +1118,11 @@ impl Agent {
         self.runtime.llm_call_last_message_id = 0;
         self.runtime.last_token_total = 0;
         self.runtime.compact_state.has_compacted = true;
-        self.runtime.stats.compactions += 1;
+        self.runtime
+            .stats
+            .write()
+            .expect("session stats lock poisoned")
+            .compactions += 1;
 
         // Informational status only: item count and a bounded compaction id
         // prefix. Never expose the opaque encrypted content, and never echo
@@ -1249,11 +1271,19 @@ impl Agent {
             extra_body: None,
         }));
         // ── Stats: before compaction LLM call ──
-        self.runtime.stats.prompt_count += 1;
+        self.runtime
+            .stats
+            .write()
+            .expect("session stats lock poisoned")
+            .prompt_count += 1;
         let compact_prompt_chars = serde_json::to_string(&initial_request)
             .map(|s| s.chars().count() as u64)
             .unwrap_or(0);
-        self.runtime.stats.total_prompt_chars += compact_prompt_chars;
+        self.runtime
+            .stats
+            .write()
+            .expect("session stats lock poisoned")
+            .total_prompt_chars += compact_prompt_chars;
         let compact_start = std::time::Instant::now();
 
         // Summarization call with two independent recovery axes:
@@ -1331,22 +1361,30 @@ impl Agent {
         let blocks = blocks_all;
 
         // ── Stats: after compaction LLM call ──
-        self.runtime
-            .stats
-            .llm_call_durations
-            .push(compact_start.elapsed());
         let compact_response_chars = serde_json::to_string(&blocks)
             .map(|s| s.chars().count() as u64)
             .unwrap_or(0);
-        self.runtime.stats.total_response_chars += compact_response_chars;
-        for block in &blocks {
-            if let ContentBlock::Thinking { thinking, .. } = block {
-                self.runtime.stats.thinking_blocks += 1;
-                self.runtime.stats.total_thinking_chars += thinking.chars().count() as u64;
+        {
+            let mut stats = self
+                .runtime
+                .stats
+                .write()
+                .expect("session stats lock poisoned");
+            stats.llm_call_durations.push(compact_start.elapsed());
+            stats.total_response_chars += compact_response_chars;
+            for block in &blocks {
+                if let ContentBlock::Thinking { thinking, .. } = block {
+                    stats.thinking_blocks += 1;
+                    stats.total_thinking_chars += thinking.chars().count() as u64;
+                }
             }
         }
         if let Some(ref usage) = token_usage {
-            self.runtime.stats.record_token_usage(usage);
+            self.runtime
+                .stats
+                .write()
+                .expect("session stats lock poisoned")
+                .record_token_usage(usage);
             // Do NOT assign usage.total to last_token_total: that figure is for
             // the summarization request (large history prompt), not the size of
             // the replacement context below.
@@ -1470,7 +1508,11 @@ impl Agent {
         // context (via token estimate / next main-loop TokenUsage), not the
         // pre-compact or summarizer-prompt totals.
         self.runtime.last_token_total = 0;
-        self.runtime.stats.compactions += 1;
+        self.runtime
+            .stats
+            .write()
+            .expect("session stats lock poisoned")
+            .compactions += 1;
         Ok(())
     }
 
@@ -2830,7 +2872,13 @@ mod tests {
             "runtime context must remain the old committed context"
         );
         assert_eq!(
-            agent.runtime.stats.compactions, 0,
+            agent
+                .runtime
+                .stats
+                .read()
+                .expect("session stats lock poisoned")
+                .compactions,
+            0,
             "no compaction may be recorded when usage persistence failed"
         );
         assert!(

--- a/crates/tact/src/agent/tool_dispatch.rs
+++ b/crates/tact/src/agent/tool_dispatch.rs
@@ -275,6 +275,8 @@ impl Agent {
             *self
                 .runtime
                 .stats
+                .write()
+                .unwrap()
                 .tool_counts
                 .entry(name.clone())
                 .or_insert(0) += 1;
@@ -784,6 +786,8 @@ impl Agent {
                     *self
                         .runtime
                         .stats
+                        .write()
+                        .unwrap()
                         .tool_success_counts
                         .entry(prep_name.clone())
                         .or_insert(0) += 1;
@@ -791,6 +795,8 @@ impl Agent {
                     *self
                         .runtime
                         .stats
+                        .write()
+                        .unwrap()
                         .tool_failure_counts
                         .entry(prep_name.clone())
                         .or_insert(0) += 1;
@@ -798,12 +804,16 @@ impl Agent {
                 *self
                     .runtime
                     .stats
+                    .write()
+                    .unwrap()
                     .tool_total_durations_ms
                     .entry(prep_name.clone())
                     .or_insert(0) += duration_us / 1000;
                 *self
                     .runtime
                     .stats
+                    .write()
+                    .unwrap()
                     .tool_timing_counts
                     .entry(prep_name.clone())
                     .or_insert(0) += 1;
@@ -813,6 +823,8 @@ impl Agent {
             for duration_us in pending_durations_us {
                 self.runtime
                     .stats
+                    .write()
+                    .unwrap()
                     .tool_durations_ms
                     .push(duration_us / 1000);
             }

--- a/crates/tact/src/hook/rtk_filter.rs
+++ b/crates/tact/src/hook/rtk_filter.rs
@@ -122,6 +122,8 @@ pub fn create_rtk_post_tool_hook() -> impl PostToolUseFn + 'static {
             agent
                 .runtime
                 .stats
+                .write()
+                .unwrap()
                 .record_rtk(succeeded, raw_chars, saved, elapsed_ms);
             tool_result.content = filtered;
             Ok(HookControl::Continue)

--- a/crates/tact/src/plugin/marketplace.rs
+++ b/crates/tact/src/plugin/marketplace.rs
@@ -50,17 +50,21 @@ impl PluginSource {
     }
 
     fn from_catalog_value(value: RawPluginSource) -> Result<Self> {
-        let (source, url, path, reference) = match value {
-            RawPluginSource::String(source) => (source, None, None, None),
+        let (source, url, path, reference, sha) = match value {
+            RawPluginSource::String(source) => (source, None, None, None, None),
             RawPluginSource::Object {
                 source,
                 url,
                 path,
                 reference,
-            } => (source, url, path, reference),
+                sha,
+            } => (source, url, path, reference, sha),
         };
-        // git-subdir means: clone url, checkout ref, use the subdirectory at path.
-        if source == "git-subdir" {
+        // `git-subdir` and `url` both describe a Git repository plugin: the
+        // former tracks a named ref and uses a subdirectory, the latter pins a
+        // commit (and may still use a subdirectory). Prefer the pinned `sha`
+        // for reproducible installs, falling back to the named `ref`.
+        if matches!(source.as_str(), "git-subdir" | "url") {
             let url =
                 url.with_context(|| format!("{source} source object must specify a url field"))?;
             if let Some(path) = &path {
@@ -69,7 +73,7 @@ impl PluginSource {
             return Ok(Self::Git {
                 url,
                 path,
-                reference,
+                reference: sha.or(reference),
             });
         }
         if is_relative_source(&source) {
@@ -77,7 +81,7 @@ impl PluginSource {
                 Some(path) => format!("{}/{}", source.trim_end_matches('/'), path),
                 None => source,
             };
-            if reference.is_some() {
+            if reference.is_some() || sha.is_some() {
                 bail!("repository-relative plugin source cannot specify ref");
             }
             return Ok(Self::Relative(normalize_relative(&source)?));
@@ -92,7 +96,7 @@ impl PluginSource {
         Ok(Self::Git {
             url,
             path,
-            reference,
+            reference: sha.or(reference),
         })
     }
 }
@@ -443,6 +447,8 @@ enum RawPluginSource {
         path: Option<String>,
         #[serde(default, rename = "ref")]
         reference: Option<String>,
+        #[serde(default)]
+        sha: Option<String>,
     },
 }
 
@@ -623,7 +629,98 @@ mod tests {
             PluginSource::Git {
                 url: "https://github.com/example/plugins.git".into(),
                 path: Some("plugins/api-security".into()),
-                reference: Some("v1.0.0".into()),
+                reference: Some("abc123".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_url_plugin_source() {
+        let root = tempdir().unwrap();
+        let catalog = MarketplaceCatalog::parse(
+            r#"{
+                "name":"fixture-market",
+                "plugins":[{
+                    "name":"external",
+                    "source":{
+                        "source":"url",
+                        "url":"https://github.com/example/external.git",
+                        "sha":"deadbeef"
+                    }
+                }]
+            }"#,
+            root.path(),
+        )
+        .unwrap();
+
+        let plugin = &catalog.plugins["external"];
+        assert_eq!(
+            plugin.source,
+            PluginSource::Git {
+                url: "https://github.com/example/external.git".into(),
+                path: None,
+                reference: Some("deadbeef".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_url_plugin_source_with_subdirectory() {
+        let root = tempdir().unwrap();
+        let catalog = MarketplaceCatalog::parse(
+            r#"{
+                "name":"fixture-market",
+                "plugins":[{
+                    "name":"zilliz",
+                    "source":{
+                        "source":"url",
+                        "url":"https://github.com/zilliztech/zilliz-plugin.git",
+                        "path":"plugins/zilliz",
+                        "sha":"768d3db"
+                    }
+                }]
+            }"#,
+            root.path(),
+        )
+        .unwrap();
+
+        let plugin = &catalog.plugins["zilliz"];
+        assert_eq!(
+            plugin.source,
+            PluginSource::Git {
+                url: "https://github.com/zilliztech/zilliz-plugin.git".into(),
+                path: Some("plugins/zilliz".into()),
+                reference: Some("768d3db".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn git_source_falls_back_to_named_ref_without_a_sha() {
+        let root = tempdir().unwrap();
+        let catalog = MarketplaceCatalog::parse(
+            r#"{
+                "name":"fixture-market",
+                "plugins":[{
+                    "name":"tracked",
+                    "source":{
+                        "source":"url",
+                        "url":"https://github.com/example/tracked.git",
+                        "ref":"main"
+                    }
+                }]
+            }"#,
+            root.path(),
+        )
+        .unwrap();
+
+        let plugin = &catalog.plugins["tracked"];
+        assert_eq!(
+            plugin.source,
+            PluginSource::Git {
+                url: "https://github.com/example/tracked.git".into(),
+                path: None,
+                reference: Some("main".into()),
             }
         );
     }

--- a/crates/tui/src/handlers/insert.rs
+++ b/crates/tui/src/handlers/insert.rs
@@ -125,14 +125,6 @@ fn handle_enter_submit(app: &mut App, key: &KeyEvent, _user_cmd_tx: &UnboundedSe
             }
         }
 
-        if matches!(app.status, Status::Planning | Status::Executing { .. }) {
-            app.flash_msg = Some((
-                app.msgs().input_busy_msg.to_string(),
-                std::time::Instant::now(),
-            ));
-            return;
-        }
-
         let display = app.input.clone();
         if tact::consts::exceeds_input_char_limit(display.chars().count()) {
             let msg = app
@@ -145,6 +137,15 @@ fn handle_enter_submit(app: &mut App, key: &KeyEvent, _user_cmd_tx: &UnboundedSe
 
         app.input.clear();
         app.input_cursor = 0;
+
+        if matches!(app.status, Status::Planning | Status::Executing { .. }) {
+            // Codex-style: while the agent is busy, Enter queues the message
+            // (hint shown above the input box) instead of rejecting it. It is
+            // auto-submitted after the current task finishes, or immediately
+            // when the user presses Esc.
+            app.queue_pending_message(display.clone(), display);
+            return;
+        }
         let _ = submit_user_task(app, display.clone(), display);
     }
 }
@@ -596,7 +597,7 @@ mod tests {
     use tokio::sync::mpsc::unbounded_channel;
 
     use super::{handle_insert_mode, insert_transcript};
-    use crate::widgets::state::{App, Status};
+    use crate::widgets::state::{App, InputMode, Status};
 
     fn make_app() -> (App, tokio::sync::mpsc::UnboundedReceiver<UserCommand>) {
         let (agent_tx, agent_rx) = unbounded_channel::<AgentUpdate>();
@@ -643,10 +644,20 @@ mod tests {
     }
 
     #[test]
-    fn slash_cancel_sends_cancel_without_submitting_task() {
+    fn slash_cancel_sends_cancel_without_touching_queue() {
         let (mut app, mut user_cmd_rx) = make_app();
         let user_cmd_tx = app.user_cmd_tx.clone();
         app.status = Status::Planning;
+        // Queue a message while busy, then /cancel.
+        app.input = "queued message".to_string();
+        app.input_cursor = app.input.len();
+        handle_insert_mode(
+            &mut app,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &user_cmd_tx,
+        );
+        assert_eq!(app.pending_messages.len(), 1);
+
         app.input = "/cancel".to_string();
         app.input_cursor = app.input.len();
 
@@ -656,6 +667,11 @@ mod tests {
             &user_cmd_tx,
         );
 
+        assert_eq!(
+            app.pending_messages.len(),
+            1,
+            "/cancel must NOT drop queued (pending) messages — that is the [Cancel] button's job"
+        );
         let cmd = user_cmd_rx
             .try_recv()
             .expect("expected /cancel to dispatch UserCommand::Cancel");
@@ -845,7 +861,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_rejected_while_agent_busy() {
+    fn submit_queued_while_agent_busy() {
         let (mut app, mut user_cmd_rx) = make_app();
         let user_cmd_tx = app.user_cmd_tx.clone();
         app.status = Status::Planning;
@@ -860,12 +876,76 @@ mod tests {
 
         assert!(
             user_cmd_rx.try_recv().is_err(),
-            "expected busy input not to submit task"
+            "busy input must not dispatch SubmitTask immediately"
         );
+        assert_eq!(app.pending_messages.len(), 1, "busy input should be queued");
+        assert_eq!(app.pending_messages[0].display, "do something");
+        assert!(app.input.is_empty(), "queued input should be cleared");
         assert!(
-            app.flash_msg.is_some(),
-            "expected a flash message while busy"
+            app.flash_msg.is_none(),
+            "queuing must not flash the old busy message"
         );
+    }
+
+    #[test]
+    fn esc_with_pending_exits_insert_mode_and_keeps_queue() {
+        let (mut app, mut user_cmd_rx) = make_app();
+        let user_cmd_tx = app.user_cmd_tx.clone();
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        app.input = "do something".to_string();
+        app.input_cursor = app.input.chars().count();
+
+        // Queue a message while the agent is busy.
+        handle_insert_mode(
+            &mut app,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &user_cmd_tx,
+        );
+        assert_eq!(app.pending_messages.len(), 1);
+
+        // Esc stays a plain "exit insert mode" key — it must never interrupt
+        // the running task or touch the queue (Send-now is the button / `s`).
+        handle_insert_mode(
+            &mut app,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &user_cmd_tx,
+        );
+
+        assert!(
+            matches!(app.input_mode, InputMode::Normal),
+            "Esc must exit insert mode even with queued messages"
+        );
+        assert_eq!(app.pending_messages.len(), 1, "queue untouched by Esc");
+        assert!(
+            user_cmd_rx.try_recv().is_err(),
+            "Esc must not dispatch Cancel/SubmitTask"
+        );
+    }
+
+    #[test]
+    fn esc_without_pending_still_exits_insert_mode() {
+        let (mut app, _user_cmd_rx) = make_app();
+        let user_cmd_tx = app.user_cmd_tx.clone();
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        app.input_mode = InputMode::Insert;
+
+        handle_insert_mode(
+            &mut app,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            &user_cmd_tx,
+        );
+
+        assert!(
+            matches!(app.input_mode, InputMode::Normal),
+            "Esc with no pending messages must exit insert mode"
+        );
+        assert!(app.pending_messages.is_empty());
     }
 
     #[test]

--- a/crates/tui/src/handlers/mod.rs
+++ b/crates/tui/src/handlers/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use normal::handle_normal_mode;
 pub(crate) use overlay::handle_overlay_key;
 pub(crate) use palette::handle_palette_mode;
 pub(crate) use select::handle_select_mode;
+pub(crate) use skills::flush_pending_when_idle;
 use tact_protocol::UserCommand;
 
 use crate::widgets::state::{App, InputMode, SelectKind, Status};
@@ -358,7 +359,9 @@ pub(crate) fn execute_palette_command(app: &mut App, cmd: &str) -> CommandExecOu
         }
         "plugin" => plugin::handle_plugin_command(app),
         "cancel" => {
-            // Only cancel an in-flight task; Idle and Done have nothing to abort.
+            // Only cancel an in-flight task; Idle and Done have nothing to
+            // abort. Queued (pending) messages are NOT touched — dropping
+            // them is the `[Cancel]` button's job.
             if matches!(app.status, Status::Planning | Status::Executing { .. }) {
                 let _ = app.user_cmd_tx.send(UserCommand::Cancel);
             } else {
@@ -640,6 +643,55 @@ mod tests {
         let outcome = execute_palette_command(&mut app, "nonexistent");
         assert!(!outcome.handled);
         assert!(!outcome.clear_input);
+    }
+
+    #[test]
+    fn cancel_command_leaves_queued_messages_alone() {
+        let (mut app, mut user_cmd_rx) = make_app();
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        app.queue_pending_message("one".into(), "one".into());
+        app.queue_pending_message("two".into(), "two".into());
+        assert_eq!(app.pending_messages.len(), 2);
+
+        let outcome = execute_palette_command(&mut app, "cancel");
+
+        assert!(outcome.handled);
+        assert_eq!(
+            app.pending_messages.len(),
+            2,
+            "/cancel must NOT clear the queue — the [Cancel] button does that"
+        );
+        assert!(matches!(
+            user_cmd_rx.try_recv().expect("expected Cancel"),
+            UserCommand::Cancel
+        ));
+    }
+
+    #[test]
+    fn cancel_command_idle_keeps_noop_flash() {
+        let (mut app, mut user_cmd_rx) = make_app();
+        app.status = Status::Idle;
+        app.queue_pending_message("stale".into(), "stale".into());
+
+        let outcome = execute_palette_command(&mut app, "cancel");
+
+        assert!(outcome.handled);
+        assert_eq!(
+            app.pending_messages.len(),
+            1,
+            "idle cancel must not touch the queue"
+        );
+        assert!(
+            app.flash_msg.is_some(),
+            "idle cancel still shows noop flash"
+        );
+        assert!(
+            user_cmd_rx.try_recv().is_err(),
+            "idle cancel must not dispatch Cancel"
+        );
     }
 
     #[test]

--- a/crates/tui/src/handlers/mouse.rs
+++ b/crates/tui/src/handlers/mouse.rs
@@ -100,6 +100,12 @@ fn handle_mouse_down(app: &mut App, mouse: MouseEvent, hit: MousePanelHit) {
         handle_voice_button_click(app);
         return;
     }
+    if point_in_rect(mouse.column, mouse.row, app.pending_cancel_btn_area) {
+        // Clicking `[Cancel]` drops the queued messages only — the running
+        // task keeps going (unlike `/cancel`, which stops it too).
+        app.clear_pending_messages();
+        return;
+    }
     if app.close_overlay_on_outside_click(mouse.column, mouse.row) {
         return;
     }
@@ -541,6 +547,54 @@ mod tests {
         assert!(
             cmd_rx.try_recv().is_err(),
             "outside click should not send commands"
+        );
+    }
+
+    #[test]
+    fn pending_cancel_button_drops_queue_without_touching_task() {
+        use tact_protocol::UserCommand;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let (_agent_tx, agent_rx) = unbounded_channel::<tact_protocol::AgentUpdate>();
+        let (user_cmd_tx, mut user_cmd_rx) = unbounded_channel::<UserCommand>();
+        let (plugin_tx, _plugin_request_rx) = unbounded_channel();
+        let (_plugin_event_tx, plugin_rx) = unbounded_channel();
+        let (history_tx, _history_rx) = unbounded_channel();
+        let mut app = App::new(
+            agent_rx,
+            None,
+            plugin_rx,
+            plugin_tx,
+            user_cmd_tx,
+            std::path::PathBuf::from("."),
+            Vec::new(),
+            "test-session".to_string(),
+            history_tx,
+            "retro".to_string(),
+            String::new(),
+            Vec::new(),
+        );
+        app.status = crate::widgets::state::Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        app.queue_pending_message("regret".into(), "regret".into());
+        app.set_cancel_button_area(Rect::new(70, 0, 10, 1));
+
+        // Click [Cancel]: the queue is dropped, the running task is untouched.
+        handle_mouse_event(&mut app, mouse_down(71, 0));
+
+        assert!(
+            app.pending_messages.is_empty(),
+            "[Cancel] must drop the queued messages"
+        );
+        assert!(
+            matches!(app.status, crate::widgets::state::Status::Executing { .. }),
+            "[Cancel] must not change the task status"
+        );
+        assert!(
+            user_cmd_rx.try_recv().is_err(),
+            "[Cancel] must not dispatch Cancel/SubmitTask"
         );
     }
 

--- a/crates/tui/src/handlers/mouse.rs
+++ b/crates/tui/src/handlers/mouse.rs
@@ -229,12 +229,14 @@ fn handle_log_click(app: &mut App, mouse: MouseEvent) {
         return;
     }
 
-    // Task-stats `[copy]` button: copy this turn's log text.
+    // Task-stats `[copy]` button: copy this turn's log text. Only clicks that
+    // land inside the button glyphs count — the rest of the row selects text.
     if let Some(raw) = app.raw_messages.get(phys_idx)
         && crate::widgets::state::is_task_stats_line(raw)
-        && let Some(btn_at) = raw.find(crate::widgets::state::TASK_STATS_COPY_BTN)
+        && let Some((btn_start, btn_end)) = crate::widgets::state::find_task_stats_copy_button(raw)
         && let Some((_, byte)) = app.byte_offset_from_log_position(line_idx, visual_row, col)
-        && byte >= btn_at
+        && byte >= btn_start
+        && byte < btn_end
     {
         app.copy_turn_ending_at_stats(phys_idx);
         app.mouse.log_selection = None;
@@ -1039,5 +1041,50 @@ mod tests {
         handle_mouse_event(&mut app, mouse_down(1, 20));
 
         assert!(app.mouse.log_selection.is_none());
+    }
+
+    #[test]
+    fn task_stats_copy_only_triggers_inside_button() {
+        let mut app = app_with_clickable_log();
+        app.add_system_message("first answer".into());
+        app.add_system_message("second answer".into());
+        app.last_prompt_elapsed_secs = Some(5);
+        app.add_task_stats_block();
+        app.log_scroll.visual_start = vec![0, 1, 2, 3];
+
+        // Stats row is logical 2 (visual row 2 → mouse row 3). Raw row is
+        // `[copy]  Task stats:⏱ 00:05`; column 3 maps to byte 2, inside the
+        // button glyphs (bytes 0..6). A successful copy appends a notice row.
+        let before = app.raw_messages.len();
+        handle_mouse_event(&mut app, mouse_down(3, 3));
+        assert!(
+            app.raw_messages.len() > before,
+            "clicking the [copy] button should copy this turn"
+        );
+        let last = app.raw_messages.last().expect("copy notice");
+        assert!(
+            last.contains("已复制") || last.contains("Copied"),
+            "expected a copy notice, got: {last}"
+        );
+    }
+
+    #[test]
+    fn task_stats_body_click_does_not_copy() {
+        let mut app = app_with_clickable_log();
+        app.add_system_message("first answer".into());
+        app.add_system_message("second answer".into());
+        app.last_prompt_elapsed_secs = Some(5);
+        app.add_task_stats_block();
+        app.log_scroll.visual_start = vec![0, 1, 2, 3];
+
+        // Column 15 maps into the "Task stats:" body (byte 11) — outside the
+        // button range (0..6), so no copy notice may be appended.
+        let before = app.raw_messages.len();
+        handle_mouse_event(&mut app, mouse_down(15, 3));
+        assert_eq!(
+            app.raw_messages.len(),
+            before,
+            "clicking the stats body must not copy"
+        );
     }
 }

--- a/crates/tui/src/handlers/normal.rs
+++ b/crates/tui/src/handlers/normal.rs
@@ -104,7 +104,9 @@ pub(crate) fn handle_normal_mode(
             }
         }
         KeyCode::Char('c') => {
-            // Same gate as `/cancel`: only Planning / Executing.
+            // Same gate as `/cancel`: only Planning / Executing. Queued
+            // (pending) messages are NOT touched — dropping them is the
+            // `[Cancel]` button's job.
             if matches!(app.status, Status::Planning | Status::Executing { .. }) {
                 let _ = _user_cmd_tx.send(UserCommand::Cancel);
             }
@@ -181,6 +183,49 @@ mod tests {
     }
 
     #[test]
+    fn s_is_unbound_noop_key() {
+        use std::path::PathBuf;
+
+        use tact_protocol::{AgentUpdate, UserCommand};
+
+        use crate::widgets::state::Status;
+
+        let (_agent_tx, agent_rx) = unbounded_channel::<AgentUpdate>();
+        let (user_cmd_tx, mut user_cmd_rx) = unbounded_channel::<UserCommand>();
+        let (plugin_tx, _plugin_request_rx) = unbounded_channel();
+        let (_plugin_event_tx, plugin_rx) = unbounded_channel();
+        let (history_tx, _history_rx) = unbounded_channel();
+        let mut app = App::new(
+            agent_rx,
+            None,
+            plugin_rx,
+            plugin_tx,
+            user_cmd_tx.clone(),
+            PathBuf::from("."),
+            Vec::new(),
+            "test-session".to_string(),
+            history_tx,
+            "retro".to_string(),
+            String::new(),
+            Vec::new(),
+        );
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        app.queue_pending_message("urgent".into(), "urgent".into());
+
+        // `s` is not a bound key: it must not send or drop anything.
+        handle_normal_mode(&mut app, key(KeyCode::Char('s')), &user_cmd_tx);
+
+        assert_eq!(app.pending_messages.len(), 1, "s must not touch the queue");
+        assert!(
+            user_cmd_rx.try_recv().is_err(),
+            "s must not dispatch anything"
+        );
+    }
+
+    #[test]
     fn c_cancels_while_executing() {
         use std::path::PathBuf;
 
@@ -211,6 +256,7 @@ mod tests {
             current_step: 0,
             total: 1,
         };
+        app.queue_pending_message("queued".into(), "queued".into());
 
         handle_normal_mode(&mut app, key(KeyCode::Char('c')), &user_cmd_tx);
 
@@ -218,6 +264,11 @@ mod tests {
             user_cmd_rx.try_recv().expect("expected Cancel"),
             UserCommand::Cancel
         ));
+        assert_eq!(
+            app.pending_messages.len(),
+            1,
+            "Normal-mode c must NOT drop queued (pending) messages — that is the [Cancel] button's job"
+        );
     }
 
     #[test]

--- a/crates/tui/src/handlers/skills.rs
+++ b/crates/tui/src/handlers/skills.rs
@@ -121,16 +121,25 @@ pub(super) fn format_skill_agent_task(skill: &SkillEntry, args: &str) -> String 
 }
 
 /// Shared task submission used by normal Enter and skill invoke.
-/// Returns `true` when the task was accepted and dispatched.
+///
+/// Returns `true` when the task was accepted — either dispatched immediately
+/// (agent idle) or queued while the agent is busy (Codex-style "submit after
+/// the current task"; see [`flush_pending_when_idle`]).
 pub(crate) fn submit_user_task(app: &mut App, display_text: String, agent_task: String) -> bool {
-    if matches!(app.status, Status::Planning | Status::Executing { .. }) {
-        app.flash_msg = Some((
-            app.msgs().input_busy_msg.to_string(),
-            std::time::Instant::now(),
-        ));
+    if !task_within_limits(app, &display_text, &agent_task) {
         return false;
     }
+    if matches!(app.status, Status::Planning | Status::Executing { .. }) {
+        // The agent is busy: queue the message instead of rejecting it. It is
+        // auto-submitted when the current task finishes (or immediately on Esc).
+        app.queue_pending_message(display_text, agent_task);
+        return true;
+    }
+    dispatch_user_task(app, display_text, agent_task)
+}
 
+/// Char-limit validation shared by the direct and queued submit paths.
+fn task_within_limits(app: &mut App, display_text: &str, agent_task: &str) -> bool {
     let display_chars = display_text.chars().count();
     let agent_chars = agent_task.chars().count();
     if tact::consts::exceeds_input_char_limit(agent_chars) {
@@ -149,7 +158,13 @@ pub(crate) fn submit_user_task(app: &mut App, display_text: String, agent_task: 
         app.add_system_message(msg);
         return false;
     }
+    true
+}
 
+/// Dispatch one task to the agent: record history, show the user bubble, and
+/// send `SubmitTask`. Callers must already have validated limits and the busy
+/// gate (see [`submit_user_task`]).
+fn dispatch_user_task(app: &mut App, display_text: String, agent_task: String) -> bool {
     if app.input_history.entries.last() != Some(&display_text) {
         app.input_history.entries.push(display_text.clone());
         app.save_history(&display_text);
@@ -164,6 +179,19 @@ pub(crate) fn submit_user_task(app: &mut App, display_text: String, agent_task: 
     app.task_start_time = Some(chrono::Local::now());
     let _ = app.user_cmd_tx.send(UserCommand::SubmitTask(agent_task));
     true
+}
+
+/// Codex-style auto-submit: once the agent reaches Idle/Done, submit every
+/// queued message as its own task. The command driver serializes them in
+/// order, so each queued message becomes the next user turn.
+pub(crate) fn flush_pending_when_idle(app: &mut App) {
+    if app.pending_messages.is_empty() || !matches!(app.status, Status::Idle | Status::Done) {
+        return;
+    }
+    let pending = std::mem::take(&mut app.pending_messages);
+    for p in pending {
+        let _ = dispatch_user_task(app, p.display, p.agent_task);
+    }
 }
 
 /// Invoke `/skill-name` [args]: always runs (no equip step).
@@ -278,5 +306,124 @@ mod tests {
         };
         let out = format_skill_agent_task(&skill, "");
         assert!(out.contains(r#"<skill name="weird&quot;name">"#));
+    }
+
+    // ---- Codex-style queued submission (pending messages) ----
+
+    fn make_app_with_cmds() -> (App, tokio::sync::mpsc::UnboundedReceiver<UserCommand>) {
+        use std::path::PathBuf;
+
+        use tact_protocol::AgentUpdate;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        let (_agent_tx, agent_rx) = unbounded_channel::<AgentUpdate>();
+        let (user_cmd_tx, user_cmd_rx) = unbounded_channel::<UserCommand>();
+        let (plugin_tx, _plugin_request_rx) = unbounded_channel();
+        let (_plugin_event_tx, plugin_rx) = unbounded_channel();
+        let (history_tx, _history_rx) = unbounded_channel();
+        let app = App::new(
+            agent_rx,
+            None,
+            plugin_rx,
+            plugin_tx,
+            user_cmd_tx,
+            PathBuf::from("."),
+            Vec::new(),
+            "test-session".to_string(),
+            history_tx,
+            "retro".to_string(),
+            String::new(),
+            Vec::new(),
+        );
+        (app, user_cmd_rx)
+    }
+
+    #[test]
+    fn submit_user_task_queues_when_busy() {
+        let (mut app, mut user_cmd_rx) = make_app_with_cmds();
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+
+        let ok = submit_user_task(&mut app, "hi".into(), "hi".into());
+
+        assert!(ok, "queued task counts as accepted");
+        assert_eq!(app.pending_messages.len(), 1);
+        assert_eq!(app.pending_messages[0].display, "hi");
+        assert_eq!(app.pending_messages[0].agent_task, "hi");
+        assert!(
+            user_cmd_rx.try_recv().is_err(),
+            "queued task must not dispatch immediately"
+        );
+        assert!(
+            matches!(app.status, Status::Executing { .. }),
+            "busy status must be preserved while queued"
+        );
+    }
+
+    #[test]
+    fn submit_user_task_dispatches_when_idle() {
+        let (mut app, mut user_cmd_rx) = make_app_with_cmds();
+        app.status = Status::Idle;
+
+        let ok = submit_user_task(&mut app, "go".into(), "go".into());
+
+        assert!(ok);
+        assert!(app.pending_messages.is_empty());
+        assert!(matches!(app.status, Status::Planning));
+        match user_cmd_rx.try_recv().expect("SubmitTask") {
+            UserCommand::SubmitTask(task) => assert_eq!(task, "go"),
+            other => panic!("expected SubmitTask, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flush_pending_when_idle_submits_all_queued_in_order() {
+        let (mut app, mut user_cmd_rx) = make_app_with_cmds();
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        submit_user_task(&mut app, "one".into(), "one".into());
+        submit_user_task(&mut app, "two".into(), "two".into());
+        assert_eq!(app.pending_messages.len(), 2);
+
+        // Still busy: flush must not fire.
+        flush_pending_when_idle(&mut app);
+        assert_eq!(app.pending_messages.len(), 2);
+        assert!(user_cmd_rx.try_recv().is_err());
+
+        // Agent reached Idle (e.g. TaskComplete): every queued message is
+        // submitted, each as its own task, in queue order.
+        app.status = Status::Idle;
+        flush_pending_when_idle(&mut app);
+        assert!(app.pending_messages.is_empty(), "queue drained by flush");
+        let mut tasks = Vec::new();
+        while let Ok(cmd) = user_cmd_rx.try_recv() {
+            if let UserCommand::SubmitTask(task) = cmd {
+                tasks.push(task);
+            }
+        }
+        assert_eq!(tasks, vec!["one".to_string(), "two".to_string()]);
+    }
+
+    #[test]
+    fn flush_pending_fires_on_done_too() {
+        let (mut app, mut user_cmd_rx) = make_app_with_cmds();
+        app.status = Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        submit_user_task(&mut app, "x".into(), "x".into());
+
+        app.status = Status::Done;
+        flush_pending_when_idle(&mut app);
+
+        assert!(app.pending_messages.is_empty());
+        assert!(matches!(
+            user_cmd_rx.try_recv(),
+            Ok(UserCommand::SubmitTask(_))
+        ));
     }
 }

--- a/crates/tui/src/i18n.rs
+++ b/crates/tui/src/i18n.rs
@@ -115,6 +115,7 @@ pub struct Messages {
     pub palette_empty: &'static str,
     pub select_empty: &'static str,
     pub select_arrow: &'static str,
+    pub pending_cancel_btn: &'static str,
 
     // ---- 帮助面板 ---
     pub help_header_shortcuts: &'static str,
@@ -127,6 +128,7 @@ pub struct Messages {
     pub help_colon: &'static str,
     pub help_insert_header: &'static str,
     pub help_type_task: &'static str,
+    pub help_queued_submit: &'static str,
     pub help_ctrl_z: &'static str,
     pub help_global_header: &'static str,
     pub help_yn: &'static str,
@@ -276,6 +278,7 @@ pub struct Messages {
     pub input_too_long_tmpl: &'static str,
     pub skill_task_too_long_tmpl: &'static str,
     pub input_busy_msg: &'static str,
+    pub pending_submit_hint: &'static str,
     pub cancel_noop_msg: &'static str,
 
     // ---- 持久任务进度 ----
@@ -384,6 +387,7 @@ impl Messages {
             palette_empty: "No matching commands",
             select_empty: "No options",
             select_arrow: "▶ ",
+            pending_cancel_btn: "Cancel",
 
             help_header_shortcuts: "⌨️  Keyboard Shortcuts:",
             help_normal_header: "  🔤 Normal Mode (Esc from Insert)",
@@ -395,6 +399,7 @@ impl Messages {
             help_colon: "    /           Command palette (commands & skills)",
             help_insert_header: "  ✏️  Insert Mode (i or Enter from Normal)",
             help_type_task: "    Type task or /skill, Enter to submit, @ to attach file",
+            help_queued_submit: "    Enter while running  Queue; auto-submit after task ([Cancel] to drop)",
             help_ctrl_z: "    Ctrl+Z/Y    Undo/redo input",
             help_global_header: "  🌐 Global",
             help_yn: "    ↑↓/j/k      Move in select popup; Enter/Esc confirm/cancel",
@@ -537,6 +542,7 @@ impl Messages {
             input_too_long_tmpl: "⚠ Input too long (max {} characters). Please shorten your message.",
             skill_task_too_long_tmpl: "⚠ Skill payload too long (max {} characters). Shorten the skill body or args.",
             input_busy_msg: "⏳ Still processing previous prompt, please wait...",
+            pending_submit_hint: "Message will be submitted after the current task finishes",
             cancel_noop_msg: "Nothing to cancel",
 
             tasks_sticky_title: "Tasks",
@@ -640,6 +646,7 @@ impl Messages {
             palette_empty: "没有匹配的命令",
             select_empty: "无选项",
             select_arrow: "▶ ",
+            pending_cancel_btn: "取消",
 
             help_header_shortcuts: "⌨️  键盘快捷键:",
             help_normal_header: "  🔤 普通模式 (在插入模式按 Esc)",
@@ -651,6 +658,7 @@ impl Messages {
             help_colon: "    /           命令面板 (内置命令与 Skills)",
             help_insert_header: "  ✏️  插入模式 (在普通模式按 i 或 Enter)",
             help_type_task: "    输入任务或 /skill，Enter 提交，@ 附加文件",
+            help_queued_submit: "    运行中输入按 Enter 排队；任务结束后自动提交（[取消] 丢弃）",
             help_ctrl_z: "    Ctrl+Z/Y    撤销/重做输入",
             help_global_header: "  🌐 全局",
             help_yn: "    ↑↓/j/k      选择弹窗移动；Enter/Esc 确认/取消",
@@ -793,6 +801,7 @@ impl Messages {
             input_too_long_tmpl: "⚠ 输入过长（最多 {} 个字符），请缩短后再发送。",
             skill_task_too_long_tmpl: "⚠ 技能内容过长（最多 {} 个字符），请缩短技能正文或参数。",
             input_busy_msg: "⏳ 上一个任务还在处理中，请稍候...",
+            pending_submit_hint: "消息将在当前任务结束后自动提交",
             cancel_noop_msg: "当前没有可取消的任务",
 
             tasks_sticky_title: "任务",

--- a/crates/tui/src/i18n.rs
+++ b/crates/tui/src/i18n.rs
@@ -295,7 +295,7 @@ pub struct Messages {
     pub scroll_indicator_tmpl: &'static str,
 
     // ---- 任务统计行 ----
-    pub task_stats_prefix: &'static str,   // "Task stats:" / "任务统计：" (no emoji — it rendered too wide)
+    pub task_stats_prefix: &'static str, // "Task stats:" / "任务统计：" (no emoji — it rendered too wide)
     pub task_stats_copy_btn: &'static str, // "[copy]" / "[复制]"
 }
 

--- a/crates/tui/src/i18n.rs
+++ b/crates/tui/src/i18n.rs
@@ -9,7 +9,7 @@ pub enum Language {
 }
 
 impl Language {
-    fn all() -> &'static [Language] {
+    pub(crate) fn all() -> &'static [Language] {
         &[Language::English, Language::Chinese]
     }
 
@@ -293,6 +293,10 @@ pub struct Messages {
 
     // ---- 其他 ----
     pub scroll_indicator_tmpl: &'static str,
+
+    // ---- 任务统计行 ----
+    pub task_stats_prefix: &'static str,   // "Task stats:" / "任务统计：" (no emoji — it rendered too wide)
+    pub task_stats_copy_btn: &'static str, // "[copy]" / "[复制]"
 }
 
 impl Messages {
@@ -555,6 +559,8 @@ impl Messages {
             exit_bye: "Bye! 🔔",
 
             scroll_indicator_tmpl: "↕ {}/{} ",
+            task_stats_prefix: "Task stats:",
+            task_stats_copy_btn: "[copy]",
         }
     }
 
@@ -808,6 +814,8 @@ impl Messages {
             exit_bye: "再见! 🔔",
 
             scroll_indicator_tmpl: "↕ {}/{} ",
+            task_stats_prefix: "任务统计：",
+            task_stats_copy_btn: "[复制]",
         }
     }
 }

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -45,8 +45,8 @@ use tokio_stream::StreamExt;
 pub use crate::widgets::state::SkillEntry;
 use crate::{
     handlers::{
-        handle_file_picker_mode, handle_insert_mode, handle_mouse_event, handle_normal_mode,
-        handle_overlay_key, handle_palette_mode, handle_select_mode,
+        flush_pending_when_idle, handle_file_picker_mode, handle_insert_mode, handle_mouse_event,
+        handle_normal_mode, handle_overlay_key, handle_palette_mode, handle_select_mode,
     },
     render::{
         render_bottom_bar, render_command_palette, render_file_picker, render_input_box,
@@ -255,6 +255,9 @@ pub async fn run_tui(cfg: TuiConfig) -> Result<()> {
         while let Ok(update) = app.agent_rx.try_recv() {
             app.handle_agent_update(update);
         }
+        // Codex-style: messages queued while the agent was busy are submitted
+        // automatically once the current task reaches Idle/Done.
+        flush_pending_when_idle(&mut app);
         let account_updates: Vec<AccountUpdate> = app
             .account_rx
             .as_mut()
@@ -289,7 +292,10 @@ pub async fn run_tui(cfg: TuiConfig) -> Result<()> {
                     .map(|line| wrap_line(line, inner_width).len())
                     .sum::<usize>()
                     .clamp(1, 3) as u16;
-                let input_height = input_lines + 2;
+                // Pending (Codex-style queued) messages add a hint row plus one
+                // row per queued message above the input box.
+                let pending_lines = app.pending_display_lines();
+                let input_height = input_lines + 2 + pending_lines;
                 let bottom_height = 2u16;
                 let log_area = Layout::default()
                     .direction(Direction::Vertical)

--- a/crates/tui/src/render/cells/text.rs
+++ b/crates/tui/src/render/cells/text.rs
@@ -12,10 +12,10 @@ use crate::render::{renderable::Renderable, util::wrap_line};
 fn render_line(line: &Line, x: u16, y: u16, width: u16, bg_color: Color, buf: &mut Buffer) {
     let mut col = x;
     for span in &line.spans {
-        // Spans that bring their own background (fenced code, H1 headings)
-        // keep it; everything else sits on the panel surface color. Either
-        // way every glyph writes an explicit bg so no overlay residue can
-        // leak through when the line scrolls into view.
+        // Fenced code spans may bring their own background; everything else
+        // sits on the panel surface color. Either way every glyph writes an
+        // explicit bg so no overlay residue can leak through when the line
+        // scrolls into view.
         let style = if span.style.bg.is_some() {
             span.style
         } else {

--- a/crates/tui/src/render/input.rs
+++ b/crates/tui/src/render/input.rs
@@ -86,6 +86,26 @@ pub(crate) fn render_input_box(frame: &mut Frame, area: Rect, app: &mut App) {
         return;
     }
 
+    // Codex-style queued messages: the hint + "↳ message" rows sit above the
+    // bordered input box, which shrinks to the remaining height. The pending
+    // block paints its own background (TUI invariant: no shadow residue).
+    let pending_lines = app.pending_display_lines();
+    let area = if pending_lines == 0 {
+        area
+    } else {
+        render_pending_block(
+            frame,
+            Rect::new(area.x, area.y, area.width, pending_lines),
+            app,
+        );
+        Rect::new(
+            area.x,
+            area.y + pending_lines,
+            area.width,
+            area.height - pending_lines,
+        )
+    };
+
     // Logical rows are separated by explicit `\n`; the caret line/column is
     // computed on the raw input, then mapped through soft-wrapping below.
     let mut cursor_line = 0;
@@ -200,6 +220,84 @@ pub(crate) fn render_input_box(frame: &mut Frame, area: Rect, app: &mut App) {
         (area.x + 1 + caret_col_in_line as u16).min(area.x + area.width.saturating_sub(2));
     let cursor_y = area.y + 1 + (cursor_display_line - app.input_scroll as usize) as u16;
     frame.set_cursor_position((cursor_x, cursor_y));
+}
+
+/// Truncate a string to at most `max` display columns, appending `…` when cut.
+fn truncate_to_width(s: &str, max: usize) -> String {
+    if UnicodeWidthStr::width(s) <= max {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    let mut width = 0;
+    for c in s.chars() {
+        let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        if width + cw > max.saturating_sub(1) {
+            break;
+        }
+        out.push(c);
+        width += cw;
+    }
+    out.push('…');
+    out
+}
+
+/// Codex-style pending block: a hint line plus one `↳ message` row per queued
+/// message, drawn above the input box while the agent is busy. The hint row
+/// carries a clickable `[Cancel]` button (mouse) — the only way to drop the
+/// queued messages; they otherwise auto-submit when the current task finishes.
+fn render_pending_block(frame: &mut Frame, area: Rect, app: &mut App) {
+    if area.height == 0 || area.width == 0 {
+        return;
+    }
+    let inner_width = area.width.saturating_sub(2).max(1) as usize;
+    let cancel_label = app.msgs().pending_cancel_btn;
+    let cancel_width = UnicodeWidthStr::width(cancel_label) + 2; // "[label]"
+    // Hide the button on narrow terminals.
+    let cancel_area = if app.pending_messages.is_empty() || inner_width < cancel_width + 30 {
+        Rect::default()
+    } else {
+        let x = area.x + (inner_width - cancel_width) as u16;
+        Rect::new(x, area.y, cancel_width as u16, 1)
+    };
+    app.set_cancel_button_area(cancel_area);
+
+    let hint = app.msgs().pending_submit_hint;
+    let hint_max = if cancel_area.is_empty() {
+        inner_width
+    } else {
+        inner_width.saturating_sub(cancel_width).saturating_sub(1)
+    };
+    let mut lines = vec![Line::from(Span::styled(
+        truncate_to_width(hint, hint_max),
+        Style::default()
+            .fg(app.theme.warning)
+            .bg(app.theme.input_box_bg),
+    ))];
+    if !cancel_area.is_empty() {
+        lines[0].spans.push(Span::styled(
+            " ".to_string(),
+            Style::default().bg(app.theme.input_box_bg),
+        ));
+        lines[0].spans.push(Span::styled(
+            format!("[{cancel_label}]"),
+            Style::default()
+                .fg(app.theme.warning)
+                .bg(app.theme.input_box_bg),
+        ));
+    }
+    for pending in app.pending_messages.iter().take(3) {
+        let text = truncate_to_width(&format!("↳ {}", pending.display), inner_width);
+        lines.push(Line::from(Span::styled(
+            text,
+            Style::default()
+                .fg(app.theme.input_box_fg)
+                .bg(app.theme.input_box_bg),
+        )));
+    }
+    frame.render_widget(
+        Paragraph::new(Text::from(lines)).style(Style::default().bg(app.theme.input_box_bg)),
+        area,
+    );
 }
 
 fn voice_title(app: &App) -> Option<(String, Style)> {
@@ -418,6 +516,108 @@ mod render_tests {
 
         let text = buffer_text(terminal.backend().buffer());
         assert!(text.contains("00:08"), "recording elapsed label: {text}");
+    }
+
+    #[test]
+    fn truncate_to_width_appends_ellipsis_for_cjk() {
+        assert_eq!(super::truncate_to_width("abc", 5), "abc");
+        assert_eq!(super::truncate_to_width("abcdef", 4), "abc…");
+        // CJK wide chars count as two columns; truncation targets `max` cols.
+        assert_eq!(super::truncate_to_width("中文abc", 5), "中文…");
+        assert_eq!(super::truncate_to_width("中文abc", 6), "中文a…");
+        assert_eq!(super::truncate_to_width("中文abc", 7), "中文abc");
+    }
+
+    #[test]
+    fn input_box_renders_pending_block_above_input() {
+        let mut app = make_app();
+        app.status = crate::widgets::state::Status::Executing {
+            current_step: 0,
+            total: 1,
+        };
+        app.queue_pending_message("fix the auth bug".into(), "fix the auth bug".into());
+
+        // Height = hint row + 1 message row + input box (2 border + 1 content).
+        let backend = TestBackend::new(80, 5);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| render_input_box(frame, Rect::new(0, 0, 80, 5), &mut app))
+            .expect("draw");
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            text.contains("Message will be submitted after the current task"),
+            "pending hint visible: {text}"
+        );
+        assert!(
+            text.contains("↳ fix the auth bug"),
+            "pending message row visible: {text}"
+        );
+        assert!(
+            text.contains("[Cancel]"),
+            "cancel button visible on wide enough terminal: {text}"
+        );
+        assert!(
+            !app.pending_cancel_btn_area.is_empty(),
+            "render must record the cancel button hit area"
+        );
+        assert!(text.contains("Type a task"), "input box still rendered");
+        // Pending block rows must carry the input-box background (no shadow).
+        let buf = terminal.backend().buffer();
+        for x in 0..buf.area.width {
+            for y in 0..2 {
+                assert_eq!(
+                    buf[(x, y)].style().bg,
+                    Some(app.theme.input_box_bg),
+                    "pending row {y} col {x} must paint its own background"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn input_box_pending_button_hidden_on_narrow_terminal() {
+        let mut app = make_app();
+        app.status = crate::widgets::state::Status::Planning;
+        app.queue_pending_message("narrow".into(), "narrow".into());
+
+        // Too narrow for the hint + button: button must be hidden and the hit
+        // area cleared.
+        let backend = TestBackend::new(30, 5);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| render_input_box(frame, Rect::new(0, 0, 30, 5), &mut app))
+            .expect("draw");
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            !text.contains("[Cancel]"),
+            "button must be hidden on narrow terminals: {text}"
+        );
+        assert!(
+            app.pending_cancel_btn_area.is_empty(),
+            "cancel hit area must be cleared when the button is hidden"
+        );
+    }
+
+    #[test]
+    fn input_box_pending_block_truncates_long_messages() {
+        let mut app = make_app();
+        app.status = crate::widgets::state::Status::Planning;
+        app.queue_pending_message("x".repeat(200), "x".repeat(200));
+
+        let backend = TestBackend::new(40, 5);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| render_input_box(frame, Rect::new(0, 0, 40, 5), &mut app))
+            .expect("draw");
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains('…'), "overlong pending message ellipsized");
+        assert!(
+            !text.contains("xxxxx".repeat(20).as_str()),
+            "pending message must not overflow the width"
+        );
     }
     #[test]
     fn input_box_keeps_top_border_between_title_and_voice() {

--- a/crates/tui/src/render/log_style.rs
+++ b/crates/tui/src/render/log_style.rs
@@ -97,13 +97,16 @@ pub(crate) fn restyle_log_line_with_skills(
         return single_span(raw, theme.accent);
     }
 
-    // Only fenced-code lines carry the code background; a heading's
-    // highlight background must keep its own style instead of being
-    // restyled as code.
+    // Only whole fenced-code lines — every span already carries the code
+    // background — are restyled as a code block. A prose line that merely
+    // contains inline code (e.g. a `- run `cargo build`` list item) must keep
+    // its prose styling: restyling it here paints the whole line with the code
+    // background, a full-width highlight block that `wrap_line` re-slices onto
+    // every wrapped continuation row and reads as a shadow band.
     if stored
         .spans
         .iter()
-        .any(|s| s.style.bg == Some(theme.code_block_bg()))
+        .all(|s| s.style.bg == Some(theme.code_block_bg()))
     {
         return restyle_code_line(stored, theme);
     }
@@ -306,6 +309,42 @@ mod tests {
             line.spans.first().unwrap().style.fg,
             Some(theme.code_block_fg())
         );
+    }
+
+    #[test]
+    fn inline_code_line_keeps_narrow_patch_not_full_block_bg() {
+        // A list item with inline code (`- run `cargo build``) is prose, not a
+        // code block: only the inline-code span may carry the code background.
+        // Restyling the whole line as code painted a full-width highlight block
+        // that wrapped into a shadow band on continuation rows.
+        let theme = brutal();
+        let stored = Line::from(vec![
+            Span::styled("• ".to_string(), Style::default().fg(theme.fg)),
+            Span::styled("run ".to_string(), Style::default().fg(theme.fg)),
+            Span::styled(
+                "cargo build".to_string(),
+                Style::default()
+                    .fg(theme.code_block_fg())
+                    .bg(theme.code_block_bg()),
+            ),
+            Span::styled(" now".to_string(), Style::default().fg(theme.fg)),
+        ]);
+        let line = restyle_log_line(
+            &stored,
+            "- run `cargo build` now",
+            &theme,
+            RawMessageType::LLM,
+            false,
+        );
+        let bgs: Vec<Option<Color>> = line.spans.iter().map(|s| s.style.bg).collect();
+        assert_eq!(
+            bgs,
+            vec![None, None, Some(theme.code_block_bg()), None],
+            "only the inline code span may carry the code background"
+        );
+        // The prose spans keep their own fg (not the code fg).
+        assert_eq!(line.spans[0].style.fg, Some(theme.fg));
+        assert_eq!(line.spans[3].style.fg, Some(theme.fg));
     }
 
     #[test]

--- a/crates/tui/src/render/log_style.rs
+++ b/crates/tui/src/render/log_style.rs
@@ -103,11 +103,11 @@ pub(crate) fn restyle_log_line_with_skills(
     // its prose styling: restyling it here paints the whole line with the code
     // background, a full-width highlight block that `wrap_line` re-slices onto
     // every wrapped continuation row and reads as a shadow band.
-    if stored
+    let is_code_line = stored
         .spans
         .iter()
-        .all(|s| s.style.bg == Some(theme.code_block_bg()))
-    {
+        .all(|s| s.style.bg == Some(theme.code_block_bg()));
+    if is_code_line {
         return restyle_code_line(stored, theme);
     }
 
@@ -117,6 +117,13 @@ pub(crate) fn restyle_log_line_with_skills(
         .iter()
         .map(|span| {
             let mut style = line_style.patch(span.style);
+            if style.bg == Some(theme.code_block_bg()) {
+                // Inline code is part of prose, so distinguish it with the
+                // accent foreground rather than a rectangular code-block patch.
+                style.bg = None;
+                style.fg = Some(theme.accent);
+                return Span::styled(span.content.to_string(), style);
+            }
             // H1 headings used to carry the theme.highlight background here
             // (a leftover from tui-markdown). The pulldown pipeline emits
             // headings without a background and the MarkdownCell path never
@@ -312,11 +319,9 @@ mod tests {
     }
 
     #[test]
-    fn inline_code_line_keeps_narrow_patch_not_full_block_bg() {
-        // A list item with inline code (`- run `cargo build``) is prose, not a
-        // code block: only the inline-code span may carry the code background.
-        // Restyling the whole line as code painted a full-width highlight block
-        // that wrapped into a shadow band on continuation rows.
+    fn inline_code_uses_accent_without_background() {
+        // Inline code is prose, not a code block: use the accent foreground
+        // without painting a rectangular background patch.
         let theme = brutal();
         let stored = Line::from(vec![
             Span::styled("• ".to_string(), Style::default().fg(theme.fg)),
@@ -339,10 +344,10 @@ mod tests {
         let bgs: Vec<Option<Color>> = line.spans.iter().map(|s| s.style.bg).collect();
         assert_eq!(
             bgs,
-            vec![None, None, Some(theme.code_block_bg()), None],
-            "only the inline code span may carry the code background"
+            vec![None, None, None, None],
+            "inline code must not carry a code-block background"
         );
-        // The prose spans keep their own fg (not the code fg).
+        assert_eq!(line.spans[2].style.fg, Some(theme.accent));
         assert_eq!(line.spans[0].style.fg, Some(theme.fg));
         assert_eq!(line.spans[3].style.fg, Some(theme.fg));
     }

--- a/crates/tui/src/render/pulldown.rs
+++ b/crates/tui/src/render/pulldown.rs
@@ -337,10 +337,7 @@ impl Writer {
     }
 
     fn push_inline_code(&mut self, code: &str) {
-        let style = self
-            .current_style()
-            .fg(self.theme.code_block_fg())
-            .bg(self.theme.code_block_bg());
+        let style = self.current_style().fg(self.theme.accent);
         self.push_span(Span::styled(code.to_string(), style));
     }
 
@@ -463,5 +460,39 @@ impl Writer {
         }
         let (styled, _raw) = format_table(&md_lines, &self.theme, self.available_width);
         self.lines.extend(styled);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::{Theme, ThemeName};
+
+    #[test]
+    fn inline_code_uses_accent_without_background() {
+        let theme = Theme::from(ThemeName::Brutal);
+        let (lines, _) = render_markdown("prose `git push` tail", &theme, None);
+        let code = lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content == "git push")
+            .expect("inline code span");
+
+        assert_eq!(code.style.fg, Some(theme.accent));
+        assert_eq!(code.style.bg, None);
+    }
+
+    #[test]
+    fn fenced_code_keeps_code_block_background() {
+        let theme = Theme::from(ThemeName::Brutal);
+        let (lines, _) = render_markdown("```sh\ngit push\n```", &theme, None);
+        let code = lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .find(|span| span.content == "git push")
+            .expect("fenced code span");
+
+        assert_eq!(code.style.fg, Some(theme.code_block_fg()));
+        assert_eq!(code.style.bg, Some(theme.code_block_bg()));
     }
 }

--- a/crates/tui/src/widgets/help_widget.rs
+++ b/crates/tui/src/widgets/help_widget.rs
@@ -41,6 +41,7 @@ impl<'a> Widget for HelpWidget<'a> {
             // ── Insert Mode ──
             Line::from(Span::styled(msgs.help_insert_header, dim_style)),
             Line::from(Span::styled(msgs.help_type_task, normal_style)),
+            Line::from(Span::styled(msgs.help_queued_submit, normal_style)),
             Line::from(Span::styled(msgs.help_ctrl_z, normal_style)),
             Line::from(""),
             // ── Global ──

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -204,7 +204,8 @@ impl App {
             }
             AgentUpdate::TaskCancelled => {
                 // Cancel exits without TaskComplete; must leave Planning/Executing
-                // or Enter keeps flashing input_busy_msg.
+                // or queued (pending) messages would be flushed against a stale
+                // busy state.
                 self.flush_stream_pending();
                 self.add_task_end_separator();
                 if self.input_mode == InputMode::Insert || self.input_mode == InputMode::Normal {

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -1980,11 +1980,11 @@ mod lifecycle_tests {
 
         let joined = app.raw_messages.join("\n");
         assert!(
-            joined.contains("📊 任务统计：⏱ 01:05"),
+            joined.contains("Task stats:⏱ 01:05"),
             "elapsed part missing: {joined}"
         );
         assert!(
-            joined.contains("🧠 mock-model"),
+            joined.contains("mock-model"),
             "model part missing: {joined}"
         );
         assert!(
@@ -2003,9 +2003,37 @@ mod lifecycle_tests {
         let joined = app.raw_messages.join("\n");
         let stats_line = joined
             .lines()
-            .find(|l| l.contains("📊 任务统计："))
+            .find(|l| l.contains("Task stats:"))
             .expect("stats block missing");
-        assert_eq!(stats_line, "📊 任务统计：⏱ 00:05  [copy]");
+        assert_eq!(stats_line, "[copy]  Task stats:⏱ 00:05");
+    }
+
+    #[test]
+    fn task_stats_block_localizes_prefix_and_copy_button() {
+        let mut app = make_app();
+        app.language = crate::i18n::Language::Chinese;
+        app.last_prompt_elapsed_secs = Some(5);
+
+        app.handle_agent_update(AgentUpdate::TaskComplete("All done.".into()));
+
+        let joined = app.raw_messages.join("\n");
+        let stats_line = joined
+            .lines()
+            .find(|l| l.contains("任务统计："))
+            .expect("stats block missing");
+        assert_eq!(stats_line, "[复制]  任务统计：⏱ 00:05");
+    }
+
+    #[test]
+    fn task_stats_line_detection_covers_all_languages_and_legacy_rows() {
+        use crate::widgets::state::is_task_stats_line;
+
+        assert!(is_task_stats_line("[copy]  Task stats:⏱ 01:05"));
+        assert!(is_task_stats_line("[复制]  任务统计：⏱ 01:05"));
+        // Rows persisted before the icon was removed still need `[copy]` support
+        // (legacy rows keep the button at the end).
+        assert!(is_task_stats_line("📊 任务统计：⏱ 01:05  [copy]"));
+        assert!(!is_task_stats_line("plain answer text"));
     }
 
     #[test]
@@ -2026,7 +2054,7 @@ mod lifecycle_tests {
         let stats_idx = app
             .raw_messages
             .iter()
-            .rposition(|l| l.contains("📊 任务统计："))
+            .rposition(|l| l.contains("Task stats:"))
             .expect("stats");
         app.copy_turn_ending_at_stats(stats_idx);
         let copy_notice = app.raw_messages.last().expect("copy notice");
@@ -2038,7 +2066,7 @@ mod lifecycle_tests {
         let start = app
             .raw_messages
             .iter()
-            .position(|l| l.contains("📊 任务统计："))
+            .position(|l| l.contains("Task stats:"))
             .expect("first stats")
             + 1;
         let mut expected_parts = Vec::new();

--- a/crates/tui/src/widgets/state/app/construct.rs
+++ b/crates/tui/src/widgets/state/app/construct.rs
@@ -62,6 +62,8 @@ impl App {
             input: String::new(),
             input_cursor: 0,
             input_scroll: 0,
+            pending_messages: Vec::new(),
+            pending_cancel_btn_area: ratatui::layout::Rect::default(),
             cmd_line: String::new(),
             model_context_window: 200_000,
             messages: Vec::new(),

--- a/crates/tui/src/widgets/state/app/messages.rs
+++ b/crates/tui/src/widgets/state/app/messages.rs
@@ -6,6 +6,7 @@ use ratatui::{
 use tact_llm::content::{ContentBlock, Message, MessageContent, Role};
 
 use crate::{
+    i18n::{Language, Messages},
     render::{cells::separator::is_task_end_separator, render_md::render_markdown_tui},
     widgets::state::{
         log_messages::{SystemMsgStyle, classify_system_message},
@@ -13,13 +14,35 @@ use crate::{
     },
 };
 
-/// Prefix for the per-turn stats row appended after each task-end separator.
-pub(crate) const TASK_STATS_PREFIX: &str = "📊 任务统计：";
-/// Clickable copy affordance appended to each task-stats row.
-pub(crate) const TASK_STATS_COPY_BTN: &str = "[copy]";
-
+/// Returns true for a per-turn stats row in any supported language, including
+/// the legacy `📊 任务统计：` rows persisted before the icon was removed (old
+/// sessions still need the `[copy]` affordance to keep working).
 pub(crate) fn is_task_stats_line(raw: &str) -> bool {
-    raw.starts_with(TASK_STATS_PREFIX)
+    // The copy affordance renders before the stats body; strip it (any
+    // language) before matching the prefix. Rows without a leading button
+    // (the legacy format) are matched as-is.
+    let body = Language::all()
+        .iter()
+        .filter_map(|lang| {
+            raw.strip_prefix(Messages::by_language(*lang).task_stats_copy_btn)
+                .map(str::trim_start)
+        })
+        .next()
+        .unwrap_or(raw);
+    Language::all()
+        .iter()
+        .any(|lang| body.starts_with(Messages::by_language(*lang).task_stats_prefix))
+        || body.starts_with("📊 任务统计：")
+}
+
+/// Byte range `(start, end)` of the clickable copy affordance in a task-stats
+/// raw row, or `None` when no localized button label is present.
+pub(crate) fn find_task_stats_copy_button(raw: &str) -> Option<(usize, usize)> {
+    Language::all().iter().find_map(|lang| {
+        let btn = Messages::by_language(*lang).task_stats_copy_btn;
+        let start = raw.find(btn)?;
+        Some((start, start + btn.len()))
+    })
 }
 
 impl App {
@@ -212,7 +235,7 @@ impl App {
 
         let mut parts = vec![format!("⏱ {mm_ss}")];
         if !self.status_bar.model_name.is_empty() {
-            parts.push(format!("🧠 {}", self.status_bar.model_name));
+            parts.push(self.status_bar.model_name.clone());
         }
         let tokens = self.status_bar.token_total;
         if tokens > 0 {
@@ -232,18 +255,20 @@ impl App {
             }
             parts.push(detail);
         }
-        let body = format!("{TASK_STATS_PREFIX}{}", parts.join(" · "));
-        let raw = format!("{body}  {TASK_STATS_COPY_BTN}");
+        let msgs = self.msgs();
+        let body = format!("{}{}", msgs.task_stats_prefix, parts.join(" · "));
+        let copy_btn = msgs.task_stats_copy_btn;
+        let raw = format!("{copy_btn}  {body}");
         let line = Line::from(vec![
-            Span::styled(body, Style::default().fg(self.theme.accent)),
-            Span::raw("  "),
             Span::styled(
-                TASK_STATS_COPY_BTN.to_string(),
+                copy_btn.to_string(),
                 Style::default()
                     .fg(self.theme.heading)
                     .add_modifier(Modifier::BOLD)
                     .add_modifier(Modifier::UNDERLINED),
             ),
+            Span::raw("  "),
+            Span::styled(body, Style::default().fg(self.theme.accent)),
         ]);
         self.append_msg(line, raw, RawMessageType::LLM);
         if self.input_mode == InputMode::Insert || self.input_mode == InputMode::Normal {

--- a/crates/tui/src/widgets/state/app/mod.rs
+++ b/crates/tui/src/widgets/state/app/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod agent;
 pub(crate) mod config;
 pub(crate) mod construct;
 pub(crate) mod messages;
+pub(crate) mod pending;
 pub(crate) mod popups;
 pub(crate) mod scroll;
 pub(crate) mod visibility;

--- a/crates/tui/src/widgets/state/app/pending.rs
+++ b/crates/tui/src/widgets/state/app/pending.rs
@@ -1,0 +1,53 @@
+//! Codex-style queued messages ("submit after next tool call").
+//!
+//! While the agent is busy (`Status::Planning` / `Status::Executing`), Enter
+//! no longer flashes a "still processing" message: the typed text is queued
+//! here, shown above the input box with a hint, and auto-submitted once the
+//! current task finishes. Esc interrupts the running task and submits the
+//! queue immediately (see `handlers::skills::interrupt_and_submit_pending`).
+
+use crate::widgets::state::App;
+
+/// A user message queued while the agent was busy.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingMessage {
+    /// Text shown in the pending block and later in the user bubble.
+    pub display: String,
+    /// Text dispatched to the agent as the `SubmitTask` payload.
+    pub agent_task: String,
+}
+
+impl App {
+    /// Append a message typed while the agent is busy.
+    pub(crate) fn queue_pending_message(&mut self, display: String, agent_task: String) {
+        self.pending_messages.push(PendingMessage {
+            display,
+            agent_task,
+        });
+        self.dirty = true;
+    }
+
+    /// Drop all queued messages (`/cancel` / Normal-mode `c`): cancel means
+    /// "cancel everything", unlike Esc which submits the queue immediately.
+    pub(crate) fn clear_pending_messages(&mut self) {
+        if !self.pending_messages.is_empty() {
+            self.pending_messages.clear();
+            self.dirty = true;
+        }
+    }
+
+    /// Record the `[Cancel]` button hit area (render-time; drops the queue
+    /// without touching the running task, see the mouse handler).
+    pub(crate) fn set_cancel_button_area(&mut self, area: ratatui::layout::Rect) {
+        self.pending_cancel_btn_area = area;
+    }
+
+    /// Display rows the pending block needs: one hint line plus one row per
+    /// queued message, capped so the log area is never starved.
+    pub(crate) fn pending_display_lines(&self) -> u16 {
+        if self.pending_messages.is_empty() {
+            return 0;
+        }
+        (1 + self.pending_messages.len()).min(4) as u16
+    }
+}

--- a/crates/tui/src/widgets/state/mod.rs
+++ b/crates/tui/src/widgets/state/mod.rs
@@ -42,6 +42,7 @@ pub(crate) use status_bar_state::StatusBarState;
 pub(crate) use stream_state::StreamState;
 
 pub(crate) use app::messages::{find_task_stats_copy_button, is_task_stats_line};
+pub(crate) use app::pending::PendingMessage;
 pub(crate) use task_dag::{DEFAULT_DAG_RENDER_WIDTH, TaskDagPopup, render_task_dag_lines};
 pub(crate) use task_panel::TaskPanelState;
 pub(crate) use thinking_state::{ActiveThinkingBlock, ThinkingBlock, ThinkingPopup, ThinkingState};
@@ -246,6 +247,12 @@ pub struct App {
     pub(crate) input: String,
     pub(crate) input_cursor: usize,
     pub(crate) input_scroll: u16,
+    /// Messages queued while the agent is busy (Codex-style "submit after the
+    /// current task"); auto-submitted on Idle/Done, or immediately on Esc.
+    pub(crate) pending_messages: Vec<PendingMessage>,
+    /// Hit area of the pending block's `[Cancel]` button (drops the queue
+    /// without touching the running task; `Rect::default()` = inactive).
+    pub(crate) pending_cancel_btn_area: ratatui::layout::Rect,
     pub(crate) cmd_line: String,
     /// Model context window in tokens (from agent config `model_context_window`).
     pub(crate) model_context_window: usize,

--- a/crates/tui/src/widgets/state/mod.rs
+++ b/crates/tui/src/widgets/state/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use slash_command::SlashCommandState;
 pub(crate) use status_bar_state::StatusBarState;
 pub(crate) use stream_state::StreamState;
 
-pub(crate) use app::messages::{TASK_STATS_COPY_BTN, is_task_stats_line};
+pub(crate) use app::messages::{find_task_stats_copy_button, is_task_stats_line};
 pub(crate) use task_dag::{DEFAULT_DAG_RENDER_WIDTH, TaskDagPopup, render_task_dag_lines};
 pub(crate) use task_panel::TaskPanelState;
 pub(crate) use thinking_state::{ActiveThinkingBlock, ThinkingBlock, ThinkingPopup, ThinkingState};

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -242,7 +242,7 @@ try_install_release() {
   asset_name="${BINARY_NAME}-v${version}-${triple}.tar.gz"
   url="https://github.com/${REPO}/releases/download/v${version}/${asset_name}"
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' RETURN
+  trap '[[ -n "${tmp:-}" ]] && rm -rf "$tmp"' RETURN
 
   log "Trying release asset: ${asset_name}"
   if ! curl -fsSL -o "${tmp}/${asset_name}" "$url"; then
@@ -317,7 +317,9 @@ ensure_path() {
 }
 
 main() {
-  local src_root="" work="" version="" triple=""
+  local src_root="" version="" triple=""
+  # Global so the EXIT trap can clean up the clone directory after `main` returns.
+  work=""
 
   if repo_root "$(pwd)"; then
     src_root="$(pwd)"


### PR DESCRIPTION
## Summary

- fix: plugin install dispatch, install.sh traps, and task-stats i18n
- fix(tui): don't paint whole-line code background on prose with inline code
- fix(tui): inline code uses accent text instead of a background patch
- feat(tui): Codex-style queued messages while the agent is busy
- fix: /stats responds immediately via shared stats snapshot (Arc<RwLock<SessionStats>>)
- chore: bump to v1.1.20 (Cargo.toml, Cargo.lock, README badge/tag example)

## Release

Version bumped to v1.1.20; after merge, tagging `v1.1.20` triggers `.github/workflows/release.yml` to publish pre-built binaries.