### PR TITLE
chore: bump to v1.1.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "tact-ui"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tact_llm"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "tool_refactor_macros"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.22"
+version = "1.1.23"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/language-Rust-orange?style=flat-square&logo=rust" alt="Rust" />
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License" />
-  <img src="https://img.shields.io/badge/version-1.1.22-blue?style=flat-square" alt="Version" />
+  <img src="https://img.shields.io/badge/version-1.1.23-blue?style=flat-square" alt="Version" />
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20WSL-lightgrey?style=flat-square" alt="Platform" />
   <a href="https://ko-fi.com/00x80">
     <img src="https://img.shields.io/badge/Ko--fi-Buy%20me%20a%20coffee-FF5E5B?style=flat-square&logo=ko-fi&logoColor=white" alt="Support on Ko-fi" />
@@ -123,8 +123,8 @@ cargo install --path crates/tact-ui   # or: cargo install -p tact-ui from the re
 **Binary releases:** push a version tag to publish pre-built binaries for Linux (x86_64 / ARM64), macOS (x86_64 / ARM64), and Windows (x86_64):
 
 ```bash
-git tag v1.1.22
-git push origin v1.1.22
+git tag v1.1.23
+git push origin v1.1.23
 ```
 
 GitHub Actions (`.github/workflows/release.yml`) uploads `tact-ui-v<version>-<target-triple>.tar.gz` / `.zip` plus `SHA256SUMS`.


### PR DESCRIPTION
## What

Release prep for **v1.1.23** — a patch release carrying the docs/CHM sync (#24091a40):

- Bump workspace version `1.1.22` → `1.1.23` in `Cargo.toml` (`[workspace.package]`)
- Sync `Cargo.lock` (`tact`, `tact-ui`, `tact_llm`, `tool_refactor_macros`)
- Update `README.md` version badge + tag instructions

## Release process

After merge, tag `v1.1.23` and push — `.github/workflows/release.yml` builds pre-built binaries for Linux/macOS/Windows and publishes the GitHub release.

## Changes since v1.1.22

- docs: sync CHM/mindmap TOC with current chapters (removed Ch 16 Cron / 20 LSP references, added Ch 26 Issue log + Quality group)