### PR TITLE
feat: route select requests through UiResponder + bump v1.1.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "tact"
-version = "1.1.24"
+version = "1.1.25"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "tact-ui"
-version = "1.1.24"
+version = "1.1.25"
 dependencies = [
  "anyhow",
  "base64",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "tact_llm"
-version = "1.1.24"
+version = "1.1.25"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "tool_refactor_macros"
-version = "1.1.24"
+version = "1.1.25"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.1.24"
+version = "1.1.25"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/language-Rust-orange?style=flat-square&logo=rust" alt="Rust" />
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License" />
-  <img src="https://img.shields.io/badge/version-1.1.24-blue?style=flat-square" alt="Version" />
+  <img src="https://img.shields.io/badge/version-1.1.25-blue?style=flat-square" alt="Version" />
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20WSL-lightgrey?style=flat-square" alt="Platform" />
   <a href="https://ko-fi.com/00x80">
     <img src="https://img.shields.io/badge/Ko--fi-Buy%20me%20a%20coffee-FF5E5B?style=flat-square&logo=ko-fi&logoColor=white" alt="Support on Ko-fi" />
@@ -123,8 +123,8 @@ cargo install --path crates/tact-ui   # or: cargo install -p tact-ui from the re
 **Binary releases:** push a version tag to publish pre-built binaries for Linux (x86_64 / ARM64), macOS (x86_64 / ARM64), and Windows (x86_64):
 
 ```bash
-git tag v1.1.24
-git push origin v1.1.24
+git tag v1.1.25
+git push origin v1.1.25
 ```
 
 GitHub Actions (`.github/workflows/release.yml`) uploads `tact-ui-v<version>-<target-triple>.tar.gz` / `.zip` plus `SHA256SUMS`.

--- a/book/25_chapter_protocol.md
+++ b/book/25_chapter_protocol.md
@@ -15,16 +15,17 @@ Related chapters: [Ch 18 Agent Loop](./18_chapter_agent_loop.md), [Ch 23 TUI](./
 graph LR
     Agent[Agent runtime] -->|AgentUpdate| TUI[TUI App]
     TUI -->|UserCommand| Driver[tact-ui driver]
+    TUI -->|UiResponse| Driver
     Account[account service] -->|AccountUpdate| TUI
 ```
 
 | Channel | Type | Direction | Purpose |
 |---------|------|-----------|---------|
-| `agent_tx` / `agent_rx` | `AgentUpdate` | Agent → TUI | Progress, streaming, metadata |
-| `user_cmd_tx` / `user_cmd_rx` | `UserCommand` | TUI → driver | Submit task, cancel, balance query |
+| `agent_tx` / `agent_rx` | `AgentUpdate` | Agent → TUI | Progress, streaming, metadata, select requests |
+| `user_cmd_tx` / `user_cmd_rx` | `UserCommand` | TUI → driver | Submit task, cancel, balance query, UI responses |
 | `account_tx` / `account_rx` | `AccountUpdate` | Account → TUI | Balance / quota (separate from agent protocol) |
 
-All three use `tokio::sync::mpsc::unbounded_channel`. `RequestSelect` embeds a `oneshot::Sender` for in-process request–response; it is not serializable and cannot be replayed from session storage.
+All channels use `tokio::sync::mpsc::unbounded_channel`. `AgentUpdate` is **pure data**: `RequestSelect` / `RequestMultiSelect` carry a `request_id` instead of an embedded `oneshot::Sender`, so the enum can be serialized / replayed. The TUI answers over the reverse channel by sending `UserCommand::UiResponse` back to the driver, which routes it through the runtime's shared [`UiResponder`] registry (`crates/tact/src/ui_responder.rs`) to the waiting caller (parent agent or subagent).
 
 ---
 
@@ -46,8 +47,8 @@ pub enum AgentUpdate {
     TokenUsage(TokenUsageInfo),
     ModelInfo(ModelCallParams),
     Info(String),
-    RequestSelect { prompt, options, respond, log_confirm }, // single; permission=`false`, ask_user=`true`
-    RequestMultiSelect { prompt, options, respond },         // multi; ask_user only (`multi_select`)
+    RequestSelect { request_id, prompt, options, log_confirm }, // single; permission=`false`, ask_user=`true`
+    RequestMultiSelect { request_id, prompt, options },          // multi; ask_user only (`multi_select`)
     StreamChunk(String),
     ThinkingChunk(ThinkingChunk),
     /// Persistent task list changed (`task_create` / `task_update`)
@@ -83,8 +84,20 @@ pub enum UserCommand {
     SubmitTask(String),
     Cancel,
     QueryBalance,
+    UiResponse(UiResponse), // answer to a RequestSelect / RequestMultiSelect
 }
 ```
+
+### `UiResponse`
+
+```rust
+pub enum UiResponse {
+    Select { request_id, choice: Option<usize> },
+    MultiSelect { request_id, choices: Option<Vec<usize>> },
+}
+```
+
+`UiResponse` is the reverse message answering a select request. It carries the request's `request_id` so the runtime can route it to the exact waiter. The driver receives it on `user_cmd_rx`, never awaits the in-flight task, and hands it to the shared `UiResponder::handle_response`, which fires the pending waiter for that id (parent or subagent).
 
 ### `PlanStep`
 
@@ -297,7 +310,7 @@ stateDiagram-v2
 
     note right of Select
         Arrives while Status = Executing.
-        respond: oneshot::Sender → tool_dispatch
+        request_id → UiResponse on the reverse command channel
     end note
 ```
 
@@ -327,7 +340,7 @@ stateDiagram-v2
 |----------|----------|------------------|
 | **Content-producing** | `StepAdded`, `StepStarted`, `StepFinished`, `StepFailed`, `StreamChunk`, `ThinkingChunk`, `Info`, `TaskComplete`, `TaskCancelled`, `Error`, `RequestSelect`, `TasksChanged` | Prefer `ThinkingChunk::Finished` to close thinking; safety-flush on other content updates; remove loading placeholder; mutate log / plan |
 | **Metadata-only** | `TokenUsage(TokenUsageInfo)`, `ModelInfo(ModelCallParams)` | Update status bar only; keep loading placeholder; **do not** close an open thinking region |
-| **Request–response** | `RequestSelect { respond }` | Blocks on user choice via oneshot channel |
+| **Request–response** | `RequestSelect { request_id }`, `RequestMultiSelect { request_id }` | Blocks on user choice via the shared `UiResponder` (reverse `UiResponse`) |
 
 Thinking lifecycle is explicit: `ThinkingChunk::Started` opens the region, `Delta` appends text, `Finished` flushes and collapses. As a safety net, content-producing non-thinking updates still call `flush_and_close_thinking()` if a region is still open. `TokenUsage` / `ModelInfo` never close thinking (they may arrive mid-stream).
 
@@ -397,10 +410,11 @@ sequenceDiagram
     Agent->>TUI: StepStarted
 
     opt permission Ask
-        Agent->>TUI: RequestSelect
+        Agent->>TUI: RequestSelect (request_id)
         TUI->>TUI: InputMode → Select
         User->>TUI: pick option
-        TUI->>Agent: oneshot response
+        TUI->>Driver: UserCommand::UiResponse
+        Driver->>Agent: UiResponder::handle_response
     end
 
     Agent->>TUI: StepFinished | StepFailed

--- a/book/25_chapter_protocol.md
+++ b/book/25_chapter_protocol.md
@@ -25,7 +25,7 @@ graph LR
 | `user_cmd_tx` / `user_cmd_rx` | `UserCommand` | TUI → driver | Submit task, cancel, balance query, UI responses |
 | `account_tx` / `account_rx` | `AccountUpdate` | Account → TUI | Balance / quota (separate from agent protocol) |
 
-All channels use `tokio::sync::mpsc::unbounded_channel`. `AgentUpdate` is **pure data**: `RequestSelect` / `RequestMultiSelect` carry a `request_id` instead of an embedded `oneshot::Sender`, so the enum can be serialized / replayed. The TUI answers over the reverse channel by sending `UserCommand::UiResponse` back to the driver, which routes it through the runtime's shared [`UiResponder`] registry (`crates/tact/src/ui_responder.rs`) to the waiting caller (parent agent or subagent).
+All channels use `tokio::sync::mpsc::unbounded_channel`. `AgentUpdate` is **pure data**: `RequestSelect` / `RequestMultiSelect` carry a `request_id` instead of an embedded `oneshot::Sender`, so the enum no longer carries a transport handle (and is free to derive `Serialize`/`Clone` later). The TUI answers over the reverse channel by sending `UserCommand::UiResponse` back to the driver, which routes it through the runtime's shared [`UiResponder`] registry (`crates/tact/src/ui_responder.rs`) to the waiting caller (parent agent or subagent).
 
 ---
 

--- a/book/25_chapter_protocol_zh.md
+++ b/book/25_chapter_protocol_zh.md
@@ -26,7 +26,7 @@ graph LR
 | `user_cmd_tx` / `user_cmd_rx` | `UserCommand` | TUI → driver | 提交任务、取消、余额查询、UI 响应 |
 | `account_tx` / `account_rx` | `AccountUpdate` | Account → TUI | 余额 / 配额（与 agent 协议分离） |
 
-所有通道均用 `tokio::sync::mpsc::unbounded_channel`。`AgentUpdate` 是**纯数据**：`RequestSelect` / `RequestMultiSelect` 携带 `request_id` 而非内嵌的 `oneshot::Sender`，因此该 enum 可序列化 / 重放。TUI 通过反向通道发送 `UserCommand::UiResponse` 回 driver，driver 再经运行时共享的 [`UiResponder`] 注册表（`crates/tact/src/ui_responder.rs`）路由给等待中的调用方（父 agent 或 subagent）。
+所有通道均用 `tokio::sync::mpsc::unbounded_channel`。`AgentUpdate` 是**纯数据**：`RequestSelect` / `RequestMultiSelect` 携带 `request_id` 而非内嵌的 `oneshot::Sender`，因此该 enum 不再携带传输句柄（后续可自由派生 `Serialize`/`Clone`）。TUI 通过反向通道发送 `UserCommand::UiResponse` 回 driver，driver 再经运行时共享的 [`UiResponder`] 注册表（`crates/tact/src/ui_responder.rs`）路由给等待中的调用方（父 agent 或 subagent）。
 
 ---
 

--- a/book/25_chapter_protocol_zh.md
+++ b/book/25_chapter_protocol_zh.md
@@ -16,16 +16,17 @@
 graph LR
     Agent[Agent runtime] -->|AgentUpdate| TUI[TUI App]
     TUI -->|UserCommand| Driver[tact-ui driver]
+    TUI -->|UiResponse| Driver
     Account[account service] -->|AccountUpdate| TUI
 ```
 
 | Channel | 类型 | 方向 | 用途 |
 |---------|------|------|------|
-| `agent_tx` / `agent_rx` | `AgentUpdate` | Agent → TUI | 进度、流式、元数据 |
-| `user_cmd_tx` / `user_cmd_rx` | `UserCommand` | TUI → driver | 提交任务、取消、余额查询 |
+| `agent_tx` / `agent_rx` | `AgentUpdate` | Agent → TUI | 进度、流式、元数据、选择请求 |
+| `user_cmd_tx` / `user_cmd_rx` | `UserCommand` | TUI → driver | 提交任务、取消、余额查询、UI 响应 |
 | `account_tx` / `account_rx` | `AccountUpdate` | Account → TUI | 余额 / 配额（与 agent 协议分离） |
 
-三者均用 `tokio::sync::mpsc::unbounded_channel`。`RequestSelect` 嵌入 `oneshot::Sender` 做进程内请求–响应；不可序列化，无法从 session 存储重放。
+所有通道均用 `tokio::sync::mpsc::unbounded_channel`。`AgentUpdate` 是**纯数据**：`RequestSelect` / `RequestMultiSelect` 携带 `request_id` 而非内嵌的 `oneshot::Sender`，因此该 enum 可序列化 / 重放。TUI 通过反向通道发送 `UserCommand::UiResponse` 回 driver，driver 再经运行时共享的 [`UiResponder`] 注册表（`crates/tact/src/ui_responder.rs`）路由给等待中的调用方（父 agent 或 subagent）。
 
 ---
 
@@ -47,8 +48,8 @@ pub enum AgentUpdate {
     TokenUsage(TokenUsageInfo),
     ModelInfo(ModelCallParams),
     Info(String),
-    RequestSelect { prompt, options, respond, log_confirm }, // 单选；permission=`false`，ask_user=`true`
-    RequestMultiSelect { prompt, options, respond },         // 多选；仅 ask_user（`multi_select`）
+    RequestSelect { request_id, prompt, options, log_confirm }, // 单选；permission=`false`，ask_user=`true`
+    RequestMultiSelect { request_id, prompt, options },          // 多选；仅 ask_user（`multi_select`）
     StreamChunk(String),
     ThinkingChunk(ThinkingChunk),
     /// 持久任务列表变更（`task_create` / `task_update`）
@@ -82,8 +83,20 @@ pub enum UserCommand {
     SubmitTask(String),
     Cancel,
     QueryBalance,
+    UiResponse(UiResponse), // 回答 RequestSelect / RequestMultiSelect
 }
 ```
+
+### `UiResponse`
+
+```rust
+pub enum UiResponse {
+    Select { request_id, choice: Option<usize> },
+    MultiSelect { request_id, choices: Option<Vec<usize>> },
+}
+```
+
+`UiResponse` 是回答选择请求的反向消息，携带请求的 `request_id`，以便运行时路由到精确的等待方。driver 在 `user_cmd_rx` 上收到它，**不**等待 in-flight 任务，直接交给共享的 `UiResponder::handle_response`，由其按 id 触发等待方（父 agent 或 subagent）。
 
 ### `PlanStep`
 
@@ -294,7 +307,7 @@ stateDiagram-v2
 
     note right of Select
         到达时 Status = Executing。
-        respond: oneshot::Sender → tool_dispatch
+        request_id → 反向命令通道上的 UiResponse
     end note
 ```
 
@@ -324,7 +337,7 @@ stateDiagram-v2
 |------|----------|------------|
 | **内容产出** | `StepAdded`、`StepStarted`、`StepFinished`、`StepFailed`、`StreamChunk`、`ThinkingChunk`、`Info`、`TaskComplete`、`TaskCancelled`、`Error`、`RequestSelect`、`TasksChanged` | 优先 `ThinkingChunk::Finished` 关闭 thinking；其他内容更新上 safety-flush；移除 loading placeholder；变更 log / plan |
 | **仅元数据** | `TokenUsage(TokenUsageInfo)`、`ModelInfo(ModelCallParams)` | 仅更新状态栏；保留 loading placeholder；**不**关闭已开 thinking 区域 |
-| **请求–响应** | `RequestSelect { respond }` | 经 oneshot channel 阻塞等待用户选择 |
+| **请求–响应** | `RequestSelect { request_id }`、`RequestMultiSelect { request_id }` | 经共享 `UiResponder`（反向 `UiResponse`）阻塞等待用户选择 |
 
 Thinking 生命周期显式：`ThinkingChunk::Started` 打开区域，`Delta` 追加文本，`Finished` flush 并折叠。安全网：其他内容产出非 thinking 更新仍会在区域仍开时调用 `flush_and_close_thinking()`。`TokenUsage` / `ModelInfo` 从不关闭 thinking（可能 mid-stream 到达）。
 
@@ -394,10 +407,11 @@ sequenceDiagram
     Agent->>TUI: StepStarted
 
     opt permission Ask
-        Agent->>TUI: RequestSelect
+        Agent->>TUI: RequestSelect (request_id)
         TUI->>TUI: InputMode → Select
         User->>TUI: 选择选项
-        TUI->>Agent: oneshot response
+        TUI->>Driver: UserCommand::UiResponse
+        Driver->>Agent: UiResponder::handle_response
     end
 
     Agent->>TUI: StepFinished | StepFailed

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -29,6 +29,21 @@ Newest entries first. Each entry should include:
 
 ---
 
+## 1. 2026-08-24 — `AgentUpdate` drops the embedded oneshot; select requests use `request_id` + `UiResponse`
+
+| Field | Value |
+|-------|-------|
+| **Type** | optimization |
+| **Related** | `crates/protocol/src/agent.rs`, `crates/tact/src/ui_responder.rs` (new), `crates/tact/src/tool/ask_user.rs`, `crates/tact/src/tool/subagent_ui.rs`, `crates/tact/src/agent/tool_dispatch.rs`, `crates/tact-ui/src/driver.rs`, `crates/agent_tui_kit/src/state/select_popup.rs`, `crates/tui/src/handlers/select.rs`; Ch 25 |
+
+**Symptom / motivation:** `AgentUpdate::RequestSelect` / `RequestMultiSelect` embedded a `tokio::sync::oneshot::Sender`, coupling the protocol enum to an in-process transport handle. The enum could not derive `Clone`/`Serialize`, each request had exactly one in-process responder, and every new "ask the UI" shape would need its own variant carrying a sender.
+
+**Decision:** requests carry a pure-data `request_id: u64`; the TUI answers over the reverse channel with `UserCommand::UiResponse` (`Select` / `MultiSelect`). A new shared `UiResponder` allocates globally-unique ids and routes responses to the exact waiter. Parent and subagents clone the same inner state, so a subagent request forwarded through the parent's tagged channel still resolves. The driver handles `UiResponse` without awaiting the in-flight task and calls `UiResponder::shutdown` on exit so a vanished UI unblocks any waiter.
+
+**Behavior after:** `AgentUpdate` is serializable / replayable transport data; select responses route by `request_id` across the parent and all subagents; a closed UI unblocks the agent loop instead of deadlocking it.
+
+---
+
 ## 1. 2026-08-24 — Plugin update command: `tact plugin update` / `/plugin update`
 
 | Field | Value |

--- a/book/26_chapter_issue.md
+++ b/book/26_chapter_issue.md
@@ -40,7 +40,7 @@ Newest entries first. Each entry should include:
 
 **Decision:** requests carry a pure-data `request_id: u64`; the TUI answers over the reverse channel with `UserCommand::UiResponse` (`Select` / `MultiSelect`). A new shared `UiResponder` allocates globally-unique ids and routes responses to the exact waiter. Parent and subagents clone the same inner state, so a subagent request forwarded through the parent's tagged channel still resolves. The driver handles `UiResponse` without awaiting the in-flight task and calls `UiResponder::shutdown` on exit so a vanished UI unblocks any waiter.
 
-**Behavior after:** `AgentUpdate` is serializable / replayable transport data; select responses route by `request_id` across the parent and all subagents; a closed UI unblocks the agent loop instead of deadlocking it.
+**Behavior after:** `AgentUpdate` is transport-agnostic data (no embedded handle; free to derive `Serialize`/`Clone` later); select responses route by `request_id` across the parent and all subagents; a closed UI unblocks the agent loop instead of deadlocking it.
 
 ---
 

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -40,7 +40,7 @@
 
 **决策：** 请求改为携带纯数据 `request_id: u64`；TUI 通过反向通道用 `UserCommand::UiResponse`（`Select` / `MultiSelect`）作答。新增共享的 `UiResponder` 分配全局唯一 id 并把响应路由到精确的等待方；父 agent 与每个 subagent 克隆同一 inner 状态，因此 subagent 经父 tagged 通道转发的请求仍能正确路由。driver 处理 `UiResponse` 时不等待 in-flight 任务，退出时调用 `UiResponder::shutdown`，使 UI 关闭时仍能唤醒等待方。
 
-**改动后行为：** `AgentUpdate` 变为可序列化 / 可重放的传输数据；选择响应按 `request_id` 跨父 agent 与所有 subagent 路由；UI 关闭时 agent 循环被唤醒而非死锁。
+**改动后行为：** `AgentUpdate` 变为不携带传输句柄的数据（后续可自由派生 `Serialize`/`Clone`）；选择响应按 `request_id` 跨父 agent 与所有 subagent 路由；UI 关闭时 agent 循环被唤醒而非死锁。
 
 ---
 

--- a/book/26_chapter_issue_zh.md
+++ b/book/26_chapter_issue_zh.md
@@ -29,6 +29,21 @@
 
 ---
 
+## 1. 2026-08-24 — `AgentUpdate` 移除内嵌 oneshot；选择请求改用 `request_id` + `UiResponse`
+
+| Field | Value |
+|-------|-------|
+| **类型** | optimization |
+| **相关** | `crates/protocol/src/agent.rs`、`crates/tact/src/ui_responder.rs`（新增）、`crates/tact/src/tool/ask_user.rs`、`crates/tact/src/tool/subagent_ui.rs`、`crates/tact/src/agent/tool_dispatch.rs`、`crates/tact-ui/src/driver.rs`、`crates/agent_tui_kit/src/state/select_popup.rs`、`crates/tui/src/handlers/select.rs`；Ch 25 |
+
+**症状 / 动机：** `AgentUpdate::RequestSelect` / `RequestMultiSelect` 内嵌了 `tokio::sync::oneshot::Sender`，把协议 enum 耦合到了进程内传输句柄。该 enum 无法派生 `Clone`/`Serialize`，每个请求只有一个进程内响应者，且每新增一种「向 UI 提问」都需要一个携带 sender 的新变体。
+
+**决策：** 请求改为携带纯数据 `request_id: u64`；TUI 通过反向通道用 `UserCommand::UiResponse`（`Select` / `MultiSelect`）作答。新增共享的 `UiResponder` 分配全局唯一 id 并把响应路由到精确的等待方；父 agent 与每个 subagent 克隆同一 inner 状态，因此 subagent 经父 tagged 通道转发的请求仍能正确路由。driver 处理 `UiResponse` 时不等待 in-flight 任务，退出时调用 `UiResponder::shutdown`，使 UI 关闭时仍能唤醒等待方。
+
+**改动后行为：** `AgentUpdate` 变为可序列化 / 可重放的传输数据；选择响应按 `request_id` 跨父 agent 与所有 subagent 路由；UI 关闭时 agent 循环被唤醒而非死锁。
+
+---
+
 ## 1. 2026-08-24 — 插件更新命令：`tact plugin update` / `/plugin update`
 
 | Field | Value |

--- a/crates/agent_tui_kit/src/bridge.rs
+++ b/crates/agent_tui_kit/src/bridge.rs
@@ -75,6 +75,9 @@ impl TryFrom<UserCommand> for Command {
             UserCommand::SetReasoningEffort(effort) => Ok(Self::SetReasoningEffort(effort)),
             UserCommand::SetModel(model) => Ok(Self::SetModel(model)),
             UserCommand::QueryBalance => Err(()),
+            // Responses to agent-originated selects flow on the reverse command
+            // channel; they are not host commands and never map to `Command`.
+            UserCommand::UiResponse(_) => Err(()),
         }
     }
 }

--- a/crates/agent_tui_kit/src/state/select_popup.rs
+++ b/crates/agent_tui_kit/src/state/select_popup.rs
@@ -1,4 +1,9 @@
-/// Select popup state: independently manages prompt, options, selected index, and response channel.
+/// Select popup state: independently manages prompt, options, selected index,
+/// and the request id used to answer agent-originated requests.
+///
+/// The popup no longer holds a oneshot sender. Agent-originated selects carry a
+/// `request_id`; confirming or cancelling produces a [`tact_protocol::UiResponse`]
+/// that the caller (the TUI) sends over the reverse command channel.
 pub struct SelectPopup {
     /// Popup prompt text.
     pub prompt: String,
@@ -6,10 +11,9 @@ pub struct SelectPopup {
     pub options: Vec<String>,
     /// Index of the currently focused option (cursor).
     pub selected: usize,
-    /// Response channel for single-select (permission / default ask_user).
-    pub respond: Option<tokio::sync::oneshot::Sender<Option<usize>>>,
-    /// Response channel for multi-select (`ask_user` with `multi_select`).
-    pub respond_multi: Option<tokio::sync::oneshot::Sender<Option<Vec<usize>>>>,
+    /// Request id for agent-originated selects (`RequestSelect` /
+    /// `RequestMultiSelect`); `None` for local TUI flows like `/model`.
+    pub request_id: Option<u64>,
     /// When true, Space toggles checkboxes; Enter submits all checked indices.
     pub multi: bool,
     /// Checkbox state per option (only used when `multi`).
@@ -25,8 +29,7 @@ impl Default for SelectPopup {
             prompt: String::new(),
             options: Vec::new(),
             selected: 0,
-            respond: None,
-            respond_multi: None,
+            request_id: None,
             multi: false,
             checked: Vec::new(),
             log_confirm: true,
@@ -35,12 +38,7 @@ impl Default for SelectPopup {
 }
 
 impl SelectPopup {
-    fn clear_channels(&mut self) {
-        self.respond = None;
-        self.respond_multi = None;
-    }
-
-    /// Set popup content without a oneshot channel (local TUI flows like `/model`).
+    /// Set popup content without a request id (local TUI flows like `/model`).
     pub fn set_local(
         &mut self,
         prompt: String,
@@ -51,25 +49,24 @@ impl SelectPopup {
         self.prompt = prompt;
         self.options = options;
         self.selected = selected.min(self.options.len().saturating_sub(1));
-        self.clear_channels();
+        self.request_id = None;
         self.multi = false;
         self.checked.clear();
         self.log_confirm = log_confirm;
     }
 
-    /// Single-select popup (permission / default ask_user). Unchanged contract.
+    /// Single-select popup (permission / default ask_user).
     pub fn set(
         &mut self,
         prompt: String,
         options: Vec<String>,
-        respond: tokio::sync::oneshot::Sender<Option<usize>>,
+        request_id: u64,
         log_confirm: bool,
     ) {
         self.prompt = prompt;
         self.options = options;
         self.selected = 0;
-        self.respond = Some(respond);
-        self.respond_multi = None;
+        self.request_id = Some(request_id);
         self.multi = false;
         self.checked.clear();
         self.log_confirm = log_confirm;
@@ -80,58 +77,61 @@ impl SelectPopup {
         &mut self,
         prompt: String,
         options: Vec<String>,
-        respond: tokio::sync::oneshot::Sender<Option<Vec<usize>>>,
+        request_id: u64,
         log_confirm: bool,
     ) {
         let n = options.len();
         self.prompt = prompt;
         self.options = options;
         self.selected = 0;
-        self.respond = None;
-        self.respond_multi = Some(respond);
+        self.request_id = Some(request_id);
         self.multi = true;
         self.checked = vec![false; n];
         self.log_confirm = log_confirm;
     }
 
-    /// Confirm single-select: send the focused index. No-op for multi (use [`confirm_multi`]).
+    /// Consume and return the pending request id, if this was agent-originated.
+    pub fn take_request_id(&mut self) -> Option<u64> {
+        self.request_id.take()
+    }
+
+    /// Focused index for single-select (no side effects). No-op for multi.
     pub fn confirm(&mut self) -> Option<usize> {
         if self.multi {
             return None;
         }
-        let respond = self.respond.take();
-        let idx = self.selected.min(self.options.len().saturating_sub(1));
-        if let Some(tx) = respond {
-            let _ = tx.send(Some(idx));
-        }
-        Some(idx)
+        Some(self.selected.min(self.options.len().saturating_sub(1)))
     }
 
-    /// Confirm multi-select: send all checked indices (may be empty).
+    /// All checked indices for multi-select (may be empty).
     pub fn confirm_multi(&mut self) -> Vec<usize> {
-        let idxs: Vec<usize> = self
-            .checked
+        self.checked
             .iter()
             .enumerate()
             .filter_map(|(i, on)| on.then_some(i))
-            .collect();
-        if let Some(tx) = self.respond_multi.take() {
-            let _ = tx.send(Some(idxs.clone()));
-        }
-        self.respond = None;
-        idxs
+            .collect()
     }
 
-    /// Cancel selection: send None on the active channel.
-    pub fn cancel(&mut self) {
-        if let Some(tx) = self.respond.take() {
-            let _ = tx.send(None);
-        }
-        if let Some(tx) = self.respond_multi.take() {
-            let _ = tx.send(None);
-        }
+    /// Build the cancellation response for an agent-originated request, if any.
+    /// Resets multi/checked state. Returns `None` for local flows.
+    pub fn cancel(&mut self) -> Option<tact_protocol::UiResponse> {
+        let request_id = self.request_id.take();
+        let response = request_id.map(|id| {
+            if self.multi {
+                tact_protocol::UiResponse::MultiSelect {
+                    request_id: id,
+                    choices: None,
+                }
+            } else {
+                tact_protocol::UiResponse::Select {
+                    request_id: id,
+                    choice: None,
+                }
+            }
+        });
         self.multi = false;
         self.checked.clear();
+        response
     }
 
     pub fn toggle_checked(&mut self) {

--- a/crates/protocol/src/agent.rs
+++ b/crates/protocol/src/agent.rs
@@ -249,8 +249,8 @@ pub enum AgentUpdate {
     ///
     /// The request carries a unique `request_id`; the TUI answers over the
     /// reverse [`UserCommand::UiResponse`] channel rather than an in-message
-    /// oneshot sender, so [`AgentUpdate`] stays pure data (serializable /
-    /// replayable / transport-agnostic).
+    /// oneshot sender, so [`AgentUpdate`] no longer carries a transport handle
+    /// (pure data, transport-agnostic).
     RequestSelect {
         request_id: u64,
         prompt: String,

--- a/crates/protocol/src/agent.rs
+++ b/crates/protocol/src/agent.rs
@@ -9,7 +9,6 @@
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::oneshot;
 
 use crate::tool_output::ToolOutputChunk;
 
@@ -247,10 +246,15 @@ pub enum AgentUpdate {
 
     /// Request user to choose **one** option; returns option index (None = cancelled).
     /// Used by permission prompts and single-choice `ask_user`.
+    ///
+    /// The request carries a unique `request_id`; the TUI answers over the
+    /// reverse [`UserCommand::UiResponse`] channel rather than an in-message
+    /// oneshot sender, so [`AgentUpdate`] stays pure data (serializable /
+    /// replayable / transport-agnostic).
     RequestSelect {
+        request_id: u64,
         prompt: String,
         options: Vec<String>,
-        respond: oneshot::Sender<Option<usize>>,
         /// When true, TUI appends a "Selected: …" system line after confirm.
         /// Permission prompts keep this `false` (choice already shown on the tool meta row).
         log_confirm: bool,
@@ -258,9 +262,9 @@ pub enum AgentUpdate {
     /// Request user to choose **zero or more** options (Space toggles, Enter confirms).
     /// Used by `ask_user` when `multi_select` is true. Does not affect [`RequestSelect`].
     RequestMultiSelect {
+        request_id: u64,
         prompt: String,
         options: Vec<String>,
-        respond: oneshot::Sender<Option<Vec<usize>>>,
     },
     /// Streaming output text fragment (appended to Log in real time)
     StreamChunk(String),
@@ -309,6 +313,37 @@ pub enum ThinkingChunk {
     Finished,
 }
 
+/// Response to a UI request, sent from the TUI back to the agent runtime over
+/// the reverse channel ([`UserCommand::UiResponse`]).
+///
+/// Carries the [`AgentUpdate::RequestSelect`] / [`AgentUpdate::RequestMultiSelect`]
+/// `request_id` so the runtime can route it to the waiting caller. Keeping this
+/// separate from the request enum (rather than embedding a oneshot sender) is
+/// what lets [`AgentUpdate`] stay pure data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UiResponse {
+    /// Answer a single-choice request; `choice` is `None` when cancelled.
+    Select {
+        request_id: u64,
+        choice: Option<usize>,
+    },
+    /// Answer a multi-choice request; `choices` is `None` when cancelled.
+    MultiSelect {
+        request_id: u64,
+        choices: Option<Vec<usize>>,
+    },
+}
+
+impl UiResponse {
+    /// The request this response answers.
+    pub fn request_id(&self) -> u64 {
+        match self {
+            UiResponse::Select { request_id, .. } => *request_id,
+            UiResponse::MultiSelect { request_id, .. } => *request_id,
+        }
+    }
+}
+
 /// User commands sent from the TUI to the Agent.
 #[derive(Debug)]
 pub enum UserCommand {
@@ -347,6 +382,9 @@ pub enum UserCommand {
     /// Set the active agent session's model (per-agent, not global).
     /// The TUI sends this after `/model` model confirmation.
     SetModel(String),
+    /// Answer a pending [`AgentUpdate::RequestSelect`] / [`RequestMultiSelect`]
+    /// (see [`UiResponse`]). Routed by the driver to the shared responder.
+    UiResponse(UiResponse),
 }
 
 /// A single step in the execution plan.

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -13,7 +13,7 @@ pub mod tool_output;
 pub use agent::{
     AgentErrorKind, AgentUpdate, ModelCallParams, PlanStep, StepResult, StepStatus, TaskSnapshot,
     TaskStatusSnapshot, TasksChangeReason, ThinkingChunk, TokenUsageInfo, ToolDetailKind,
-    ToolPopupKind, ToolPresentationInfo, ToolVisualKind, UserCommand,
+    ToolPopupKind, ToolPresentationInfo, ToolVisualKind, UiResponse, UserCommand,
 };
 pub use biz::{
     AccountError, AccountUpdate, BalanceEntry, BalanceInfo, UsageQuotaInfo, UsageQuotaWindow,

--- a/crates/tact-ui/src/driver.rs
+++ b/crates/tact-ui/src/driver.rs
@@ -42,6 +42,9 @@ pub async fn run_command_loop_with_account(
     // Shared stats snapshot: QueryStats can read it without awaiting the
     // in-flight task (the Agent itself is exclusively owned by that task).
     let stats = agent.runtime.stats.clone();
+    // Shared UI responder: routes TUI select responses to the waiter (parent
+    // or subagent) even while the Agent is owned by the in-flight task.
+    let ui_responder = agent.tool_context.ui_responder.clone();
 
     let mut agent = Some(agent);
     let mut active: Option<JoinHandle<Agent>> = None;
@@ -50,6 +53,11 @@ pub async fn run_command_loop_with_account(
         reap_finished_task(&mut agent, &mut active).await;
 
         match cmd {
+            UserCommand::UiResponse(response) => {
+                // Never await the in-flight task: the agent may be blocked
+                // waiting for exactly this answer.
+                ui_responder.handle_response(response);
+            }
             UserCommand::Cancel => {
                 cancel_flag.store(true, Ordering::Relaxed);
                 if let Some(tx) = &ui_tx {
@@ -94,6 +102,10 @@ pub async fn run_command_loop_with_account(
             }
         }
     }
+
+    // The UI is gone: unblock any in-flight select waiter so the task can
+    // finish instead of deadlocking on an answer that will never arrive.
+    ui_responder.shutdown();
 
     if let Some(handle) = active.take() {
         agent = Some(handle.await.expect("final task join panicked"));

--- a/crates/tact-ui/src/headless.rs
+++ b/crates/tact-ui/src/headless.rs
@@ -101,6 +101,7 @@ async fn run_headless_locked(
         teammate_manager,
         worktree_manager,
         ui_tx: None,
+        ui_responder: tact::ui_responder::UiResponder::new(),
         progress_reporter: tact::tool::ToolProgressReporter::default(),
         cancel_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         bash_timeout_secs: tact::config::settings().tools.bash_timeout_secs,

--- a/crates/tact-ui/src/headless_session.rs
+++ b/crates/tact-ui/src/headless_session.rs
@@ -64,7 +64,10 @@ where
     setup(&work_dir);
 
     let (user_cmd_tx, user_cmd_rx) = user_command_channels();
-    let mut app = HeadlessApp::new(agent_rx, work_dir.clone()).with_auto_select(permission_choice);
+    let ui_responder = agent.tool_context.ui_responder.clone();
+    let mut app = HeadlessApp::new(agent_rx, work_dir.clone())
+        .with_auto_select(permission_choice)
+        .with_ui_responder(ui_responder);
     if capture_frames {
         app = app.with_frame_capture();
     }

--- a/crates/tact-ui/src/interactive.rs
+++ b/crates/tact-ui/src/interactive.rs
@@ -121,6 +121,7 @@ async fn run_interactive_locked(
         teammate_manager,
         worktree_manager,
         ui_tx: Some(agent_tx.clone()),
+        ui_responder: tact::ui_responder::UiResponder::new(),
         progress_reporter: tact::tool::ToolProgressReporter::default(),
         cancel_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         bash_timeout_secs: tact::config::settings().tools.bash_timeout_secs,

--- a/crates/tact-ui/tests/harness/mod.rs
+++ b/crates/tact-ui/tests/harness/mod.rs
@@ -8,7 +8,7 @@ use std::sync::{
 
 use tact::permission::PermissionMode;
 use tact_llm::{ContentBlock, MockClient, StopReason};
-use tact_protocol::{AgentUpdate, TokenUsageInfo, UserCommand};
+use tact_protocol::{AgentUpdate, TokenUsageInfo, UiResponse, UserCommand};
 use tact_ui::{
     driver::run_command_loop,
     test_support::{
@@ -79,18 +79,22 @@ pub fn sample_token_usage() -> TokenUsageInfo {
 pub fn wire_permission_responder(
     agent_rx: UnboundedReceiver<AgentUpdate>,
     choice: Option<usize>,
+    ui_responder: tact::ui_responder::UiResponder,
 ) -> UnboundedReceiver<AgentUpdate> {
     let (collect_tx, collect_rx) = unbounded_channel();
     tokio::spawn(async move {
         let mut agent_rx = agent_rx;
         while let Some(update) = agent_rx.recv().await {
             match update {
-                AgentUpdate::RequestSelect { respond, .. } => {
-                    let _ = respond.send(choice);
+                AgentUpdate::RequestSelect { request_id, .. } => {
+                    ui_responder.handle_response(UiResponse::Select { request_id, choice });
                 }
-                AgentUpdate::RequestMultiSelect { respond, .. } => {
+                AgentUpdate::RequestMultiSelect { request_id, .. } => {
                     // Map single harness choice → one-element multi selection (or cancel).
-                    let _ = respond.send(choice.map(|i| vec![i]));
+                    ui_responder.handle_response(UiResponse::MultiSelect {
+                        request_id,
+                        choices: choice.map(|i| vec![i]),
+                    });
                 }
                 other => {
                     let _ = collect_tx.send(other);
@@ -130,8 +134,9 @@ pub async fn run_single_task_with_permission_choice(
 ) -> (Vec<AgentUpdate>, std::path::PathBuf) {
     install_test_config();
     let (agent_tx, agent_rx) = unbounded_channel();
-    let collect_rx = wire_permission_responder(agent_rx, permission_choice);
     let (agent, work_dir) = build_test_agent_with_mode(mock, Some(agent_tx), permission_mode);
+    let ui_responder = agent.tool_context.ui_responder.clone();
+    let collect_rx = wire_permission_responder(agent_rx, permission_choice, ui_responder);
     setup(&work_dir);
     let (user_cmd_tx, user_cmd_rx) = user_command_channels();
 
@@ -157,9 +162,10 @@ pub async fn run_single_task_with_mcp(
 ) -> (Vec<AgentUpdate>, std::path::PathBuf) {
     install_test_config();
     let (agent_tx, agent_rx) = unbounded_channel();
-    let collect_rx = wire_permission_responder(agent_rx, permission_choice);
     let (agent, work_dir) =
         build_test_agent_with_mcp(mock, Some(agent_tx), permission_mode, mcp_router);
+    let ui_responder = agent.tool_context.ui_responder.clone();
+    let collect_rx = wire_permission_responder(agent_rx, permission_choice, ui_responder);
     let (user_cmd_tx, user_cmd_rx) = user_command_channels();
 
     let driver = tokio::spawn(run_command_loop(agent, user_cmd_rx, work_dir.clone()));
@@ -183,9 +189,10 @@ pub async fn run_single_task_with_config(
     setup: impl FnOnce(&std::path::Path),
 ) -> (Vec<AgentUpdate>, std::path::PathBuf) {
     let (agent_tx, agent_rx) = unbounded_channel();
-    let collect_rx = wire_permission_responder(agent_rx, None);
     let (agent, work_dir) =
         build_test_agent_with_config(mock, Some(agent_tx), permission_mode, &config);
+    let ui_responder = agent.tool_context.ui_responder.clone();
+    let collect_rx = wire_permission_responder(agent_rx, None, ui_responder);
     setup(&work_dir);
     let (user_cmd_tx, user_cmd_rx) = user_command_channels();
 
@@ -225,8 +232,9 @@ where
 {
     install_test_config();
     let (agent_tx, agent_rx) = unbounded_channel();
-    let collect_rx = wire_permission_responder(agent_rx, permission_choice);
     let (agent, work_dir) = build_test_agent_with_mode(mock, Some(agent_tx), permission_mode);
+    let ui_responder = agent.tool_context.ui_responder.clone();
+    let collect_rx = wire_permission_responder(agent_rx, permission_choice, ui_responder);
     let (user_cmd_tx, user_cmd_rx) = user_command_channels();
 
     let driver = tokio::spawn(run_command_loop(agent, user_cmd_rx, work_dir.clone()));
@@ -466,6 +474,7 @@ pub fn compact_tool_use(id: &str, focus: Option<&str>) -> ContentBlock {
 pub fn wire_permission_responder_with_choices(
     agent_rx: UnboundedReceiver<AgentUpdate>,
     choices: Vec<Option<usize>>,
+    ui_responder: tact::ui_responder::UiResponder,
 ) -> UnboundedReceiver<AgentUpdate> {
     let (collect_tx, collect_rx) = unbounded_channel();
     tokio::spawn(async move {
@@ -473,13 +482,16 @@ pub fn wire_permission_responder_with_choices(
         let mut choices = choices.into_iter();
         while let Some(update) = agent_rx.recv().await {
             match update {
-                AgentUpdate::RequestSelect { respond, .. } => {
+                AgentUpdate::RequestSelect { request_id, .. } => {
                     let choice = choices.next().unwrap_or(None);
-                    let _ = respond.send(choice);
+                    ui_responder.handle_response(UiResponse::Select { request_id, choice });
                 }
-                AgentUpdate::RequestMultiSelect { respond, .. } => {
+                AgentUpdate::RequestMultiSelect { request_id, .. } => {
                     let choice = choices.next().unwrap_or(None);
-                    let _ = respond.send(choice.map(|i| vec![i]));
+                    ui_responder.handle_response(UiResponse::MultiSelect {
+                        request_id,
+                        choices: choice.map(|i| vec![i]),
+                    });
                 }
                 other => {
                     let _ = collect_tx.send(other);
@@ -583,6 +595,7 @@ pub async fn load_session_messages(
 pub fn wire_permission_responder_with_counter(
     agent_rx: UnboundedReceiver<AgentUpdate>,
     choices: Vec<Option<usize>>,
+    ui_responder: tact::ui_responder::UiResponder,
 ) -> (UnboundedReceiver<AgentUpdate>, Arc<AtomicUsize>) {
     let (collect_tx, collect_rx) = unbounded_channel();
     let counter = Arc::new(AtomicUsize::new(0));
@@ -592,15 +605,18 @@ pub fn wire_permission_responder_with_counter(
         let mut choices = choices.into_iter();
         while let Some(update) = agent_rx.recv().await {
             match update {
-                AgentUpdate::RequestSelect { respond, .. } => {
+                AgentUpdate::RequestSelect { request_id, .. } => {
                     counter_clone.fetch_add(1, Ordering::Relaxed);
                     let choice = choices.next().unwrap_or(None);
-                    let _ = respond.send(choice);
+                    ui_responder.handle_response(UiResponse::Select { request_id, choice });
                 }
-                AgentUpdate::RequestMultiSelect { respond, .. } => {
+                AgentUpdate::RequestMultiSelect { request_id, .. } => {
                     counter_clone.fetch_add(1, Ordering::Relaxed);
                     let choice = choices.next().unwrap_or(None);
-                    let _ = respond.send(choice.map(|i| vec![i]));
+                    ui_responder.handle_response(UiResponse::MultiSelect {
+                        request_id,
+                        choices: choice.map(|i| vec![i]),
+                    });
                 }
                 other => {
                     let _ = collect_tx.send(other);

--- a/crates/tact-ui/tests/harness_advanced.rs
+++ b/crates/tact-ui/tests/harness_advanced.rs
@@ -220,8 +220,10 @@ async fn run_single_task_with_permission_choice_and_choices(
 
     install_test_config();
     let (agent_tx, agent_rx) = unbounded_channel();
-    let (collect_rx, prompt_count) = wire_permission_responder_with_counter(agent_rx, choices);
     let (agent, work_dir) = build_test_agent_with_mode(mock, Some(agent_tx), permission_mode);
+    let ui_responder = agent.tool_context.ui_responder.clone();
+    let (collect_rx, prompt_count) =
+        wire_permission_responder_with_counter(agent_rx, choices, ui_responder);
     setup(&work_dir);
     let (user_cmd_tx, user_cmd_rx) = user_command_channels();
 

--- a/crates/tact/src/agent/tool_dispatch.rs
+++ b/crates/tact/src/agent/tool_dispatch.rs
@@ -457,7 +457,6 @@ impl Agent {
                                 _ => crate::tool::PermissionPromptPolicy::Json,
                             };
                             let choice = if let Some(tx) = &self.runtime.ui_tx {
-                                let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
                                 let prompt = format_permission_prompt(
                                     stable_name,
                                     permit_prompt,
@@ -468,13 +467,8 @@ impl Agent {
                                     "Deny".to_string(),
                                     "Always allow this tool".to_string(),
                                 ];
-                                let _ = tx.send(AgentUpdate::RequestSelect {
-                                    prompt,
-                                    options,
-                                    respond: respond_tx,
-                                    log_confirm: false,
-                                });
-                                match respond_rx.await {
+                                let responder = self.tool_context.ui_responder.clone();
+                                match responder.request_select(tx, prompt, options, false).await {
                                     Ok(Some(0)) => Some("allow_once"),
                                     Ok(Some(2)) => Some("always_allow"),
                                     _ => Some("deny"),

--- a/crates/tact/src/lib.rs
+++ b/crates/tact/src/lib.rs
@@ -40,6 +40,7 @@ pub mod store;
 pub mod task;
 pub mod team;
 pub mod tool;
+pub mod ui_responder;
 pub mod upgrade;
 pub mod utils;
 pub mod voice;

--- a/crates/tact/src/tool/ask_user.rs
+++ b/crates/tact/src/tool/ask_user.rs
@@ -75,14 +75,12 @@ pub async fn ask_user(ctx: ToolContext, input: AskUserInput) -> Result<String> {
 
     if let Some(tx) = &ctx.ui_tx {
         if !options.is_empty() {
+            let responder = ctx.ui_responder.clone();
             if multi {
-                let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
-                let _ = tx.send(AgentUpdate::RequestMultiSelect {
-                    prompt: question.clone(),
-                    options: options.clone(),
-                    respond: respond_tx,
-                });
-                return match respond_rx.await {
+                return match responder
+                    .request_multi(tx, question.clone(), options.clone())
+                    .await
+                {
                     Ok(Some(idxs)) => Ok(format_multi_selection(&options, &idxs)),
                     Ok(None) => Ok("User cancelled the question.".to_string()),
                     Err(_) => Ok(
@@ -91,15 +89,10 @@ pub async fn ask_user(ctx: ToolContext, input: AskUserInput) -> Result<String> {
                 };
             }
 
-            let (respond_tx, respond_rx) = tokio::sync::oneshot::channel();
-            let _ = tx.send(AgentUpdate::RequestSelect {
-                prompt: question.clone(),
-                options: options.clone(),
-                respond: respond_tx,
-                // Meta row already shows the choice; skip duplicate system line.
-                log_confirm: false,
-            });
-            return match respond_rx.await {
+            return match responder
+                .request_select(tx, question.clone(), options.clone(), false)
+                .await
+            {
                 Ok(Some(idx)) => {
                     let chosen = options
                         .get(idx)
@@ -156,7 +149,7 @@ fn format_headless_question(question: &str, options: &[String], multi: bool) -> 
 
 #[cfg(test)]
 mod tests {
-    use tact_protocol::AgentUpdate;
+    use tact_protocol::{AgentUpdate, UiResponse};
     use tokio::sync::mpsc::unbounded_channel;
 
     use super::*;
@@ -204,6 +197,7 @@ mod tests {
         let mut context = test_context("ask_user_popup_returns_selected_option");
         let (tx, mut rx) = unbounded_channel();
         context.ui_tx = Some(tx);
+        let responder = context.ui_responder.clone();
 
         let tool = tokio::spawn(async move {
             run_tool(
@@ -223,7 +217,7 @@ mod tests {
             AgentUpdate::RequestSelect {
                 prompt,
                 options,
-                respond,
+                request_id,
                 log_confirm,
             } => {
                 assert_eq!(prompt, "Pick a color");
@@ -232,7 +226,10 @@ mod tests {
                     !log_confirm,
                     "selection renders on tool meta, not a system line"
                 );
-                respond.send(Some(1)).unwrap();
+                responder.handle_response(UiResponse::Select {
+                    request_id,
+                    choice: Some(1),
+                });
             }
             other => panic!("expected RequestSelect, got {other:?}"),
         }
@@ -246,6 +243,7 @@ mod tests {
         let mut context = test_context("ask_user_multi_popup_returns_several");
         let (tx, mut rx) = unbounded_channel();
         context.ui_tx = Some(tx);
+        let responder = context.ui_responder.clone();
 
         let tool = tokio::spawn(async move {
             run_tool(
@@ -265,11 +263,14 @@ mod tests {
             AgentUpdate::RequestMultiSelect {
                 prompt,
                 options,
-                respond,
+                request_id,
             } => {
                 assert_eq!(prompt, "Pick toppings");
                 assert_eq!(options.len(), 3);
-                respond.send(Some(vec![0, 2])).unwrap();
+                responder.handle_response(UiResponse::MultiSelect {
+                    request_id,
+                    choices: Some(vec![0, 2]),
+                });
             }
             other => panic!("expected RequestMultiSelect, got {other:?}"),
         }
@@ -283,6 +284,7 @@ mod tests {
         let mut context = test_context("ask_user_popup_cancel");
         let (tx, mut rx) = unbounded_channel();
         context.ui_tx = Some(tx);
+        let responder = context.ui_responder.clone();
 
         let tool = tokio::spawn(async move {
             run_tool(
@@ -298,8 +300,11 @@ mod tests {
         });
 
         match rx.recv().await.expect("RequestSelect") {
-            AgentUpdate::RequestSelect { respond, .. } => {
-                respond.send(None).unwrap();
+            AgentUpdate::RequestSelect { request_id, .. } => {
+                responder.handle_response(UiResponse::Select {
+                    request_id,
+                    choice: None,
+                });
             }
             other => panic!("expected RequestSelect, got {other:?}"),
         }

--- a/crates/tact/src/tool/mod.rs
+++ b/crates/tact/src/tool/mod.rs
@@ -41,7 +41,7 @@ use tact_protocol::ToolVisualKind;
 
 use crate::{
     ToolSpec, background::SharedBackgroundManager, memory::MemoryManager, task::SharedTaskManager,
-    team::SharedTeammateManager, worktree::SharedWorktreeManager,
+    team::SharedTeammateManager, ui_responder::UiResponder, worktree::SharedWorktreeManager,
 };
 
 mod ask_user;
@@ -110,6 +110,9 @@ pub struct ToolContext {
     pub teammate_manager: SharedTeammateManager,
     pub worktree_manager: SharedWorktreeManager,
     pub ui_tx: Option<tokio::sync::mpsc::UnboundedSender<AgentUpdate>>,
+    /// Shared request/reply registry for `ask_user` and permission selects.
+    /// Cloned into subagents so request ids stay globally unique.
+    pub ui_responder: UiResponder,
     pub progress_reporter: ToolProgressReporter,
     pub cancel_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub bash_timeout_secs: u64,

--- a/crates/tact/src/tool/subagent_ui.rs
+++ b/crates/tact/src/tool/subagent_ui.rs
@@ -139,29 +139,29 @@ pub fn tagged_ui_channel_with_progress(
                     });
                 }
                 AgentUpdate::RequestSelect {
+                    request_id,
                     mut prompt,
                     options,
-                    respond,
                     log_confirm,
                 } => {
                     prompt = format!("[Subagent] {prompt}");
                     let _ = inner.send(AgentUpdate::RequestSelect {
+                        request_id,
                         prompt,
                         options,
-                        respond,
                         log_confirm,
                     });
                 }
                 AgentUpdate::RequestMultiSelect {
+                    request_id,
                     mut prompt,
                     options,
-                    respond,
                 } => {
                     prompt = format!("[Subagent] {prompt}");
                     let _ = inner.send(AgentUpdate::RequestMultiSelect {
+                        request_id,
                         prompt,
                         options,
-                        respond,
                     });
                 }
                 AgentUpdate::TaskComplete(_) | AgentUpdate::TaskCancelled => {}
@@ -421,12 +421,11 @@ mod tests {
         let progress = ToolProgressReporter::new("t1", Some(progress_tx));
         let tagged = tagged_ui_channel_with_progress(inner_tx, progress);
 
-        let (respond, _) = tokio::sync::oneshot::channel();
         tagged
             .send(AgentUpdate::RequestSelect {
+                request_id: 42,
                 prompt: "Allow bash?".into(),
                 options: vec!["Yes".into()],
-                respond,
                 log_confirm: false,
             })
             .unwrap();
@@ -434,7 +433,13 @@ mod tests {
 
         let got = inner_rx.try_recv().unwrap();
         match got {
-            AgentUpdate::RequestSelect { prompt, .. } => {
+            AgentUpdate::RequestSelect {
+                request_id, prompt, ..
+            } => {
+                assert_eq!(
+                    request_id, 42,
+                    "request id must survive subagent forwarding"
+                );
                 assert!(prompt.starts_with("[Subagent]"));
             }
             other => panic!("expected RequestSelect, got {other:?}"),

--- a/crates/tact/src/tool/test_support.rs
+++ b/crates/tact/src/tool/test_support.rs
@@ -86,6 +86,7 @@ pub fn test_context(name: &str) -> ToolContext {
             block_on(WorktreeManager::new(&db_path, root_dir)).unwrap(),
         ),
         ui_tx: None,
+        ui_responder: crate::ui_responder::UiResponder::new(),
         progress_reporter: super::ToolProgressReporter::default(),
         cancel_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         bash_timeout_secs: crate::config::ToolSettings::DEFAULT_BASH_TIMEOUT_SECS,

--- a/crates/tact/src/ui_responder.rs
+++ b/crates/tact/src/ui_responder.rs
@@ -1,0 +1,275 @@
+//! Shared request/reply registry for UI prompts (`RequestSelect` /
+//! `RequestMultiSelect`).
+//!
+//! The agent runtime no longer embeds a `tokio::sync::oneshot::Sender` inside
+//! [`AgentUpdate`] (that made the protocol enum impossible to serialize and
+//! coupled the transport to a single in-process responder). Instead a tool or
+//! the permission gate asks [`UiResponder`] for a selection, which:
+//!
+//! 1. allocates a globally-unique `request_id`,
+//! 2. records a pending oneshot for that id,
+//! 3. emits a pure-data `RequestSelect` / `RequestMultiSelect` carrying the id,
+//! 4. awaits the answer, which arrives via [`UiResponder::handle_response`] from
+//!    the command driver (after the TUI sends `UserCommand::UiResponse`).
+//!
+//! The id allocator and pending map live behind an `Arc`, so the parent agent
+//! and every subagent (which clone the same [`ToolContext`]) share one
+//! namespace: a response can always be routed to the exact waiter, even when a
+//! subagent forwarded its request through the parent's UI channel.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tact_protocol::{AgentUpdate, UiResponse};
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
+
+/// Shared registry routing UI responses back to the waiting caller.
+///
+/// Cheap to clone: every clone shares the same inner state.
+#[derive(Clone, Default)]
+pub struct UiResponder {
+    inner: Arc<UiResponderInner>,
+}
+
+#[derive(Default)]
+struct UiResponderInner {
+    pending: Mutex<HashMap<u64, oneshot::Sender<UiResponse>>>,
+    next_id: AtomicU64,
+}
+
+impl UiResponder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ask the user to pick one option.
+    ///
+    /// Returns `Ok(Some(index))` on a selection, `Ok(None)` when the user
+    /// cancelled, or `Err` when the UI closed before answering (the shared
+    /// responder was shut down).
+    pub async fn request_select(
+        &self,
+        ui_tx: &UnboundedSender<AgentUpdate>,
+        prompt: String,
+        options: Vec<String>,
+        log_confirm: bool,
+    ) -> Result<Option<usize>, oneshot::error::RecvError> {
+        let (request_id, rx) = self.register();
+        let _ = ui_tx.send(AgentUpdate::RequestSelect {
+            request_id,
+            prompt,
+            options,
+            log_confirm,
+        });
+        match rx.await {
+            Ok(UiResponse::Select { choice, .. }) => Ok(choice),
+            Err(err) => Err(err),
+            Ok(_) => Ok(None),
+        }
+    }
+
+    /// Ask the user to pick zero or more options.
+    ///
+    /// Returns `Ok(Some(indices))` on confirm (possibly empty), `Ok(None)` when
+    /// cancelled, or `Err` when the UI closed before answering.
+    pub async fn request_multi(
+        &self,
+        ui_tx: &UnboundedSender<AgentUpdate>,
+        prompt: String,
+        options: Vec<String>,
+    ) -> Result<Option<Vec<usize>>, oneshot::error::RecvError> {
+        let (request_id, rx) = self.register();
+        let _ = ui_tx.send(AgentUpdate::RequestMultiSelect {
+            request_id,
+            prompt,
+            options,
+        });
+        match rx.await {
+            Ok(UiResponse::MultiSelect { choices, .. }) => Ok(choices),
+            Err(err) => Err(err),
+            Ok(_) => Ok(None),
+        }
+    }
+
+    /// Route a TUI response to the waiting caller. Called by the command driver
+    /// when it receives [`UserCommand::UiResponse`]; no-op if the request id is
+    /// unknown (e.g. already answered or cancelled).
+    pub fn handle_response(&self, response: UiResponse) {
+        let request_id = response.request_id();
+        if let Some(tx) = self
+            .inner
+            .pending
+            .lock()
+            .expect("ui responder lock poisoned")
+            .remove(&request_id)
+        {
+            let _ = tx.send(response);
+        }
+    }
+
+    /// Drop every pending waiter, unblocking any in-flight `request_*` call
+    /// with `Err(RecvError)`. Invoked by the driver when the UI is gone so the
+    /// agent task can finish instead of deadlocking on an answer that never
+    /// arrives.
+    pub fn shutdown(&self) {
+        self.inner
+            .pending
+            .lock()
+            .expect("ui responder lock poisoned")
+            .clear();
+    }
+
+    fn register(&self) -> (u64, oneshot::Receiver<UiResponse>) {
+        let request_id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .pending
+            .lock()
+            .expect("ui responder lock poisoned")
+            .insert(request_id, tx);
+        (request_id, rx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tact_protocol::UserCommand;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    #[tokio::test]
+    async fn multi_select_routes_response_by_request_id() {
+        let responder = UiResponder::new();
+        let (tx, mut rx) = unbounded_channel::<AgentUpdate>();
+
+        let handle = tokio::spawn({
+            let responder = responder.clone();
+            async move {
+                responder
+                    .request_multi(&tx, "Pick toppings".into(), vec!["a".into(), "b".into()])
+                    .await
+            }
+        });
+
+        // The request carries a request_id, not a sender.
+        let AgentUpdate::RequestMultiSelect {
+            request_id,
+            prompt,
+            options,
+        } = rx.recv().await.unwrap()
+        else {
+            panic!("expected RequestMultiSelect");
+        };
+        assert_eq!(prompt, "Pick toppings");
+        assert_eq!(options, vec!["a", "b"]);
+
+        responder.handle_response(UiResponse::MultiSelect {
+            request_id,
+            choices: Some(vec![0]),
+        });
+        assert_eq!(handle.await.unwrap(), Ok(Some(vec![0])));
+    }
+
+    #[tokio::test]
+    async fn select_returns_none_on_cancel() {
+        let responder = UiResponder::new();
+        let (tx, mut rx) = unbounded_channel::<AgentUpdate>();
+
+        let handle = tokio::spawn({
+            let responder = responder.clone();
+            async move {
+                responder
+                    .request_select(&tx, "Allow?".into(), vec!["Yes".into()], false)
+                    .await
+            }
+        });
+
+        let AgentUpdate::RequestSelect { request_id, .. } = rx.recv().await.unwrap() else {
+            panic!("expected RequestSelect");
+        };
+        responder.handle_response(UiResponse::Select {
+            request_id,
+            choice: None,
+        });
+        assert_eq!(handle.await.unwrap(), Ok(None));
+    }
+
+    #[tokio::test]
+    async fn shutdown_unblocks_waiters_with_error() {
+        let responder = UiResponder::new();
+        let (tx, _rx) = unbounded_channel::<AgentUpdate>();
+
+        let handle = tokio::spawn({
+            let responder = responder.clone();
+            async move {
+                responder
+                    .request_select(&tx, "stale".into(), vec!["x".into()], false)
+                    .await
+            }
+        });
+
+        // No response is ever sent; shutdown must still unblock the waiter.
+        tokio::task::yield_now().await;
+        responder.shutdown();
+        assert!(handle.await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn request_ids_are_globally_unique_across_clones() {
+        let a = UiResponder::new();
+        let b = a.clone();
+        let (tx, mut rx) = unbounded_channel::<AgentUpdate>();
+
+        let h1 = tokio::spawn({
+            let a = a.clone();
+            let tx = tx.clone();
+            async move {
+                a.request_select(&tx, "one".into(), vec!["x".into()], false)
+                    .await
+            }
+        });
+        let h2 = tokio::spawn({
+            let b = b.clone();
+            let tx = tx.clone();
+            async move {
+                b.request_select(&tx, "two".into(), vec!["y".into()], false)
+                    .await
+            }
+        });
+
+        let id1 = match rx.recv().await.unwrap() {
+            AgentUpdate::RequestSelect { request_id, .. } => request_id,
+            other => panic!("unexpected {other:?}"),
+        };
+        let id2 = match rx.recv().await.unwrap() {
+            AgentUpdate::RequestSelect { request_id, .. } => request_id,
+            other => panic!("unexpected {other:?}"),
+        };
+        assert_ne!(id1, id2);
+
+        // Answer both so the spawned tasks finish.
+        a.handle_response(UiResponse::Select {
+            request_id: id1,
+            choice: None,
+        });
+        a.handle_response(UiResponse::Select {
+            request_id: id2,
+            choice: None,
+        });
+        h1.await.unwrap().unwrap();
+        h2.await.unwrap().unwrap();
+    }
+
+    #[test]
+    fn ui_response_request_id_accessor() {
+        let resp = UserCommand::UiResponse(UiResponse::Select {
+            request_id: 7,
+            choice: Some(1),
+        });
+        let UserCommand::UiResponse(resp) = resp else {
+            panic!("expected UiResponse");
+        };
+        assert_eq!(resp.request_id(), 7);
+    }
+}

--- a/crates/tact/src/ui_responder.rs
+++ b/crates/tact/src/ui_responder.rs
@@ -18,11 +18,36 @@
 //! subagent forwarded its request through the parent's UI channel.
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tact_protocol::{AgentUpdate, UiResponse};
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
+
+/// Why a UI select request failed to complete.
+///
+/// Distinct from the payload types (`Option<usize>` / `Option<Vec<usize>>`),
+/// which represent a completed request that was answered or cancelled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiRequestError {
+    /// The UI channel closed before answering (the responder was shut down or
+    /// the request could not be delivered).
+    Closed,
+    /// The response variant did not match the request kind — a protocol bug.
+    Mismatched,
+}
+
+impl fmt::Display for UiRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UiRequestError::Closed => f.write_str("UI closed before answering"),
+            UiRequestError::Mismatched => f.write_str("UI response variant mismatch"),
+        }
+    }
+}
+
+impl std::error::Error for UiRequestError {}
 
 /// Shared registry routing UI responses back to the waiting caller.
 ///
@@ -46,49 +71,64 @@ impl UiResponder {
     /// Ask the user to pick one option.
     ///
     /// Returns `Ok(Some(index))` on a selection, `Ok(None)` when the user
-    /// cancelled, or `Err` when the UI closed before answering (the shared
-    /// responder was shut down).
+    /// cancelled, or `Err` when the UI closed before answering or answered with
+    /// the wrong response kind.
     pub async fn request_select(
         &self,
         ui_tx: &UnboundedSender<AgentUpdate>,
         prompt: String,
         options: Vec<String>,
         log_confirm: bool,
-    ) -> Result<Option<usize>, oneshot::error::RecvError> {
+    ) -> Result<Option<usize>, UiRequestError> {
         let (request_id, rx) = self.register();
-        let _ = ui_tx.send(AgentUpdate::RequestSelect {
-            request_id,
-            prompt,
-            options,
-            log_confirm,
-        });
+        if ui_tx
+            .send(AgentUpdate::RequestSelect {
+                request_id,
+                prompt,
+                options,
+                log_confirm,
+            })
+            .is_err()
+        {
+            // UI already gone: drop the pending waiter so the receiver resolves
+            // immediately instead of hanging until `shutdown`.
+            self.unregister(request_id);
+            return Err(UiRequestError::Closed);
+        }
         match rx.await {
             Ok(UiResponse::Select { choice, .. }) => Ok(choice),
-            Err(err) => Err(err),
-            Ok(_) => Ok(None),
+            Ok(_) => Err(UiRequestError::Mismatched),
+            Err(_) => Err(UiRequestError::Closed),
         }
     }
 
     /// Ask the user to pick zero or more options.
     ///
     /// Returns `Ok(Some(indices))` on confirm (possibly empty), `Ok(None)` when
-    /// cancelled, or `Err` when the UI closed before answering.
+    /// cancelled, or `Err` when the UI closed before answering or answered with
+    /// the wrong response kind.
     pub async fn request_multi(
         &self,
         ui_tx: &UnboundedSender<AgentUpdate>,
         prompt: String,
         options: Vec<String>,
-    ) -> Result<Option<Vec<usize>>, oneshot::error::RecvError> {
+    ) -> Result<Option<Vec<usize>>, UiRequestError> {
         let (request_id, rx) = self.register();
-        let _ = ui_tx.send(AgentUpdate::RequestMultiSelect {
-            request_id,
-            prompt,
-            options,
-        });
+        if ui_tx
+            .send(AgentUpdate::RequestMultiSelect {
+                request_id,
+                prompt,
+                options,
+            })
+            .is_err()
+        {
+            self.unregister(request_id);
+            return Err(UiRequestError::Closed);
+        }
         match rx.await {
             Ok(UiResponse::MultiSelect { choices, .. }) => Ok(choices),
-            Err(err) => Err(err),
-            Ok(_) => Ok(None),
+            Ok(_) => Err(UiRequestError::Mismatched),
+            Err(_) => Err(UiRequestError::Closed),
         }
     }
 
@@ -109,9 +149,9 @@ impl UiResponder {
     }
 
     /// Drop every pending waiter, unblocking any in-flight `request_*` call
-    /// with `Err(RecvError)`. Invoked by the driver when the UI is gone so the
-    /// agent task can finish instead of deadlocking on an answer that never
-    /// arrives.
+    /// with `Err(UiRequestError::Closed)`. Invoked by the driver when the UI is
+    /// gone so the agent task can finish instead of deadlocking on an answer
+    /// that never arrives.
     pub fn shutdown(&self) {
         self.inner
             .pending
@@ -129,6 +169,16 @@ impl UiResponder {
             .expect("ui responder lock poisoned")
             .insert(request_id, tx);
         (request_id, rx)
+    }
+
+    /// Remove a pending waiter without delivering a response, unblocking its
+    /// receiver with `Err` (the sender is dropped).
+    fn unregister(&self, request_id: u64) {
+        self.inner
+            .pending
+            .lock()
+            .expect("ui responder lock poisoned")
+            .remove(&request_id);
     }
 }
 
@@ -212,7 +262,47 @@ mod tests {
         // No response is ever sent; shutdown must still unblock the waiter.
         tokio::task::yield_now().await;
         responder.shutdown();
-        assert!(handle.await.unwrap().is_err());
+        assert_eq!(handle.await.unwrap(), Err(UiRequestError::Closed));
+    }
+
+    #[tokio::test]
+    async fn closed_channel_fails_fast_without_hanging() {
+        let responder = UiResponder::new();
+        let (tx, rx) = unbounded_channel::<AgentUpdate>();
+        drop(rx); // close the UI channel
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            responder.request_select(&tx, "q".into(), vec!["a".into()], false),
+        )
+        .await;
+
+        assert_eq!(result, Ok(Err(UiRequestError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn mismatched_response_is_an_error_not_cancel() {
+        let responder = UiResponder::new();
+        let (tx, mut rx) = unbounded_channel::<AgentUpdate>();
+
+        let handle = tokio::spawn({
+            let responder = responder.clone();
+            async move {
+                responder
+                    .request_select(&tx, "Allow?".into(), vec!["Yes".into()], false)
+                    .await
+            }
+        });
+
+        let AgentUpdate::RequestSelect { request_id, .. } = rx.recv().await.unwrap() else {
+            panic!("expected RequestSelect");
+        };
+        // Wrong variant for a single-select request.
+        responder.handle_response(UiResponse::MultiSelect {
+            request_id,
+            choices: Some(vec![0]),
+        });
+        assert_eq!(handle.await.unwrap(), Err(UiRequestError::Mismatched));
     }
 
     #[tokio::test]

--- a/crates/tui/src/handlers/select.rs
+++ b/crates/tui/src/handlers/select.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{KeyCode, KeyEvent};
-use tact_protocol::UserCommand;
+use tact_protocol::{UiResponse, UserCommand};
 
 use crate::widgets::state::{App, InputMode, SelectKind};
 
@@ -107,6 +107,7 @@ pub(crate) fn handle_select_mode(app: &mut App, key: KeyEvent) {
 
             if multi {
                 let idxs = app.select.confirm_multi();
+                let request_id = app.select.take_request_id();
                 let chosen: Vec<String> = idxs
                     .iter()
                     .filter_map(|&i| app.select.options.get(i).cloned())
@@ -118,6 +119,14 @@ pub(crate) fn handle_select_mode(app: &mut App, key: KeyEvent) {
                 };
                 match std::mem::replace(&mut app.select_kind, SelectKind::Agent) {
                     SelectKind::Agent => {
+                        if let Some(id) = request_id {
+                            let _ = app.user_cmd_tx.send(UserCommand::UiResponse(
+                                UiResponse::MultiSelect {
+                                    request_id: id,
+                                    choices: Some(idxs),
+                                },
+                            ));
+                        }
                         if log_confirm {
                             let msgs = app.msgs();
                             app.add_system_message(msgs.selected_tmpl.replace("{}", &label));
@@ -144,6 +153,7 @@ pub(crate) fn handle_select_mode(app: &mut App, key: KeyEvent) {
             }
 
             let idx = app.select.confirm().unwrap_or(0);
+            let request_id = app.select.take_request_id();
             let chosen = app
                 .select
                 .options
@@ -153,6 +163,14 @@ pub(crate) fn handle_select_mode(app: &mut App, key: KeyEvent) {
 
             match std::mem::replace(&mut app.select_kind, SelectKind::Agent) {
                 SelectKind::Agent => {
+                    if let Some(id) = request_id {
+                        let _ = app
+                            .user_cmd_tx
+                            .send(UserCommand::UiResponse(UiResponse::Select {
+                                request_id: id,
+                                choice: Some(idx),
+                            }));
+                    }
                     if log_confirm {
                         let msgs = app.msgs();
                         app.add_system_message(msgs.selected_tmpl.replace("{}", &chosen));
@@ -270,7 +288,9 @@ pub(crate) fn handle_select_mode(app: &mut App, key: KeyEvent) {
             app.select.move_up();
         }
         KeyCode::Esc => {
-            app.select.cancel();
+            if let Some(response) = app.select.cancel() {
+                let _ = app.user_cmd_tx.send(UserCommand::UiResponse(response));
+            }
             let msgs = app.msgs();
             match std::mem::replace(&mut app.select_kind, SelectKind::Agent) {
                 SelectKind::PersistModelAndBudget {
@@ -861,14 +881,17 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::empty())
     }
 
-    fn seed_select(app: &mut App) -> tokio::sync::oneshot::Receiver<Option<usize>> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
+    fn seed_select(app: &mut App) -> tokio::sync::mpsc::UnboundedReceiver<UserCommand> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        // Swap in an observable command channel so tests can assert the
+        // UiResponse the confirm/cancel path emits.
+        app.user_cmd_tx = tx;
         app.select_kind = SelectKind::Agent;
         app.input_mode = InputMode::Select;
         app.select.set(
             "Pick one".into(),
             vec!["Allow once".into(), "Deny".into()],
-            tx,
+            1,
             true,
         );
         rx
@@ -1022,7 +1045,13 @@ thinking_budget = {thinking_budget}
         handle_select_mode(&mut app, key(KeyCode::Enter));
 
         assert!(matches!(app.input_mode, InputMode::Normal));
-        assert_eq!(rx.try_recv(), Ok(Some(1)));
+        match rx.try_recv() {
+            Ok(UserCommand::UiResponse(UiResponse::Select {
+                request_id: 1,
+                choice: Some(1),
+            })) => {}
+            other => panic!("expected Select response, got {other:?}"),
+        }
         assert!(
             app.log.items.iter().any(|item| {
                 item.raw.contains("Deny")
@@ -1042,7 +1071,13 @@ thinking_budget = {thinking_budget}
         handle_select_mode(&mut app, key(KeyCode::Esc));
 
         assert!(matches!(app.input_mode, InputMode::Normal));
-        assert_eq!(rx.try_recv(), Ok(None));
+        match rx.try_recv() {
+            Ok(UserCommand::UiResponse(UiResponse::Select {
+                request_id: 1,
+                choice: None,
+            })) => {}
+            other => panic!("expected cancelled Select response, got {other:?}"),
+        }
     }
 
     /// Serialize model-picker tests that share global `CACHE` / `PROVIDER`.

--- a/crates/tui/src/headless_loop.rs
+++ b/crates/tui/src/headless_loop.rs
@@ -2,10 +2,10 @@
 
 use std::time::Duration;
 
-use tact_protocol::AgentUpdate;
+use tact_protocol::{AgentUpdate, UiResponse, UserCommand};
 use tokio::sync::mpsc::UnboundedReceiver;
 
-use crate::widgets::state::{App, InputMode};
+use crate::widgets::state::{App, InputMode, SelectKind};
 
 /// Drain pending updates from `agent_rx`, optionally auto-confirm permission selects.
 pub fn drain_agent_updates(app: &mut App, auto_select: Option<usize>) {
@@ -19,23 +19,45 @@ pub fn drain_agent_updates(app: &mut App, auto_select: Option<usize>) {
     }
 }
 
-/// Confirm the current select popup programmatically (headless substitute for Enter).
-pub fn auto_confirm_select(app: &mut App, choice: usize) {
+/// Build the response for auto-confirming the current select popup.
+///
+/// Consumes the popup's request id and leaves `InputMode::Normal`. Returns the
+/// [`UiResponse`] to deliver, or `None` when the popup is a local flow (no
+/// request id) or not actually open.
+pub fn build_auto_confirm_response(app: &mut App, choice: usize) -> Option<UiResponse> {
     if !matches!(app.input_mode, InputMode::Select) || app.select.options.is_empty() {
-        return;
+        return None;
     }
     let idx = choice.min(app.select.options.len().saturating_sub(1));
     app.select.selected = idx;
-    if app.select.multi {
+    let request_id = app.select.take_request_id();
+    let response = if app.select.multi {
         if let Some(slot) = app.select.checked.get_mut(idx) {
             *slot = true;
         }
-        app.select.confirm_multi();
+        let idxs = app.select.confirm_multi();
+        request_id.map(|id| UiResponse::MultiSelect {
+            request_id: id,
+            choices: Some(idxs),
+        })
     } else {
-        app.select.confirm();
-    }
-    app.select_kind = crate::widgets::state::SelectKind::Agent;
+        let _ = app.select.confirm();
+        request_id.map(|id| UiResponse::Select {
+            request_id: id,
+            choice: Some(idx),
+        })
+    };
+    app.select_kind = SelectKind::Agent;
     app.input_mode = InputMode::Normal;
+    response
+}
+
+/// Confirm the current select popup programmatically, sending the response on
+/// the App's command channel (headless substitute for Enter).
+pub fn auto_confirm_select(app: &mut App, choice: usize) {
+    if let Some(response) = build_auto_confirm_response(app, choice) {
+        let _ = app.user_cmd_tx.send(UserCommand::UiResponse(response));
+    }
 }
 
 /// Poll until `should_continue` returns false, draining updates each tick.

--- a/crates/tui/src/render/popup_scene_tests.rs
+++ b/crates/tui/src/render/popup_scene_tests.rs
@@ -547,9 +547,8 @@ fn full_frame_done_status_renders_in_status_bar() {
 fn full_frame_select_mode_shows_in_status_bar() {
     let mut app = make_app();
     app.input_mode = InputMode::Select;
-    let (tx, _rx) = tokio::sync::oneshot::channel();
     app.select
-        .set("Pick one".into(), vec!["A".into(), "B".into()], tx, false);
+        .set("Pick one".into(), vec!["A".into(), "B".into()], 0, false);
 
     let text = render_app_text(&mut app, 100, 24);
 

--- a/crates/tui/src/render/render_gap_tests.rs
+++ b/crates/tui/src/render/render_gap_tests.rs
@@ -750,12 +750,11 @@ fn full_frame_planning_status_renders_in_status_bar() {
 #[test]
 fn request_select_update_renders_select_popup() {
     let mut app = make_app();
-    let (tx, _rx) = tokio::sync::oneshot::channel();
 
     app.handle_agent_update(AgentUpdate::RequestSelect {
+        request_id: 0,
         prompt: "Allow edit_file on lib.rs?".into(),
         options: vec!["Allow once".into(), "Deny".into()],
-        respond: tx,
         log_confirm: false,
     });
 

--- a/crates/tui/src/render/scene_tests.rs
+++ b/crates/tui/src/render/scene_tests.rs
@@ -215,11 +215,10 @@ fn full_frame_token_usage_in_bottom_bar() {
 #[test]
 fn full_frame_select_popup_overlays() {
     let mut app = make_app();
-    let (tx, _rx) = tokio::sync::oneshot::channel();
     app.handle_agent_update(AgentUpdate::RequestSelect {
+        request_id: 0,
         prompt: "Allow bash?".into(),
         options: vec!["Allow once".into(), "Deny".into()],
-        respond: tx,
         log_confirm: false,
     });
 
@@ -234,9 +233,9 @@ fn full_frame_select_popup_overlays() {
 #[test]
 fn full_frame_select_popup_wraps_long_prompt() {
     let mut app = make_app();
-    let (tx, _rx) = tokio::sync::oneshot::channel();
     let prompt = "📝 对比题：He went to ___ school to pick up his daughter after ___ class.";
     app.handle_agent_update(AgentUpdate::RequestSelect {
+        request_id: 0,
         prompt: prompt.into(),
         options: vec![
             "A. the ... the".into(),
@@ -244,7 +243,6 @@ fn full_frame_select_popup_wraps_long_prompt() {
             "C. the ... Ø".into(),
             "D. Ø ... the".into(),
         ],
-        respond: tx,
         log_confirm: false,
     });
 

--- a/crates/tui/src/test_support.rs
+++ b/crates/tui/src/test_support.rs
@@ -6,7 +6,7 @@ use tact_protocol::AgentUpdate;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::{
-    headless_loop::{auto_confirm_select, drain_agent_updates, make_headless_app},
+    headless_loop::{build_auto_confirm_response, make_headless_app},
     render::test_harness::{make_app, render_app_text, render_main_area_text},
     widgets::state::{App, InputMode, Status},
 };
@@ -162,6 +162,9 @@ pub struct HeadlessApp {
     inner: App,
     auto_select: Option<usize>,
     capture_frames: bool,
+    /// Direct route for auto-confirmed select responses. The driver owns the
+    /// same shared registry, so `handle_response` reaches the waiting tool.
+    ui_responder: Option<tact::ui_responder::UiResponder>,
 }
 
 impl HeadlessApp {
@@ -170,11 +173,21 @@ impl HeadlessApp {
             inner: make_headless_app(agent_rx, work_dir),
             auto_select: None,
             capture_frames: false,
+            ui_responder: None,
         }
     }
 
     pub fn with_auto_select(mut self, choice: Option<usize>) -> Self {
         self.auto_select = choice;
+        self
+    }
+
+    /// Answer auto-confirmed selects through the shared [`UiResponder`] directly
+    /// instead of the (disconnected) command channel. The headless App and the
+    /// driver do not share a `user_cmd` channel, so routing responses this way
+    /// is what lets a blocked tool unblock.
+    pub fn with_ui_responder(mut self, responder: tact::ui_responder::UiResponder) -> Self {
+        self.ui_responder = Some(responder);
         self
     }
 
@@ -185,17 +198,46 @@ impl HeadlessApp {
     }
 
     pub fn poll(&mut self) {
-        drain_agent_updates(&mut self.inner, self.auto_select);
+        self.drain(true);
     }
 
     pub fn poll_without_auto_confirm(&mut self) {
+        self.drain(false);
+    }
+
+    fn drain(&mut self, auto_confirm: bool) {
         while let Ok(update) = self.inner.agent_rx.try_recv() {
             self.inner.handle_agent_update(update);
+            if auto_confirm
+                && matches!(self.inner.input_mode, InputMode::Select)
+                && let Some(choice) = self.auto_select
+            {
+                let response = build_auto_confirm_response(&mut self.inner, choice);
+                self.deliver_response(response);
+            }
         }
     }
 
     pub fn confirm_select(&mut self, choice: usize) {
-        auto_confirm_select(&mut self.inner, choice);
+        let response = build_auto_confirm_response(&mut self.inner, choice);
+        self.deliver_response(response);
+    }
+
+    /// Deliver a select response to the waiting tool: directly through the
+    /// shared responder when wired, else on the App's command channel.
+    fn deliver_response(&self, response: Option<tact_protocol::UiResponse>) {
+        let Some(response) = response else {
+            return;
+        };
+        match &self.ui_responder {
+            Some(responder) => responder.handle_response(response),
+            None => {
+                let _ = self
+                    .inner
+                    .user_cmd_tx
+                    .send(tact_protocol::UserCommand::UiResponse(response));
+            }
+        }
     }
 
     pub fn render(&mut self, width: u16, height: u16) -> String {

--- a/crates/tui/src/widgets/state/app/agent.rs
+++ b/crates/tui/src/widgets/state/app/agent.rs
@@ -279,21 +279,21 @@ impl App {
             AgentUpdate::RequestSelect {
                 prompt,
                 options,
-                respond,
+                request_id,
                 log_confirm,
             } => {
                 self.select_kind = SelectKind::Agent;
-                self.select.set(prompt, options, respond, log_confirm);
+                self.select.set(prompt, options, request_id, log_confirm);
                 self.input_mode = InputMode::Select;
             }
             AgentUpdate::RequestMultiSelect {
                 prompt,
                 options,
-                respond,
+                request_id,
             } => {
                 self.select_kind = SelectKind::Agent;
                 // Choice is shown on the ask_user tool meta row; no duplicate log line.
-                self.select.set_multi(prompt, options, respond, false);
+                self.select.set_multi(prompt, options, request_id, false);
                 self.input_mode = InputMode::Select;
             }
             AgentUpdate::ThinkingChunk(chunk) => {
@@ -1892,15 +1892,15 @@ mod lifecycle_tests {
         use crate::widgets::state::InputMode;
 
         let mut app = make_app();
-        let (tx, _rx) = tokio::sync::oneshot::channel();
         app.handle_agent_update(AgentUpdate::RequestSelect {
+            request_id: 1,
             prompt: "Allow bash?".into(),
             options: vec!["Yes".into(), "No".into()],
-            respond: tx,
             log_confirm: false,
         });
         assert!(matches!(app.input_mode, InputMode::Select));
         assert!(app.select.prompt.contains("Allow bash"));
+        assert_eq!(app.select.request_id, Some(1));
     }
 
     #[test]

--- a/crates/tui/src/widgets/state/mod.rs
+++ b/crates/tui/src/widgets/state/mod.rs
@@ -75,7 +75,7 @@ pub(crate) const PALETTE_COMMANDS: &[(&str, &str)] = &[
 /// Why the select popup is open (agent permission vs `/model` flow).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SelectKind {
-    /// Agent `RequestSelect` — confirm sends oneshot reply.
+    /// Agent `RequestSelect` — confirm emits a `UiResponse` on the command channel.
     Agent,
     /// `/model` first step — choose a model before applying either value.
     ModelPick,


### PR DESCRIPTION
feat: route select requests through UiResponder + bump v1.1.25

## Summary

Replaces the embedded `oneshot::Sender` in `AgentUpdate::RequestSelect` /
`RequestMultiSelect` with a pure-data `request_id: u64`. Responses flow back
over the reverse `UserCommand::UiResponse` channel, routed through a new
shared `UiResponder` registry.

## Commits

- `f3c0cf48` feat: replace embedded oneshot in select requests with UiResponder + UiResponse
- `42b6a2fd` fix: typed UiRequestError, fail-fast on closed UI channel
- `71664caf` chore: bump to v1.1.25

## Details

- `AgentUpdate` no longer carries a transport handle (pure data, transport-agnostic — free to derive `Serialize`/`Clone` later).
- New `UiResponder` allocates globally-unique request ids and routes `UiResponse` back to the exact waiter; parent and subagents share the same inner state.
- Typed `UiRequestError` (`Closed` / `Mismatched`) replaces leaking `oneshot::error::RecvError`:
  - closed UI channel fails fast (unregister + return) instead of hanging until `shutdown`
  - a wrong response variant is reported as a protocol error, not silently treated as cancel
- Driver handles `UiResponse` without awaiting the in-flight task and calls `UiResponder::shutdown` on exit so a vanished UI unblocks any waiter.
- Docs: book 25 (protocol), book 26 (issue log, en/zh). Tests: 7 ui_responder tests pass.
